### PR TITLE
feat(wallpaper): 增加 Grok Saved 安全读取桥接

### DIFF
--- a/docs/llm-wiki/wallpaper-search.md
+++ b/docs/llm-wiki/wallpaper-search.md
@@ -198,6 +198,34 @@ explicit load-more retry and validated remote-media download path as the public
 providers. Synthetic fixtures prove parsing, budgets, cache, cancellation and
 SSRF boundaries, not live account availability.
 
+## Grok Saved Host bridge
+
+Grok Saved uses a dedicated persistent Tauri WebView at
+`https://grok.com/imagine/saved`. The window is absent from every Tauri
+capability, restricts top-level navigation to first-party Grok/xAI pages plus
+the supported Google and Apple sign-in pages, and denies new windows and
+downloads. The Host never reads or exports cookies, storage, authorization
+headers, request signatures, or raw API responses.
+
+Renderer callers select only fixed Host commands. The Host executes bundled
+JavaScript that returns a bounded allowlisted media DTO; caller-provided scripts,
+endpoints, headers and credentials are not accepted. Album media must remain on
+`assets.grok.com`. Navigation, window close, account/page revision changes and
+explicit cancellation invalidate cached metadata and active transfers.
+
+Manual unauthenticated HTTP/SOCKS5 proxy settings are pinned to the isolated
+WebView on Windows and Linux. Unsupported schemes, authenticated proxies,
+Direct mode and macOS Manual mode fail closed instead of silently taking a
+different route; saving a proxy change destroys the existing album window.
+
+Thumbnail and selected-original requests race the isolated signed-in WebView
+against a credential-free Host request. Only the first valid result continues,
+and both routes converge on the existing URL, redirect, byte-limit, MIME and
+signature checks. Thumbnails stay in memory. A selected original is written
+once under the distinct `grok_album` library source. This Host slice registers
+the commands but does not yet expose a Saved source tab; renderer UX is a
+separate review layer.
+
 ## Public image provider UI
 
 The source picker groups the sources delivered so far into discovery, creation

--- a/docs/plans/WALLPAPER-GROK-SAVED-ALBUM.md
+++ b/docs/plans/WALLPAPER-GROK-SAVED-ALBUM.md
@@ -1,0 +1,68 @@
+# Grok Imagine saved album as a wallpaper source
+
+Status: delivery in progress; secure Host bridge is the first review slice
+
+## Goal
+
+Add `https://grok.com/imagine/saved` as an independent wallpaper source without changing X search, reusing Grok Build OAuth, or exporting Grok web credentials.
+
+## Security contract
+
+- The album opens in a dedicated Tauri WebView window with its own persistent data directory.
+- On Windows and Linux, a valid unauthenticated Manual `http` / `socks5` proxy is pinned directly to that remote WebView (`socks5h` is normalized to WebView SOCKSv5). System/PAC/env modes retain the native WebView route. Unsupported manual schemes, proxy authentication, Direct mode, and macOS Manual mode fail closed instead of silently using another route. Saving a proxy change destroys the existing album window so its next open uses the new route; the isolated persistent profile preserves the official sign-in session.
+- The album window label is deliberately absent from every Tauri capability, so remote content has no IPC access.
+- Navigation is restricted to HTTPS first-party Grok/xAI pages and the explicitly supported identity-provider sign-in pages. New-window requests and downloads are denied.
+- Cookies, authorization headers, request signatures, storage values, and raw API responses are never read, returned, persisted, or logged by Grok App.
+- The Host runs only fixed, bundled JavaScript against the album page. Frontend callers cannot supply scripts.
+- The bridge returns an allowlisted DTO only: media URL, optional thumbnail URL, media kind, dimensions, creation time, and post id. Host validation accepts media only from `assets.grok.com` and caps item counts and field lengths.
+- Album metadata is held in memory only while the current Saved page instance remains active; top-level navigation and window close clear it. Only a wallpaper that the user previews or applies is downloaded through the existing media allowlist into the app wallpaper library under the distinct `grok_album` source.
+- Album cards never load `assets.grok.com` directly from the main WebView because the CDN rejects that cross-site context. For each revalidated generated-media URL, the isolated signed-in WebView and the credential-free Host proxy race; the first successful route produces an in-memory JPEG thumbnail (480 px edge, 512 KiB output cap, four concurrent jobs), and the losing route is cancelled. The current 20 cards and one 20-card lookahead may be warmed; switching sources clears the frontend cache, and no thumbnail is written to disk or the wallpaper library.
+- A user-selected original races the configured credential-free Host proxy against a fixed `credentials: include` fetch in the isolated Saved WebView. The WebView-managed login state never leaves that page. If the WebView wins, its Blob stays inside the isolated page and is read back in bounded 512 KiB binary chunks; if the Host wins, the WebView job is cooperatively cancelled and cleaned up. Both routes converge before the sole save point, which reapplies the URL allowlist, 200 MiB limit, MIME/real-signature checks, and writes only the validated file under the `grok_album` library source. Cookies, tokens, storage, headers, and raw API responses never cross the bridge.
+
+## User flow
+
+1. Appearance -> wallpaper exposes a separate `Grok album` entry and source tab.
+2. `Open / sign in` focuses the dedicated official Grok window. If the signed-out Saved route renders only its empty shell, the fixed bootstrap returns to the official Grok home page so its own sign-in button is usable. Later uses reuse the isolated cookie store.
+3. `Sync current page` copies only validated media metadata into the wallpaper gallery.
+4. `Load more` scrolls the official saved page, waits for its own infinite loader, then merges newly rendered cards. It does not call undocumented REST endpoints directly.
+5. Search in v1 is the official page's own search/filter interaction plus the existing local gallery filter. A direct `/rest/media/search/query` integration remains out of scope until xAI publishes a supported contract.
+6. Preview/apply races the signed-in isolated WebView against the credential-free Host proxy and accepts the first successful route before the existing signature validation, single local-library save, and wallpaper preparation pipeline.
+
+## Delivery slices
+
+### Slice 1 - secure read-only path
+
+- Dedicated window lifecycle and domain allowlist.
+- Persistent isolated WebView storage.
+- Login/loading/ready/closed status without Cookie inspection.
+- First rendered-page metadata snapshot and strict validation.
+
+### Slice 2 - wallpaper source UX
+
+- Source entry, tab, controls, gallery mapping, preview and apply.
+- Manual refresh and load-more through official-page scrolling.
+- In-memory dedupe and one-batch-ahead cache where it does not move a visible user-controlled page.
+
+### Slice 3 - product completeness
+
+- Fifteen locale catalogs in lockstep.
+- Settings search catalog registration.
+- Unit/security tests and wallpaper-search documentation.
+- Typecheck, frontend tests/build, Rust formatting/tests, and a real desktop smoke test.
+
+## Acceptance state
+
+The original development branch completed deterministic and Windows acceptance,
+but review delivery is intentionally split. Slice 1 contains only the isolated
+window, fixed-script metadata bridge, request cancellation, proxy pinning, and
+validated thumbnail/original-media transport. It does not expose the source in
+the renderer. Slice 2 will add the source UI and rerun the full desktop flow on
+top of the reviewed Host contract.
+
+## Explicit non-goals
+
+- No Grok Build OAuth token reuse for grok.com.
+- No Cookie/token export, auth-file import, or raw WebView storage access.
+- No direct calls to undocumented Grok consumer REST endpoints.
+- No coupling to or behavior change in the X wallpaper-search route.
+- No automatic upload, push, or pull request.

--- a/src-tauri/src/app_menu.rs
+++ b/src-tauri/src/app_menu.rs
@@ -171,8 +171,9 @@ pub fn install(app: &AppHandle) -> Result<(), String> {
     let menu = build_menu(app).map_err(|e| e.to_string())?;
     app.set_menu(menu).map_err(|e| e.to_string())?;
     // App-wide set_menu reattaches File/Edit/Window/Help to windows that have
-    // no menu of their own — the pet overlay must stay chrome-less.
+    // no menu of their own. Keep non-document windows chrome-less.
     crate::pet_window::reassert_overlay_chrome(app);
+    crate::wallpaper_grok_album::reassert_window_chrome(app);
     Ok(())
 }
 

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -140,6 +140,10 @@ pub async fn settings_set(
 
     store::save_settings(&settings)?;
 
+    if proxy_flip {
+        crate::wallpaper_grok_album::close_for_proxy_change(&app);
+    }
+
     if schedules_launch_agent_flip {
         let res = if settings.schedules_launch_agent {
             crate::schedules_launch_agent::enable()

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -224,6 +224,7 @@ mod voice_stt;
 
 mod voice_tools;
 
+mod wallpaper_grok_album;
 mod wallpaper_provider_search;
 mod wallpaper_remote_commands;
 mod wallpaper_remote_media;
@@ -1724,6 +1725,22 @@ pub fn run() {
             commands::wallpaper_library_list,
 
             commands::wallpaper_library_delete,
+
+            wallpaper_grok_album::wallpaper_grok_album_open,
+
+            wallpaper_grok_album::wallpaper_grok_album_snapshot,
+
+            wallpaper_grok_album::wallpaper_grok_album_refresh,
+
+            wallpaper_grok_album::wallpaper_grok_album_load_more,
+
+            wallpaper_grok_album::wallpaper_grok_album_thumbnail,
+
+            wallpaper_grok_album::wallpaper_grok_album_cancel_requests,
+
+            wallpaper_grok_album::wallpaper_grok_album_cancel_all_requests,
+
+            wallpaper_grok_album::wallpaper_grok_album_fetch_media,
 
             commands::skin_pick_open,
             commands::skin_pick_save,

--- a/src-tauri/src/proxy.rs
+++ b/src-tauri/src/proxy.rs
@@ -67,6 +67,20 @@ pub struct ProxyResolution {
     pub source: ProxySource,
 }
 
+/// Why an app-configured proxy cannot be represented by Tauri's remote
+/// WebView proxy API. The API only accepts unauthenticated HTTP CONNECT and
+/// SOCKSv5 endpoints; failing closed prevents the WebView from silently using
+/// a different network route than the rest of the app.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WebviewProxyError {
+    InvalidUrl,
+    UnsupportedScheme,
+    AuthenticationUnsupported,
+    DirectUnsupported,
+    #[cfg(target_os = "macos")]
+    PlatformUnsupported,
+}
+
 /// Env var names children understand (both cases for maximum tool coverage).
 const PROXY_ENV_KEYS: &[&str] = &[
     "HTTP_PROXY",
@@ -518,6 +532,67 @@ pub fn resolve_from(
     }
 }
 
+fn normalize_webview_proxy_url(raw: &str) -> Result<url::Url, WebviewProxyError> {
+    let mut url = url::Url::parse(raw.trim()).map_err(|_| WebviewProxyError::InvalidUrl)?;
+    if url.host_str().is_none() {
+        return Err(WebviewProxyError::InvalidUrl);
+    }
+    if !url.username().is_empty() || url.password().is_some() {
+        return Err(WebviewProxyError::AuthenticationUnsupported);
+    }
+
+    match url.scheme() {
+        "http" | "socks5" => {}
+        // Tauri exposes SOCKSv5 but not a separate socks5h spelling. WebView2
+        // and WebKit resolve destinations through their SOCKSv5 endpoint.
+        "socks5h" => {
+            url.set_scheme("socks5")
+                .map_err(|_| WebviewProxyError::InvalidUrl)?;
+        }
+        _ => return Err(WebviewProxyError::UnsupportedScheme),
+    }
+
+    // Tauri's proxy adapter consumes only scheme, host and port. Canonicalize
+    // the value before handing it over so paths, queries and fragments cannot
+    // be mistaken for a credential or request target later.
+    url.set_path("");
+    url.set_query(None);
+    url.set_fragment(None);
+    Ok(url)
+}
+
+/// Resolve the optional override for a remote WebView.
+///
+/// Manual mode is pinned explicitly. System/PAC/env modes stay native so the
+/// WebView keeps the operating system's bypass and live-reconfiguration
+/// behavior. Direct mode fails closed because Tauri does not expose a portable
+/// way to disable the native WebView proxy.
+pub fn webview_proxy_override() -> Result<Option<url::Url>, WebviewProxyError> {
+    let resolution = resolve();
+    #[cfg(target_os = "macos")]
+    if resolution.source == ProxySource::Manual {
+        // Wry's manual WKWebView proxy requires macOS 14+ plus a compile-time
+        // feature that would drop support for older macOS releases.
+        return Err(WebviewProxyError::PlatformUnsupported);
+    }
+    webview_proxy_override_from(&resolution)
+}
+
+fn webview_proxy_override_from(
+    resolution: &ProxyResolution,
+) -> Result<Option<url::Url>, WebviewProxyError> {
+    if resolution.source == ProxySource::Direct {
+        return Err(WebviewProxyError::DirectUnsupported);
+    }
+    if resolution.source != ProxySource::Manual {
+        return Ok(None);
+    }
+    let ProxyDecision::Use { url, .. } = &resolution.decision else {
+        return Ok(None);
+    };
+    normalize_webview_proxy_url(url).map(Some)
+}
+
 fn merge_optional_lists(a: Option<&str>, b: Option<&str>) -> Option<String> {
     match (a, b) {
         (None, None) => None,
@@ -784,6 +859,84 @@ mod tests {
         assert!(!is_valid_proxy_url("127.0.0.1:7890")); // scheme required
         assert!(!is_valid_proxy_url("ftp://x"));
         assert!(!is_valid_proxy_url(""));
+    }
+
+    #[test]
+    fn remote_webview_pins_only_a_safe_manual_proxy() {
+        let manual = ProxyResolution {
+            decision: ProxyDecision::Use {
+                url: "http://127.0.0.1:10809/path?ignored=1#fragment".into(),
+                no_proxy: None,
+            },
+            source: ProxySource::Manual,
+        };
+        assert_eq!(
+            webview_proxy_override_from(&manual)
+                .unwrap()
+                .unwrap()
+                .as_str(),
+            "http://127.0.0.1:10809/"
+        );
+
+        let system = ProxyResolution {
+            source: ProxySource::SystemHttp,
+            ..manual
+        };
+        assert_eq!(webview_proxy_override_from(&system).unwrap(), None);
+    }
+
+    #[test]
+    fn remote_webview_normalizes_socks_dns_without_exposing_credentials() {
+        let socks = ProxyResolution {
+            decision: ProxyDecision::Use {
+                url: "socks5h://127.0.0.1:1080".into(),
+                no_proxy: None,
+            },
+            source: ProxySource::Manual,
+        };
+        assert_eq!(
+            webview_proxy_override_from(&socks)
+                .unwrap()
+                .unwrap()
+                .as_str(),
+            "socks5://127.0.0.1:1080"
+        );
+
+        let authenticated = ProxyResolution {
+            decision: ProxyDecision::Use {
+                url: "http://user:secret@127.0.0.1:10809".into(),
+                no_proxy: None,
+            },
+            source: ProxySource::Manual,
+        };
+        assert_eq!(
+            webview_proxy_override_from(&authenticated),
+            Err(WebviewProxyError::AuthenticationUnsupported)
+        );
+    }
+
+    #[test]
+    fn remote_webview_rejects_proxy_schemes_tauri_cannot_route() {
+        let https = ProxyResolution {
+            decision: ProxyDecision::Use {
+                url: "https://127.0.0.1:10809".into(),
+                no_proxy: None,
+            },
+            source: ProxySource::Manual,
+        };
+        assert_eq!(
+            webview_proxy_override_from(&https),
+            Err(WebviewProxyError::UnsupportedScheme)
+        );
+
+        let direct = ProxyResolution {
+            decision: ProxyDecision::Direct,
+            source: ProxySource::Direct,
+        };
+        assert_eq!(
+            webview_proxy_override_from(&direct),
+            Err(WebviewProxyError::DirectUnsupported)
+        );
     }
 
     #[test]

--- a/src-tauri/src/wallpaper_grok_album.rs
+++ b/src-tauri/src/wallpaper_grok_album.rs
@@ -1,0 +1,925 @@
+//! Read-only bridge for the consumer Grok Imagine saved page.
+//!
+//! The page runs in a dedicated, zero-capability WebView window. The Host does
+//! not read cookies or storage and never accepts caller-provided JavaScript.
+//! Only a bounded, allowlisted media DTO can cross back to the app UI.
+
+mod cache;
+mod fetch_route;
+mod media_fetch;
+mod media_store;
+mod model;
+mod request_registry;
+#[cfg(test)]
+mod script_tests;
+#[cfg(test)]
+mod tests;
+
+use cache::{
+    cache_revision, cached_items, cached_media_contains, cached_media_state, clear_cache,
+    reconcile_cache_at_revision,
+};
+#[cfg(test)]
+use cache::{
+    merge_cache, merge_cache_items_at_revision, reconcile_cache_items_at_revision, AlbumCache,
+};
+use fetch_route::{first_success, AlbumFetchRoute};
+pub use model::{GrokAlbumMedia, GrokAlbumSnapshot, GrokAlbumStatus, GrokAlbumThumbnail};
+use model::{RawAlbumMedia, RawAlbumSnapshot, RawAlbumThumbnailJob};
+use request_registry::{
+    cancel as cancel_album_requests, cancel_all as cancel_all_album_requests,
+    register as register_album_request,
+};
+
+use std::path::PathBuf;
+use std::sync::mpsc;
+use std::sync::LazyLock;
+use std::time::{Duration, Instant};
+
+use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
+use parking_lot::Mutex;
+use tauri::webview::NewWindowResponse;
+use tauri::{AppHandle, Manager, Url, WebviewUrl, WebviewWindow, WebviewWindowBuilder};
+
+use crate::wallpaper_source::WallpaperSearchCancellation;
+
+const WINDOW_LABEL: &str = "grok-imagine-saved";
+const SAVED_URL: &str = "https://grok.com/imagine/saved";
+const MAX_BRIDGE_ITEMS: usize = 320;
+const MAX_MEDIA_URL_LENGTH: usize = 4_096;
+const MAX_BRIDGE_PAYLOAD_BYTES: usize = 4 * 1024 * 1024;
+const EVAL_TIMEOUT: Duration = Duration::from_secs(10);
+const LOAD_MORE_ATTEMPTS: usize = 4;
+const LOAD_MORE_WAIT: Duration = Duration::from_millis(700);
+const MAX_THUMB_SOURCE_BYTES: usize = 12 * 1024 * 1024;
+const MAX_THUMB_JPEG_BYTES: usize = 512 * 1024;
+const MAX_THUMB_HEADER_BYTES: usize = 64 * 1024;
+const THUMB_WEBVIEW_TIMEOUT: Duration = Duration::from_secs(18);
+const THUMB_WEBVIEW_POLL: Duration = Duration::from_millis(90);
+
+// Stable, album-specific WKWebView data-store identifier (macOS 14+). Windows
+// and Linux use `data_directory`; unsupported platforms ignore this field.
+const DATA_STORE_IDENTIFIER: [u8; 16] = [
+    0x47, 0x72, 0x6f, 0x6b, 0x41, 0x6c, 0x62, 0x75, 0x6d, 0x57, 0x65, 0x62, 0x56, 0x31, 0x00, 0x01,
+];
+
+const BRIDGE_MARKER_SCRIPT: &str = include_str!("wallpaper_grok_album/bridge_marker.js");
+
+// Grok currently renders `/imagine/saved` as an empty shell when its consumer
+// session is signed out. Recover to the official home page so the user can use
+// Grok's own sign-in button. A signed-in Saved page exposes its normal `main`
+// shell and is left untouched. No auth state, storage or network response is
+// inspected by this fixed script.
+const SIGNED_OUT_RECOVERY_SCRIPT: &str =
+    include_str!("wallpaper_grok_album/signed_out_recovery.js");
+
+// This is the only script that bridges data from the remote document. It
+// deliberately avoids text content, cookies, storage, headers, request bodies
+// and responses.
+const SNAPSHOT_SCRIPT: &str = include_str!("wallpaper_grok_album/snapshot.js");
+
+const SCROLL_MORE_SCRIPT: &str = include_str!("wallpaper_grok_album/scroll_more.js");
+const SCROLL_RESTORE_SCRIPT: &str = include_str!("wallpaper_grok_album/scroll_restore.js");
+
+static ALBUM_PAGE_OPERATION: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+static ALBUM_WINDOW_PROXY_OVERRIDE: LazyLock<Mutex<Option<String>>> =
+    LazyLock::new(|| Mutex::new(None));
+
+fn album_data_directory() -> PathBuf {
+    crate::paths::app_data_root()
+        .join("webviews")
+        .join("grok-imagine-saved")
+}
+
+fn detach_album_menu(window: &WebviewWindow) {
+    #[cfg(not(target_os = "macos"))]
+    {
+        // The application menu is useful in document windows, but adds a
+        // redundant File/Edit/Window/Help row above this isolated web page.
+        // A window-local empty menu also prevents a later app-wide menu
+        // refresh from attaching the row again.
+        if let Ok(empty) = tauri::menu::Menu::new(window.app_handle()) {
+            let _ = window.set_menu(empty);
+        }
+        let _ = window.hide_menu();
+    }
+    #[cfg(target_os = "macos")]
+    {
+        let _ = window;
+    }
+}
+
+/// Re-apply the album window chrome after the app-wide menu is refreshed.
+pub(crate) fn reassert_window_chrome(app: &AppHandle) {
+    if let Some(window) = app.get_webview_window(WINDOW_LABEL) {
+        detach_album_menu(&window);
+    }
+}
+
+fn host_matches(host: &str, base: &str) -> bool {
+    host == base || host.ends_with(&format!(".{base}"))
+}
+
+/// Top-level navigation allowlist. Subresources are governed by the page; the
+/// remote window has no Tauri capability regardless of the identity provider.
+pub fn is_allowed_album_navigation(url: &Url) -> bool {
+    if url.scheme() != "https"
+        || !url.username().is_empty()
+        || url.password().is_some()
+        || url.port_or_known_default() != Some(443)
+    {
+        return false;
+    }
+    let Some(host) = url.host_str().map(str::to_ascii_lowercase) else {
+        return false;
+    };
+    host_matches(&host, "grok.com")
+        || host_matches(&host, "x.ai")
+        || host_matches(&host, "x.com")
+        || host_matches(&host, "twitter.com")
+        || host == "accounts.google.com"
+        || host == "accounts.googleusercontent.com"
+        || host == "appleid.apple.com"
+}
+
+fn classify_page(
+    url: &Url,
+    ready_state: &str,
+    has_app_shell: bool,
+    has_security_challenge: bool,
+    recovery_state: &str,
+) -> GrokAlbumStatus {
+    let host = url.host_str().unwrap_or("").to_ascii_lowercase();
+    let path = url.path().to_ascii_lowercase();
+    if host_matches(&host, "grok.com") && (has_security_challenge || recovery_state == "challenge")
+    {
+        return GrokAlbumStatus::Verification;
+    }
+    let auth_path = path.contains("sign-in")
+        || path.contains("signin")
+        || path.contains("log-in")
+        || path.contains("login")
+        || path.contains("oauth")
+        || path.contains("authorize");
+    if auth_path
+        || host_matches(&host, "x.ai")
+        || host_matches(&host, "x.com")
+        || host_matches(&host, "twitter.com")
+        || host == "accounts.google.com"
+        || host == "accounts.googleusercontent.com"
+        || host == "appleid.apple.com"
+    {
+        return GrokAlbumStatus::SignIn;
+    }
+    if host_matches(&host, "grok.com") && path.starts_with("/imagine/saved") {
+        return if has_app_shell && (ready_state == "interactive" || ready_state == "complete") {
+            GrokAlbumStatus::Ready
+        } else if recovery_state == "redirecting" {
+            GrokAlbumStatus::SignIn
+        } else {
+            GrokAlbumStatus::Loading
+        };
+    }
+    if host_matches(&host, "grok.com") {
+        GrokAlbumStatus::OtherPage
+    } else {
+        GrokAlbumStatus::Loading
+    }
+}
+
+fn sanitize_media_url(raw: &str) -> Option<String> {
+    let raw = raw.trim();
+    if raw.is_empty() || raw.len() > MAX_MEDIA_URL_LENGTH {
+        return None;
+    }
+    let mut url = Url::parse(raw).ok()?;
+    if url.scheme() != "https"
+        || !url.host_str()?.eq_ignore_ascii_case("assets.grok.com")
+        || !url.username().is_empty()
+        || url.password().is_some()
+        || url.port_or_known_default() != Some(443)
+        || !url.path().contains("/generated/")
+    {
+        return None;
+    }
+    // Do not bridge arbitrary or signed query values. Known transform keys are
+    // sufficient for public asset variants; the original path remains usable.
+    let safe_pairs = url
+        .query_pairs()
+        .filter_map(|(key, value)| {
+            let key = key.to_ascii_lowercase();
+            let value = value.into_owned();
+            let allowed = match key.as_str() {
+                "format" => value.len() <= 8 && value.chars().all(|c| c.is_ascii_alphanumeric()),
+                "w" | "h" | "width" | "height" => {
+                    value.len() <= 6 && value.chars().all(|c| c.is_ascii_digit())
+                }
+                "cache" => value == "0" || value == "1",
+                _ => false,
+            };
+            allowed.then_some((key, value))
+        })
+        .collect::<Vec<_>>();
+    url.set_query(None);
+    url.set_fragment(None);
+    if !safe_pairs.is_empty() {
+        let mut query = url.query_pairs_mut();
+        for (key, value) in safe_pairs {
+            query.append_pair(&key, &value);
+        }
+    }
+    let sanitized = url.to_string();
+    (sanitized.len() <= MAX_MEDIA_URL_LENGTH).then_some(sanitized)
+}
+
+fn ensure_thumbnail_active(cancellation: &WallpaperSearchCancellation) -> Result<(), String> {
+    if cancellation.is_cancelled() {
+        Err("album_thumbnail_cancelled".to_string())
+    } else {
+        Ok(())
+    }
+}
+
+async fn fetch_album_thumbnail(
+    raw_url: String,
+    cancellation: &WallpaperSearchCancellation,
+) -> Result<GrokAlbumThumbnail, String> {
+    ensure_thumbnail_active(cancellation)?;
+    let url = sanitize_media_url(&raw_url).ok_or_else(|| "album_thumbnail_blocked".to_string())?;
+    let client = crate::proxy::apply_to_reqwest(
+        reqwest::Client::builder()
+            .timeout(Duration::from_secs(12))
+            .redirect(reqwest::redirect::Policy::none())
+            .user_agent(
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 \
+                 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+            ),
+    )
+    .build()
+    .map_err(|_| "album_thumbnail_unavailable".to_string())?;
+    let mut response = client
+        .get(url)
+        .header(
+            reqwest::header::ACCEPT,
+            "image/jpeg,image/png,image/webp;q=0.9,image/avif;q=0.8,image/*;q=0.7,*/*;q=0.5",
+        )
+        .header(reqwest::header::REFERER, SAVED_URL)
+        .header("sec-fetch-dest", "image")
+        .header("sec-fetch-mode", "no-cors")
+        .header("sec-fetch-site", "same-site")
+        .send()
+        .await
+        .map_err(|_| "album_thumbnail_unavailable".to_string())?;
+    ensure_thumbnail_active(cancellation)?;
+    if !response.status().is_success() {
+        tracing::debug!(
+            status = response.status().as_u16(),
+            "Grok album thumbnail request rejected"
+        );
+        return Err("album_thumbnail_unavailable".to_string());
+    }
+    let is_image = response
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.split(';').next())
+        .is_some_and(|value| value.trim().to_ascii_lowercase().starts_with("image/"));
+    if !is_image
+        || response
+            .content_length()
+            .is_some_and(|length| length > MAX_THUMB_SOURCE_BYTES as u64)
+    {
+        return Err("album_thumbnail_unavailable".to_string());
+    }
+
+    let mut bytes = Vec::new();
+    while let Some(chunk) = response
+        .chunk()
+        .await
+        .map_err(|_| "album_thumbnail_unavailable".to_string())?
+    {
+        ensure_thumbnail_active(cancellation)?;
+        if bytes.len().saturating_add(chunk.len()) > MAX_THUMB_SOURCE_BYTES {
+            return Err("album_thumbnail_unavailable".to_string());
+        }
+        bytes.extend_from_slice(&chunk);
+    }
+    if bytes.is_empty() {
+        return Err("album_thumbnail_unavailable".to_string());
+    }
+    ensure_thumbnail_active(cancellation)?;
+
+    let (jpeg, width, height) = tokio::task::spawn_blocking(move || {
+        crate::image_thumb::thumbnail_jpeg_from_untrusted_bytes(&bytes)
+    })
+    .await
+    .map_err(|_| "album_thumbnail_unavailable".to_string())?
+    .map_err(|_| "album_thumbnail_unavailable".to_string())?;
+    ensure_thumbnail_active(cancellation)?;
+    if jpeg.is_empty() || jpeg.len() > MAX_THUMB_JPEG_BYTES || width == 0 || height == 0 {
+        return Err("album_thumbnail_unavailable".to_string());
+    }
+    Ok(GrokAlbumThumbnail {
+        data_url: format!("data:image/jpeg;base64,{}", B64.encode(jpeg)),
+        width,
+        height,
+    })
+}
+
+fn sanitize_short_field(
+    raw: Option<String>,
+    max: usize,
+    allowed: fn(char) -> bool,
+) -> Option<String> {
+    let value = raw?.trim().to_string();
+    if value.is_empty() || value.len() > max || !value.chars().all(allowed) {
+        return None;
+    }
+    Some(value)
+}
+
+fn sanitize_raw_item(raw: RawAlbumMedia) -> Option<GrokAlbumMedia> {
+    let media_url = sanitize_media_url(&raw.media_url)?;
+    let kind = match raw.kind.trim().to_ascii_lowercase().as_str() {
+        "video" => "video",
+        _ => "image",
+    };
+    let thumbnail_url = raw
+        .thumbnail_url
+        .as_deref()
+        .and_then(sanitize_media_url)
+        .or_else(|| (kind == "image").then(|| media_url.clone()));
+    if kind == "video" && thumbnail_url.is_none() {
+        return None;
+    }
+    let webview_only =
+        raw.webview_only && kind == "video" && thumbnail_url.as_deref() == Some(media_url.as_str());
+    if raw.webview_only && !webview_only {
+        return None;
+    }
+    let width = raw.width.filter(|v| (1..=32_768).contains(v));
+    let height = raw.height.filter(|v| (1..=32_768).contains(v));
+    let created_at = sanitize_short_field(raw.created_at, 64, |c| {
+        c.is_ascii_digit() || matches!(c, 'T' | 'Z' | ':' | '+' | '-' | '.')
+    });
+    let post_id = sanitize_short_field(raw.post_id, 128, |c| {
+        c.is_ascii_alphanumeric() || matches!(c, '-' | '_')
+    });
+    Some(GrokAlbumMedia {
+        media_url,
+        thumbnail_url,
+        kind: kind.to_string(),
+        width,
+        height,
+        created_at,
+        post_id,
+        webview_only,
+    })
+}
+
+fn decode_eval_snapshot(raw: &str) -> Result<RawAlbumSnapshot, String> {
+    if raw.len() > MAX_BRIDGE_PAYLOAD_BYTES {
+        return Err("album_bridge_invalid".to_string());
+    }
+    let first: serde_json::Value =
+        serde_json::from_str(raw).map_err(|_| "album_bridge_invalid".to_string())?;
+    let value = match first {
+        serde_json::Value::String(inner) => {
+            serde_json::from_str(&inner).map_err(|_| "album_bridge_invalid".to_string())?
+        }
+        other => other,
+    };
+    serde_json::from_value(value).map_err(|_| "album_bridge_invalid".to_string())
+}
+
+fn eval_fixed(window: &WebviewWindow, script: &'static str) -> Result<String, String> {
+    eval_script(window, script)
+}
+
+fn eval_script(window: &WebviewWindow, script: &str) -> Result<String, String> {
+    let (tx, rx) = mpsc::channel::<String>();
+    window
+        .eval_with_callback(script, move |result| {
+            let _ = tx.send(result);
+        })
+        .map_err(|_| "album_bridge_unavailable".to_string())?;
+    rx.recv_timeout(EVAL_TIMEOUT)
+        .map_err(|_| "album_bridge_timeout".to_string())
+}
+
+fn decode_eval_thumbnail_job(raw: &str) -> Result<RawAlbumThumbnailJob, String> {
+    if raw.len() > MAX_BRIDGE_PAYLOAD_BYTES {
+        return Err("album_thumbnail_unavailable".to_string());
+    }
+    let first: serde_json::Value =
+        serde_json::from_str(raw).map_err(|_| "album_thumbnail_unavailable".to_string())?;
+    let value = match first {
+        serde_json::Value::String(inner) => {
+            serde_json::from_str(&inner).map_err(|_| "album_thumbnail_unavailable".to_string())?
+        }
+        other => other,
+    };
+    serde_json::from_value(value).map_err(|_| "album_thumbnail_unavailable".to_string())
+}
+
+fn thumbnail_job_start_script(url: &str) -> Result<String, String> {
+    let url = serde_json::to_string(url).map_err(|_| "album_thumbnail_blocked".to_string())?;
+    Ok(include_str!("wallpaper_grok_album/thumbnail_start.js")
+        .replace(
+            "__MAX_DATA_URL__",
+            &((MAX_THUMB_JPEG_BYTES * 4 / 3) + 128).to_string(),
+        )
+        .replace("__MAX_HEADER_BYTES__", &MAX_THUMB_HEADER_BYTES.to_string())
+        .replace(
+            "__MAX_DIMENSION__",
+            &crate::image_thumb::UNTRUSTED_THUMB_MAX_DIMENSION.to_string(),
+        )
+        .replace(
+            "__MAX_PIXELS__",
+            &crate::image_thumb::UNTRUSTED_THUMB_MAX_PIXELS.to_string(),
+        )
+        .replace("__MAX_SOURCE_BYTES__", &MAX_THUMB_SOURCE_BYTES.to_string())
+        .replace("__URL__", &url))
+}
+
+fn thumbnail_job_poll_script(url: &str, remove: bool) -> Result<String, String> {
+    let url = serde_json::to_string(url).map_err(|_| "album_thumbnail_blocked".to_string())?;
+    Ok(include_str!("wallpaper_grok_album/thumbnail_poll.js")
+        .replace("__REMOVE__", if remove { "true" } else { "false" })
+        .replace("__URL__", &url))
+}
+
+fn fetch_album_thumbnail_from_webview(
+    app: &AppHandle,
+    raw_url: &str,
+    cancellation: &WallpaperSearchCancellation,
+) -> Result<GrokAlbumThumbnail, String> {
+    let url = sanitize_media_url(raw_url).ok_or_else(|| "album_thumbnail_blocked".to_string())?;
+    if !cached_media_contains(&url) {
+        return Err("album_thumbnail_blocked".to_string());
+    }
+    let window = app
+        .get_webview_window(WINDOW_LABEL)
+        .ok_or_else(|| "album_thumbnail_unavailable".to_string())?;
+    let page_url = window
+        .url()
+        .map_err(|_| "album_thumbnail_unavailable".to_string())?;
+    if !page_url
+        .host_str()
+        .is_some_and(|host| host.eq_ignore_ascii_case("grok.com"))
+        || !page_url.path().starts_with("/imagine/saved")
+    {
+        return Err("album_thumbnail_unavailable".to_string());
+    }
+
+    let result = (|| {
+        ensure_thumbnail_active(cancellation)?;
+        let start = thumbnail_job_start_script(&url)?;
+        let _ = eval_script(&window, &start)?;
+        let deadline = Instant::now() + THUMB_WEBVIEW_TIMEOUT;
+        while Instant::now() < deadline {
+            ensure_thumbnail_active(cancellation)?;
+            let poll = thumbnail_job_poll_script(&url, false)?;
+            let job = decode_eval_thumbnail_job(&eval_script(&window, &poll)?)?;
+            match job.state.as_str() {
+                "ready" => {
+                    if job.data_url.starts_with("data:image/jpeg;base64,")
+                        && job.data_url.len() <= (MAX_THUMB_JPEG_BYTES * 4 / 3) + 128
+                        && job.width > 0
+                        && job.height > 0
+                    {
+                        return Ok(GrokAlbumThumbnail {
+                            data_url: job.data_url,
+                            width: job.width,
+                            height: job.height,
+                        });
+                    }
+                    return Err("album_thumbnail_unavailable".to_string());
+                }
+                "error" => return Err("album_thumbnail_unavailable".to_string()),
+                _ => std::thread::sleep(THUMB_WEBVIEW_POLL),
+            }
+        }
+        Err("album_thumbnail_unavailable".to_string())
+    })();
+    if let Ok(cleanup) = thumbnail_job_poll_script(&url, true) {
+        let _ = eval_script(&window, &cleanup);
+    }
+    result
+}
+
+fn closed_snapshot() -> GrokAlbumSnapshot {
+    clear_cache();
+    GrokAlbumSnapshot {
+        status: GrokAlbumStatus::Closed,
+        total: 0,
+        items: Vec::new(),
+        can_load_more: false,
+        new_items: 0,
+        prefetch_skipped: false,
+        page_changed: false,
+    }
+}
+
+fn snapshot_from_window(window: &WebviewWindow) -> Result<GrokAlbumSnapshot, String> {
+    // A navigation clears the cache and advances this revision. An eval that
+    // started in the previous document must not repopulate the new page with
+    // stale media after the navigation callback has already run.
+    let expected_revision = cache_revision();
+    let url = window
+        .url()
+        .map_err(|_| "album_page_unavailable".to_string())?;
+    let raw = decode_eval_snapshot(&eval_fixed(window, SNAPSHOT_SCRIPT)?)?;
+    let status = classify_page(
+        &url,
+        &raw.ready_state,
+        raw.has_app_shell,
+        raw.has_security_challenge,
+        &raw.recovery_state,
+    );
+    if status != GrokAlbumStatus::Ready {
+        clear_cache();
+    }
+    if raw.bridge_error {
+        return Err("album_bridge_unavailable".to_string());
+    }
+    let page_epoch = raw.page_epoch;
+    let scroll_top = raw.scroll_top;
+    let incoming = raw
+        .items
+        .into_iter()
+        .take(MAX_BRIDGE_ITEMS)
+        .filter_map(sanitize_raw_item)
+        .collect::<Vec<_>>();
+    let (new_items, page_changed) = if status == GrokAlbumStatus::Ready {
+        reconcile_cache_at_revision(incoming, expected_revision, page_epoch, scroll_top)
+            .ok_or_else(|| "album_page_changed".to_string())?
+    } else {
+        (0, false)
+    };
+    let items = cached_items();
+    let can_load_more = status == GrokAlbumStatus::Ready
+        && !items.is_empty()
+        && raw.scroll_height >= raw.viewport_height
+        && (raw.at_bottom || raw.scroll_height > raw.viewport_height);
+    Ok(GrokAlbumSnapshot {
+        status,
+        total: items.len(),
+        items,
+        can_load_more,
+        new_items,
+        prefetch_skipped: false,
+        page_changed,
+    })
+}
+
+fn open_album_window(app: &AppHandle, title: String) -> Result<(), String> {
+    let title = title.trim();
+    if title.is_empty() || title.chars().count() > 128 {
+        return Err("album_title_invalid".to_string());
+    }
+    // Validate the current route before reusing an existing window. This also
+    // prevents a stale window from bypassing a newly selected Direct or
+    // otherwise unsupported proxy mode if its earlier destruction failed.
+    let proxy_url = crate::proxy::webview_proxy_override()
+        .map_err(|_| "album_proxy_unsupported".to_string())?;
+    let proxy_override = proxy_url.as_ref().map(|url| url.as_str().to_string());
+    if let Some(window) = app.get_webview_window(WINDOW_LABEL) {
+        let route_matches = *ALBUM_WINDOW_PROXY_OVERRIDE.lock() == proxy_override;
+        if route_matches {
+            let _ = window.set_title(title);
+            let _ = window.unminimize();
+            window
+                .show()
+                .map_err(|_| "album_window_unavailable".to_string())?;
+            window
+                .set_focus()
+                .map_err(|_| "album_window_unavailable".to_string())?;
+            return Ok(());
+        }
+        window
+            .destroy()
+            .map_err(|_| "album_window_unavailable".to_string())?;
+    }
+
+    let data_dir = album_data_directory();
+    std::fs::create_dir_all(&data_dir).map_err(|_| "album_profile_unavailable".to_string())?;
+    let url = Url::parse(SAVED_URL).map_err(|_| "album_url_invalid".to_string())?;
+    clear_cache();
+    let mut builder = WebviewWindowBuilder::new(app, WINDOW_LABEL, WebviewUrl::External(url))
+        .title(title)
+        .inner_size(1120.0, 780.0)
+        .min_inner_size(720.0, 540.0)
+        .resizable(true)
+        .center()
+        .visible(false)
+        .data_directory(data_dir)
+        .data_store_identifier(DATA_STORE_IDENTIFIER)
+        .incognito(false)
+        .devtools(cfg!(debug_assertions))
+        .initialization_script(BRIDGE_MARKER_SCRIPT)
+        .initialization_script(SIGNED_OUT_RECOVERY_SCRIPT)
+        .on_navigation(|url| {
+            let allowed = is_allowed_album_navigation(url);
+            if allowed {
+                // A top-level navigation can represent logout or an account
+                // switch. Never merge a previous page's in-memory album into
+                // the next page instance.
+                clear_cache();
+            }
+            allowed
+        })
+        .on_new_window(|_, _| NewWindowResponse::Deny)
+        .on_download(|_, _| false);
+    if let Some(proxy_url) = proxy_url {
+        builder = builder.proxy_url(proxy_url);
+    }
+    let window = builder
+        .build()
+        .map_err(|_| "album_window_unavailable".to_string())?;
+    *ALBUM_WINDOW_PROXY_OVERRIDE.lock() = proxy_override;
+    detach_album_menu(&window);
+    window.on_window_event(|event| {
+        if matches!(event, tauri::WindowEvent::Destroyed) {
+            clear_cache();
+        }
+    });
+    window
+        .show()
+        .map_err(|_| "album_window_unavailable".to_string())?;
+    window
+        .set_focus()
+        .map_err(|_| "album_window_unavailable".to_string())?;
+    Ok(())
+}
+
+/// A remote WebView cannot change its proxy after construction. Drop the
+/// isolated window when network settings change; its dedicated persistent
+/// profile keeps the official sign-in session for the next open.
+pub(crate) fn close_for_proxy_change(app: &AppHandle) {
+    clear_cache();
+    if let Some(window) = app.get_webview_window(WINDOW_LABEL) {
+        let _ = window.destroy();
+    }
+}
+
+fn refresh_album_window(app: &AppHandle) -> Result<(), String> {
+    let _operation = ALBUM_PAGE_OPERATION.lock();
+    let window = app
+        .get_webview_window(WINDOW_LABEL)
+        .ok_or_else(|| "album_window_closed".to_string())?;
+    clear_cache();
+    let url = Url::parse(SAVED_URL).map_err(|_| "album_url_invalid".to_string())?;
+    window
+        .navigate(url)
+        .map_err(|_| "album_page_unavailable".to_string())?;
+    let _ = window.unminimize();
+    let _ = window.show();
+    window
+        .set_focus()
+        .map_err(|_| "album_window_unavailable".to_string())
+}
+
+fn load_more_from_window(
+    window: &WebviewWindow,
+    only_when_background: bool,
+) -> Result<GrokAlbumSnapshot, String> {
+    let _operation = ALBUM_PAGE_OPERATION.lock();
+    let initial = snapshot_from_window(window)?;
+    if initial.status != GrokAlbumStatus::Ready || !initial.can_load_more {
+        return Ok(initial);
+    }
+    if only_when_background && window.is_focused().unwrap_or(true) {
+        return Ok(GrokAlbumSnapshot {
+            prefetch_skipped: true,
+            new_items: 0,
+            ..initial
+        });
+    }
+
+    let result = (|| {
+        let baseline = initial.total;
+        let mut latest = initial;
+        for _ in 0..LOAD_MORE_ATTEMPTS {
+            if only_when_background && window.is_focused().unwrap_or(true) {
+                return Ok(GrokAlbumSnapshot {
+                    prefetch_skipped: true,
+                    new_items: latest.total.saturating_sub(baseline),
+                    ..latest
+                });
+            }
+            let _ = eval_fixed(window, SCROLL_MORE_SCRIPT)?;
+            std::thread::sleep(LOAD_MORE_WAIT);
+            latest = snapshot_from_window(window)?;
+            if latest.total > baseline || latest.status != GrokAlbumStatus::Ready {
+                break;
+            }
+        }
+        latest.new_items = latest.total.saturating_sub(baseline);
+        Ok(latest)
+    })();
+
+    // Background lookahead must not leave the user's official Grok page at
+    // the infinite-scroll boundary. The fixed page script remembers the
+    // original root and offset before the first scroll; always restore it,
+    // including focus changes and bridge failures.
+    let _ = eval_fixed(window, SCROLL_RESTORE_SCRIPT);
+    result
+}
+
+#[tauri::command]
+pub async fn wallpaper_grok_album_open(app: AppHandle, title: String) -> Result<(), String> {
+    tauri::async_runtime::spawn_blocking(move || open_album_window(&app, title))
+        .await
+        .map_err(|_| "album_window_unavailable".to_string())?
+}
+
+#[tauri::command]
+pub async fn wallpaper_grok_album_snapshot(app: AppHandle) -> Result<GrokAlbumSnapshot, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let Some(window) = app.get_webview_window(WINDOW_LABEL) else {
+            return Ok(closed_snapshot());
+        };
+        snapshot_from_window(&window)
+    })
+    .await
+    .map_err(|_| "album_bridge_unavailable".to_string())?
+}
+
+#[tauri::command]
+pub async fn wallpaper_grok_album_refresh(app: AppHandle) -> Result<(), String> {
+    tauri::async_runtime::spawn_blocking(move || refresh_album_window(&app))
+        .await
+        .map_err(|_| "album_page_unavailable".to_string())?
+}
+
+#[tauri::command]
+pub async fn wallpaper_grok_album_load_more(
+    app: AppHandle,
+    background_only: Option<bool>,
+) -> Result<GrokAlbumSnapshot, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let Some(window) = app.get_webview_window(WINDOW_LABEL) else {
+            return Ok(closed_snapshot());
+        };
+        load_more_from_window(&window, background_only.unwrap_or(false))
+    })
+    .await
+    .map_err(|_| "album_bridge_unavailable".to_string())?
+}
+
+#[tauri::command]
+pub async fn wallpaper_grok_album_thumbnail(
+    app: AppHandle,
+    url: String,
+    request_id: String,
+) -> Result<GrokAlbumThumbnail, String> {
+    let request = register_album_request(&request_id)?;
+    ensure_thumbnail_active(&request.cancellation)?;
+    let url = sanitize_media_url(&url).ok_or_else(|| "album_thumbnail_blocked".to_string())?;
+    if !cached_media_contains(&url) {
+        return Err("album_thumbnail_blocked".to_string());
+    }
+    let started = Instant::now();
+    let cancellation = request.cancellation.clone();
+    let webview_cancellation = cancellation.clone();
+    let webview_url = url.clone();
+    let webview = async move {
+        tauri::async_runtime::spawn_blocking(move || {
+            fetch_album_thumbnail_from_webview(&app, &webview_url, &webview_cancellation)
+        })
+        .await
+        .map_err(|_| "album_thumbnail_unavailable".to_string())?
+    };
+    let host_cancellation = cancellation.clone();
+    let host_url = url.clone();
+    let host = async move { fetch_album_thumbnail(host_url, &host_cancellation).await };
+    let cancellation_wait = cancellation.clone();
+    let result = tokio::select! {
+        result = first_success(webview, host) => result,
+        _ = cancellation_wait.cancelled() => Err("album_thumbnail_cancelled".to_string()),
+    };
+    let (thumbnail, route) = result?;
+    cancellation.cancel();
+    if !cached_media_contains(&url) {
+        return Err("album_thumbnail_unavailable".to_string());
+    }
+    tracing::debug!(
+        route = route.as_str(),
+        elapsed_ms = started.elapsed().as_millis() as u64,
+        "Grok album thumbnail route completed"
+    );
+    Ok(thumbnail)
+}
+
+#[tauri::command]
+pub fn wallpaper_grok_album_cancel_requests(request_ids: Vec<String>) -> Result<usize, String> {
+    let requested = request_ids.len();
+    let active = cancel_album_requests(&request_ids)?;
+    tracing::debug!(
+        requested = requested as u64,
+        active = active as u64,
+        "Grok album requests cancelled"
+    );
+    Ok(active)
+}
+
+#[tauri::command]
+pub fn wallpaper_grok_album_cancel_all_requests() -> usize {
+    let active = cancel_all_album_requests();
+    tracing::debug!(
+        active = active as u64,
+        "Grok album active requests cancelled"
+    );
+    active
+}
+
+#[tauri::command]
+pub async fn wallpaper_grok_album_fetch_media(
+    app: AppHandle,
+    url: String,
+    request_id: String,
+) -> Result<crate::wallpaper_source::WallpaperFetchResult, String> {
+    let request = register_album_request(&request_id)?;
+    if request.cancellation.is_cancelled() {
+        return Err("download_failed: album media cancelled".to_string());
+    }
+    crate::wallpaper_source::ensure_wallpaper_dirs();
+    let url = sanitize_media_url(&url).ok_or_else(|| "url_blocked".to_string())?;
+    let (expected_revision, webview_only) =
+        cached_media_state(&url).ok_or_else(|| "url_blocked".to_string())?;
+    let started = Instant::now();
+    let _media_lock = media_store::acquire(&url, &request.cancellation).await?;
+    if cache_revision() != expected_revision || !cached_media_contains(&url) {
+        return Err("download_failed: album page changed".to_string());
+    }
+    if let Some(cached) = media_store::lookup(&url)? {
+        request.cancellation.cancel();
+        tracing::debug!(
+            route = "cache",
+            media_transport = if webview_only { "blob" } else { "remote" },
+            elapsed_ms = started.elapsed().as_millis() as u64,
+            bytes = cached.bytes,
+            "Grok album media route completed"
+        );
+        return Ok(cached);
+    }
+    tracing::debug!(
+        media_transport = if webview_only { "blob" } else { "remote" },
+        "Grok album media route started"
+    );
+    let cancellation = request.cancellation.clone();
+    let app_for_webview = app.clone();
+    let url_for_webview = url.clone();
+    let webview_cancellation = cancellation.clone();
+    let webview = async move {
+        tauri::async_runtime::spawn_blocking(move || {
+            media_fetch::fetch_from_webview(
+                &app_for_webview,
+                &url_for_webview,
+                &webview_cancellation,
+                webview_only,
+            )
+        })
+        .await
+        .map_err(|_| "download_failed: album media task failed".to_string())?
+    };
+    let host_url = url.clone();
+    let host = async move {
+        let (content_type, bytes) =
+            crate::wallpaper_source::fetch_remote_media_bytes(&host_url, Some("grok_album"))
+                .await?;
+        Ok((bytes, content_type))
+    };
+    let transfer = async {
+        if webview_only {
+            webview.await.map(|value| (value, AlbumFetchRoute::Webview))
+        } else {
+            first_success(webview, host).await
+        }
+    };
+    let cancellation_wait = cancellation.clone();
+    let result = tokio::select! {
+        result = transfer => result,
+        _ = cancellation_wait.cancelled() => {
+            Err("download_failed: album media cancelled".to_string())
+        }
+    };
+    let ((bytes, content_type), route) = result?;
+    cancellation.cancel();
+    // Navigation, logout, or an account switch invalidates the URL after the
+    // race has started. Never persist a late winner from the previous page.
+    if cache_revision() != expected_revision || !cached_media_contains(&url) {
+        return Err("download_failed: album page changed".to_string());
+    }
+    tracing::debug!(
+        route = route.as_str(),
+        media_transport = if webview_only { "blob" } else { "remote" },
+        elapsed_ms = started.elapsed().as_millis() as u64,
+        bytes = bytes.len() as u64,
+        "Grok album media route completed"
+    );
+    tauri::async_runtime::spawn_blocking(move || media_store::save(&url, &content_type, bytes))
+        .await
+        .map_err(|_| "download_failed: album media save task failed".to_string())?
+}

--- a/src-tauri/src/wallpaper_grok_album/bridge_marker.js
+++ b/src-tauri/src/wallpaper_grok_album/bridge_marker.js
@@ -1,0 +1,61 @@
+(function () {
+  try {
+    // Album tracking must not alter identity-provider pages or embedded frames.
+    if (location.protocol !== "https:" || location.hostname !== "grok.com" ||
+        window.top !== window) return;
+
+    var state = { epoch: 0, href: String(location.href || ""), main: null };
+    Object.defineProperty(window, "__GROK_APP_SAVED_READ_ONLY__", {
+      value: true,
+      configurable: false,
+      enumerable: false,
+      writable: false
+    });
+    Object.defineProperty(window, "__GROK_APP_SAVED_PAGE_STATE__", {
+      value: state,
+      configurable: false,
+      enumerable: false,
+      writable: false
+    });
+
+    function markRoute() {
+      try {
+        var href = String(location.href || "");
+        if (href !== state.href) {
+          state.href = href;
+          state.epoch += 1;
+        }
+      } catch (_) {}
+    }
+
+    ["pushState", "replaceState"].forEach(function (name) {
+      try {
+        var original = history[name];
+        if (typeof original !== "function") return;
+        history[name] = function () {
+          var result = original.apply(this, arguments);
+          markRoute();
+          return result;
+        };
+      } catch (_) {}
+    });
+    window.addEventListener("popstate", markRoute);
+    window.addEventListener("hashchange", markRoute);
+
+    function inspectMain() {
+      try {
+        var next = document.querySelector("main");
+        if (!state.main && next) {
+          state.main = next;
+        } else if (state.main && next !== state.main) {
+          state.main = next;
+          state.epoch += 1;
+        }
+      } catch (_) {}
+    }
+    if (typeof MutationObserver === "function") {
+      new MutationObserver(inspectMain).observe(document, { childList: true, subtree: true });
+    }
+    document.addEventListener("DOMContentLoaded", inspectMain, { once: true });
+  } catch (_) {}
+})();

--- a/src-tauri/src/wallpaper_grok_album/cache.rs
+++ b/src-tauri/src/wallpaper_grok_album/cache.rs
@@ -1,0 +1,181 @@
+use std::collections::HashSet;
+use std::sync::LazyLock;
+
+use parking_lot::Mutex;
+use tauri::Url;
+
+use super::model::GrokAlbumMedia;
+use super::request_registry::cancel_all as cancel_all_album_requests;
+
+const MAX_CACHE_ITEMS: usize = 480;
+const CACHE_TOP_THRESHOLD: f64 = 96.0;
+const EMPTY_AT_TOP_CONFIRMATIONS: u8 = 2;
+
+#[derive(Default)]
+pub(super) struct AlbumCache {
+    pub(super) items: Vec<GrokAlbumMedia>,
+    pub(super) revision: u64,
+    pub(super) page_epoch: Option<u64>,
+    pub(super) empty_at_top_snapshots: u8,
+}
+
+static ALBUM_CACHE: LazyLock<Mutex<AlbumCache>> =
+    LazyLock::new(|| Mutex::new(AlbumCache::default()));
+
+pub(super) fn cached_media_contains(raw_url: &str) -> bool {
+    let target = media_identity(raw_url);
+    ALBUM_CACHE.lock().items.iter().any(|item| {
+        media_identity(&item.media_url) == target
+            || item
+                .thumbnail_url
+                .as_deref()
+                .is_some_and(|url| media_identity(url) == target)
+    })
+}
+
+pub(super) fn cached_media_state(raw_url: &str) -> Option<(u64, bool)> {
+    let target = media_identity(raw_url);
+    let cache = ALBUM_CACHE.lock();
+    cache.items.iter().find_map(|item| {
+        let matches = media_identity(&item.media_url) == target
+            || item
+                .thumbnail_url
+                .as_deref()
+                .is_some_and(|url| media_identity(url) == target);
+        matches.then_some((cache.revision, item.webview_only))
+    })
+}
+
+fn merge_cache_items(cache: &mut AlbumCache, incoming: Vec<GrokAlbumMedia>) -> usize {
+    let mut seen = cache
+        .items
+        .iter()
+        .map(|item| media_identity(&item.media_url))
+        .collect::<HashSet<_>>();
+    let before = cache.items.len();
+    for item in incoming {
+        if cache.items.len() >= MAX_CACHE_ITEMS {
+            break;
+        }
+        if seen.insert(media_identity(&item.media_url)) {
+            cache.items.push(item);
+        }
+    }
+    cache.items.len().saturating_sub(before)
+}
+
+#[cfg(test)]
+pub(super) fn merge_cache(incoming: Vec<GrokAlbumMedia>) -> usize {
+    let mut cache = ALBUM_CACHE.lock();
+    merge_cache_items(&mut cache, incoming)
+}
+
+#[cfg(test)]
+pub(super) fn merge_cache_items_at_revision(
+    cache: &mut AlbumCache,
+    incoming: Vec<GrokAlbumMedia>,
+    expected_revision: u64,
+) -> Option<usize> {
+    if cache.revision != expected_revision {
+        return None;
+    }
+    Some(merge_cache_items(cache, incoming))
+}
+
+pub(super) fn reconcile_cache_items_at_revision(
+    cache: &mut AlbumCache,
+    incoming: Vec<GrokAlbumMedia>,
+    expected_revision: u64,
+    page_epoch: u64,
+    scroll_top: f64,
+) -> Option<(usize, bool)> {
+    if cache.revision != expected_revision {
+        return None;
+    }
+
+    let at_top = scroll_top.is_finite() && scroll_top <= CACHE_TOP_THRESHOLD;
+    let incoming_identities = incoming
+        .iter()
+        .map(|item| media_identity(&item.media_url))
+        .collect::<HashSet<_>>();
+    let has_overlap = cache
+        .items
+        .iter()
+        .any(|item| incoming_identities.contains(&media_identity(&item.media_url)));
+    let mut reset = false;
+
+    if cache.page_epoch != Some(page_epoch) {
+        reset = !cache.items.is_empty();
+        cache.page_epoch = Some(page_epoch);
+        cache.empty_at_top_snapshots = 0;
+    }
+
+    if at_top && incoming.is_empty() && !cache.items.is_empty() {
+        cache.empty_at_top_snapshots = cache.empty_at_top_snapshots.saturating_add(1);
+        if cache.empty_at_top_snapshots >= EMPTY_AT_TOP_CONFIRMATIONS {
+            reset = true;
+        }
+    } else {
+        cache.empty_at_top_snapshots = 0;
+        if at_top && !incoming.is_empty() && !cache.items.is_empty() && !has_overlap {
+            reset = true;
+        }
+    }
+
+    if reset {
+        cache.items.clear();
+        cache.revision = cache.revision.wrapping_add(1);
+        cache.empty_at_top_snapshots = 0;
+    }
+    Some((merge_cache_items(cache, incoming), reset))
+}
+
+pub(super) fn reconcile_cache_at_revision(
+    incoming: Vec<GrokAlbumMedia>,
+    expected_revision: u64,
+    page_epoch: u64,
+    scroll_top: f64,
+) -> Option<(usize, bool)> {
+    let (new_items, reset) = {
+        let mut cache = ALBUM_CACHE.lock();
+        reconcile_cache_items_at_revision(
+            &mut cache,
+            incoming,
+            expected_revision,
+            page_epoch,
+            scroll_top,
+        )?
+    };
+    if reset {
+        let _ = cancel_all_album_requests();
+    }
+    Some((new_items, reset))
+}
+
+fn media_identity(raw: &str) -> String {
+    let Ok(mut url) = Url::parse(raw) else {
+        return raw.to_string();
+    };
+    url.set_query(None);
+    url.set_fragment(None);
+    url.to_string()
+}
+
+pub(super) fn cached_items() -> Vec<GrokAlbumMedia> {
+    ALBUM_CACHE.lock().items.clone()
+}
+
+pub(super) fn cache_revision() -> u64 {
+    ALBUM_CACHE.lock().revision
+}
+
+pub(super) fn clear_cache() {
+    {
+        let mut cache = ALBUM_CACHE.lock();
+        cache.items.clear();
+        cache.revision = cache.revision.wrapping_add(1);
+        cache.page_epoch = None;
+        cache.empty_at_top_snapshots = 0;
+    }
+    let _ = cancel_all_album_requests();
+}

--- a/src-tauri/src/wallpaper_grok_album/fetch_route.rs
+++ b/src-tauri/src/wallpaper_grok_album/fetch_route.rs
@@ -1,0 +1,38 @@
+use std::future::Future;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum AlbumFetchRoute {
+    Webview,
+    Host,
+}
+
+impl AlbumFetchRoute {
+    pub(super) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Webview => "webview",
+            Self::Host => "host",
+        }
+    }
+}
+
+pub(super) async fn first_success<T, W, H>(
+    webview: W,
+    host: H,
+) -> Result<(T, AlbumFetchRoute), String>
+where
+    W: Future<Output = Result<T, String>>,
+    H: Future<Output = Result<T, String>>,
+{
+    tokio::pin!(webview);
+    tokio::pin!(host);
+    tokio::select! {
+        webview_result = &mut webview => match webview_result {
+            Ok(value) => Ok((value, AlbumFetchRoute::Webview)),
+            Err(_) => host.await.map(|value| (value, AlbumFetchRoute::Host)),
+        },
+        host_result = &mut host => match host_result {
+            Ok(value) => Ok((value, AlbumFetchRoute::Host)),
+            Err(_) => webview.await.map(|value| (value, AlbumFetchRoute::Webview)),
+        },
+    }
+}

--- a/src-tauri/src/wallpaper_grok_album/media_fetch.rs
+++ b/src-tauri/src/wallpaper_grok_album/media_fetch.rs
@@ -1,0 +1,448 @@
+use std::time::{Duration, Instant};
+
+use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
+use serde::de::DeserializeOwned;
+use serde::Deserialize;
+use tauri::{AppHandle, Manager, WebviewWindow};
+
+use crate::wallpaper_source::WallpaperSearchCancellation;
+
+use super::{
+    cached_media_contains, eval_script, sanitize_media_url, MAX_BRIDGE_PAYLOAD_BYTES, WINDOW_LABEL,
+};
+
+const FETCH_TIMEOUT: Duration = Duration::from_secs(90);
+const TRANSFER_TIMEOUT: Duration = Duration::from_secs(180);
+const POLL_INTERVAL: Duration = Duration::from_millis(80);
+const CHUNK_TIMEOUT: Duration = Duration::from_secs(12);
+const CHUNK_BYTES: usize = 512 * 1024;
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct MediaJob {
+    #[serde(default)]
+    state: String,
+    #[serde(default)]
+    size: u64,
+    #[serde(default)]
+    mime: String,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct MediaChunk {
+    #[serde(default)]
+    state: String,
+    #[serde(default)]
+    start: u64,
+    #[serde(default)]
+    end: u64,
+    #[serde(default)]
+    data: String,
+}
+
+pub(super) fn validated_cached_media_url(raw_url: &str) -> Result<String, String> {
+    let url = sanitize_media_url(raw_url).ok_or_else(|| "url_blocked".to_string())?;
+    if !cached_media_contains(&url) {
+        return Err("url_blocked".to_string());
+    }
+    Ok(url)
+}
+
+fn saved_album_window(app: &AppHandle) -> Result<WebviewWindow, String> {
+    let window = app
+        .get_webview_window(WINDOW_LABEL)
+        .ok_or_else(|| "download_failed: album window closed".to_string())?;
+    let page_url = window
+        .url()
+        .map_err(|_| "download_failed: album page unavailable".to_string())?;
+    if !page_url
+        .host_str()
+        .is_some_and(|host| host.eq_ignore_ascii_case("grok.com"))
+        || !page_url.path().starts_with("/imagine/saved")
+    {
+        return Err("download_failed: album page unavailable".to_string());
+    }
+    Ok(window)
+}
+
+fn decode_eval_json<T: DeserializeOwned>(raw: &str) -> Result<T, String> {
+    if raw.len() > MAX_BRIDGE_PAYLOAD_BYTES {
+        return Err("download_failed: album bridge payload too large".to_string());
+    }
+    let first: serde_json::Value = serde_json::from_str(raw)
+        .map_err(|_| "download_failed: invalid album bridge payload".to_string())?;
+    let value = match first {
+        serde_json::Value::String(inner) => serde_json::from_str(&inner)
+            .map_err(|_| "download_failed: invalid album bridge payload".to_string())?,
+        other => other,
+    };
+    serde_json::from_value(value)
+        .map_err(|_| "download_failed: invalid album bridge payload".to_string())
+}
+
+fn media_job_start_script(url: &str, webview_only: bool) -> Result<String, String> {
+    let url = serde_json::to_string(url).map_err(|_| "url_blocked".to_string())?;
+    Ok(format!(
+        r#"(function () {{
+  try {{
+    var url = {url};
+    var webviewOnly = {webview_only};
+    var target = url;
+    var targetWasBlob = false;
+
+    function assetIdentity(raw) {{
+      try {{
+        var parsed = new URL(String(raw || ""), location.href);
+        if (parsed.protocol !== "https:" || parsed.hostname !== "assets.grok.com" ||
+            (parsed.port && parsed.port !== "443") || parsed.username || parsed.password ||
+            parsed.pathname.indexOf("/generated/") < 0) return null;
+        return parsed.origin + parsed.pathname;
+      }} catch (_) {{
+        return null;
+      }}
+    }}
+
+    if (webviewOnly) {{
+      var anchorIdentity = assetIdentity(url);
+      var videos = Array.prototype.slice.call(document.querySelectorAll("video"));
+      var matched = videos.find(function (video) {{
+        return assetIdentity(video && video.poster) === anchorIdentity;
+      }});
+      if (!anchorIdentity || !matched) throw new Error("anchor");
+      var rawTarget = String((matched.currentSrc || matched.src) || "");
+      var targetUrl = new URL(rawTarget, location.href);
+      var localBlob = targetUrl.protocol === "blob:" && targetUrl.origin === location.origin;
+      var generatedAsset = assetIdentity(targetUrl.href) !== null;
+      if (!localBlob && !generatedAsset) throw new Error("target");
+      target = targetUrl.href;
+      targetWasBlob = localBlob;
+    }}
+
+    var jobs = window.__GROK_APP_ALBUM_MEDIA_JOBS__ ||
+      (window.__GROK_APP_ALBUM_MEDIA_JOBS__ = Object.create(null));
+    var existing = jobs[url];
+    if (existing && (existing.state === "loading" || existing.state === "ready")) {{
+      return JSON.stringify({{
+        state: existing.state,
+        size: Number(existing.size || 0),
+        mime: String(existing.mime || "").slice(0, 64)
+      }});
+    }}
+    try {{ if (existing && existing.controller) existing.controller.abort(); }} catch (_) {{}}
+
+    var controller = typeof AbortController === "function" ? new AbortController() : null;
+    var job = {{ state: "loading", size: 0, mime: "", controller: controller }};
+    jobs[url] = job;
+    var timer = window.setTimeout(function () {{
+      try {{ if (controller) controller.abort(); }} catch (_) {{}}
+    }}, 85000);
+
+    function fail() {{
+      window.clearTimeout(timer);
+      if (jobs[url] === job) jobs[url] = {{ state: "error", size: 0, mime: "" }};
+    }}
+
+    fetch(target, {{
+      credentials: "include",
+      mode: "cors",
+      cache: "force-cache",
+      redirect: "follow",
+      signal: controller ? controller.signal : undefined
+    }})
+      .then(function (response) {{
+        if (!response.ok) throw new Error("status");
+        if (!targetWasBlob) {{
+          var finalUrl = new URL(response.url || target, location.href);
+          if (assetIdentity(finalUrl.href) === null) throw new Error("redirect");
+        }}
+        var mime = String(response.headers.get("content-type") || "")
+          .split(";")[0].trim().toLowerCase().slice(0, 64);
+        var length = Number(response.headers.get("content-length") || 0);
+        if ((mime.indexOf("image/") !== 0 && mime.indexOf("video/") !== 0 &&
+             mime !== "application/octet-stream" && mime !== "") ||
+            (webviewOnly && mime && mime.indexOf("video/") !== 0 &&
+             mime !== "application/octet-stream") ||
+            !Number.isFinite(length) || length < 0 || length > {max_bytes}) {{
+          throw new Error("metadata");
+        }}
+        return response.blob().then(function (blob) {{ return {{ blob: blob, mime: mime }}; }});
+      }})
+      .then(function (payload) {{
+        window.clearTimeout(timer);
+        if (jobs[url] !== job) return;
+        var blob = payload && payload.blob;
+        var mime = String((payload && payload.mime) || (blob && blob.type) || "")
+          .split(";")[0].trim().toLowerCase().slice(0, 64);
+        if (!blob || !blob.size || blob.size > {max_bytes}) return fail();
+        jobs[url] = {{
+          state: "ready",
+          size: Number(blob.size),
+          mime: mime,
+          blob: blob,
+          chunk: null
+        }};
+      }})
+      .catch(fail);
+    return JSON.stringify({{ state: "loading", size: 0, mime: "" }});
+  }} catch (_) {{
+    return JSON.stringify({{ state: "error", size: 0, mime: "" }});
+  }}
+}})()"#,
+        max_bytes = crate::wallpaper_source::MAX_DOWNLOAD_BYTES,
+        webview_only = if webview_only { "true" } else { "false" },
+    ))
+}
+
+fn media_job_poll_script(url: &str, remove: bool) -> Result<String, String> {
+    let url = serde_json::to_string(url).map_err(|_| "url_blocked".to_string())?;
+    Ok(format!(
+        r#"(function () {{
+  try {{
+    var url = {url};
+    var jobs = window.__GROK_APP_ALBUM_MEDIA_JOBS__;
+    var job = jobs && jobs[url];
+    if (!job) return JSON.stringify({{ state: "error", size: 0, mime: "" }});
+    var result = JSON.stringify({{
+      state: String(job.state || "error"),
+      size: Number(job.size || 0),
+      mime: String(job.mime || "").slice(0, 64)
+    }});
+    if ({remove}) {{
+      try {{ if (job.controller) job.controller.abort(); }} catch (_) {{}}
+      delete jobs[url];
+    }}
+    return result;
+  }} catch (_) {{
+    return JSON.stringify({{ state: "error", size: 0, mime: "" }});
+  }}
+}})()"#,
+        remove = if remove { "true" } else { "false" },
+    ))
+}
+
+fn media_chunk_start_script(url: &str, start: u64, end: u64) -> Result<String, String> {
+    let url = serde_json::to_string(url).map_err(|_| "url_blocked".to_string())?;
+    Ok(format!(
+        r#"(function () {{
+  try {{
+    var url = {url};
+    var start = {start};
+    var end = {end};
+    var jobs = window.__GROK_APP_ALBUM_MEDIA_JOBS__;
+    var job = jobs && jobs[url];
+    if (!job || job.state !== "ready" || !job.blob || start < 0 || end <= start ||
+        end > job.size || end - start > {chunk_bytes}) {{
+      return JSON.stringify({{ state: "error", start: start, end: end, data: "" }});
+    }}
+    var existing = job.chunk;
+    if (existing && existing.start === start && existing.end === end &&
+        (existing.state === "loading" || existing.state === "ready")) {{
+      return JSON.stringify({{ state: existing.state, start: start, end: end, data: "" }});
+    }}
+    var chunk = {{ state: "loading", start: start, end: end, data: "" }};
+    job.chunk = chunk;
+    var reader = new FileReader();
+    var timer = window.setTimeout(function () {{
+      try {{ reader.abort(); }} catch (_) {{}}
+      if (job.chunk === chunk) job.chunk = {{ state: "error", start: start, end: end, data: "" }};
+    }}, 8000);
+    function fail() {{
+      window.clearTimeout(timer);
+      if (job.chunk === chunk) job.chunk = {{ state: "error", start: start, end: end, data: "" }};
+    }}
+    reader.onload = function () {{
+      window.clearTimeout(timer);
+      if (job.chunk !== chunk) return;
+      var result = String(reader.result || "");
+      var comma = result.indexOf(",");
+      var data = comma >= 0 ? result.slice(comma + 1) : "";
+      if (!data || data.length > {max_b64} || !/^[A-Za-z0-9+/]*={{0,2}}$/.test(data)) return fail();
+      job.chunk = {{ state: "ready", start: start, end: end, data: data }};
+    }};
+    reader.onerror = fail;
+    reader.onabort = fail;
+    reader.readAsDataURL(job.blob.slice(start, end));
+    return JSON.stringify({{ state: "loading", start: start, end: end, data: "" }});
+  }} catch (_) {{
+    return JSON.stringify({{ state: "error", start: {start}, end: {end}, data: "" }});
+  }}
+}})()"#,
+        chunk_bytes = CHUNK_BYTES,
+        max_b64 = (CHUNK_BYTES * 4 / 3) + 16,
+    ))
+}
+
+fn media_chunk_poll_script(url: &str, take: bool) -> Result<String, String> {
+    let url = serde_json::to_string(url).map_err(|_| "url_blocked".to_string())?;
+    Ok(format!(
+        r#"(function () {{
+  try {{
+    var url = {url};
+    var jobs = window.__GROK_APP_ALBUM_MEDIA_JOBS__;
+    var job = jobs && jobs[url];
+    var chunk = job && job.chunk;
+    if (!chunk) return JSON.stringify({{ state: "error", start: 0, end: 0, data: "" }});
+    var result = JSON.stringify({{
+      state: String(chunk.state || "error"),
+      start: Number(chunk.start || 0),
+      end: Number(chunk.end || 0),
+      data: chunk.state === "ready" ? String(chunk.data || "") : ""
+    }});
+    if ({take} && chunk.state !== "loading") job.chunk = null;
+    return result;
+  }} catch (_) {{
+    return JSON.stringify({{ state: "error", start: 0, end: 0, data: "" }});
+  }}
+}})()"#,
+        take = if take { "true" } else { "false" },
+    ))
+}
+
+fn wait_for_media(
+    window: &WebviewWindow,
+    url: &str,
+    cancellation: &WallpaperSearchCancellation,
+    webview_only: bool,
+) -> Result<MediaJob, String> {
+    if cancellation.is_cancelled() {
+        return Err("download_failed: album media cancelled".to_string());
+    }
+    let start = media_job_start_script(url, webview_only)?;
+    let _ = eval_script(window, &start)?;
+    let deadline = Instant::now() + FETCH_TIMEOUT;
+    while Instant::now() < deadline {
+        if cancellation.is_cancelled() {
+            return Err("download_failed: album media cancelled".to_string());
+        }
+        let poll = media_job_poll_script(url, false)?;
+        let job: MediaJob = decode_eval_json(&eval_script(window, &poll)?)?;
+        match job.state.as_str() {
+            "ready" => {
+                if job.size == 0 || job.size > crate::wallpaper_source::MAX_DOWNLOAD_BYTES {
+                    return Err("download_failed: invalid album media size".to_string());
+                }
+                return Ok(job);
+            }
+            "error" => return Err("download_failed: album media unavailable".to_string()),
+            _ => std::thread::sleep(POLL_INTERVAL),
+        }
+    }
+    Err("download_failed: album media timeout".to_string())
+}
+
+fn read_media_chunk(
+    window: &WebviewWindow,
+    url: &str,
+    start: u64,
+    end: u64,
+    cancellation: &WallpaperSearchCancellation,
+) -> Result<Vec<u8>, String> {
+    let start_script = media_chunk_start_script(url, start, end)?;
+    let _ = eval_script(window, &start_script)?;
+    let deadline = Instant::now() + CHUNK_TIMEOUT;
+    while Instant::now() < deadline {
+        if cancellation.is_cancelled() {
+            return Err("download_failed: album media cancelled".to_string());
+        }
+        let poll = media_chunk_poll_script(url, false)?;
+        let chunk: MediaChunk = decode_eval_json(&eval_script(window, &poll)?)?;
+        match chunk.state.as_str() {
+            "ready" => {
+                let take = media_chunk_poll_script(url, true)?;
+                let chunk: MediaChunk = decode_eval_json(&eval_script(window, &take)?)?;
+                if chunk.start != start || chunk.end != end || chunk.data.is_empty() {
+                    return Err("download_failed: invalid album media chunk".to_string());
+                }
+                let bytes = B64
+                    .decode(chunk.data.as_bytes())
+                    .map_err(|_| "download_failed: invalid album media chunk".to_string())?;
+                if bytes.len() as u64 != end - start {
+                    return Err("download_failed: short album media chunk".to_string());
+                }
+                return Ok(bytes);
+            }
+            "error" => return Err("download_failed: album media chunk unavailable".to_string()),
+            _ => std::thread::sleep(POLL_INTERVAL),
+        }
+    }
+    Err("download_failed: album media chunk timeout".to_string())
+}
+
+pub(super) fn fetch_from_webview(
+    app: &AppHandle,
+    raw_url: &str,
+    cancellation: &WallpaperSearchCancellation,
+    webview_only: bool,
+) -> Result<(Vec<u8>, String), String> {
+    let url = validated_cached_media_url(raw_url)?;
+    let window = saved_album_window(app)?;
+    let result = (|| {
+        let job = wait_for_media(&window, &url, cancellation, webview_only)?;
+        let capacity = usize::try_from(job.size)
+            .map_err(|_| "download_failed: invalid album media size".to_string())?;
+        let mut bytes = Vec::with_capacity(capacity);
+        let transfer_deadline = Instant::now() + TRANSFER_TIMEOUT;
+        let mut offset = 0u64;
+        while offset < job.size {
+            if cancellation.is_cancelled() {
+                return Err("download_failed: album media cancelled".to_string());
+            }
+            if Instant::now() >= transfer_deadline {
+                return Err("download_failed: album media transfer timeout".to_string());
+            }
+            let end = (offset + CHUNK_BYTES as u64).min(job.size);
+            bytes.extend_from_slice(&read_media_chunk(&window, &url, offset, end, cancellation)?);
+            offset = end;
+        }
+        if bytes.len() as u64 != job.size {
+            return Err("download_failed: short album media transfer".to_string());
+        }
+        Ok((bytes, job.mime))
+    })();
+
+    if let Ok(cleanup) = media_job_poll_script(&url, true) {
+        let _ = eval_script(&window, &cleanup);
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bridge_decodes_direct_and_nested_job_json() {
+        let direct: MediaJob =
+            decode_eval_json(r#"{"state":"ready","size":123,"mime":"image/jpeg"}"#).unwrap();
+        assert_eq!(direct.state, "ready");
+        assert_eq!(direct.size, 123);
+        let nested =
+            serde_json::to_string(r#"{"state":"ready","start":0,"end":3,"data":"YWJj"}"#).unwrap();
+        let chunk: MediaChunk = decode_eval_json(&nested).unwrap();
+        assert_eq!(chunk.data, "YWJj");
+    }
+
+    #[test]
+    fn generated_scripts_embed_bounded_constants_and_unconditional_cleanup() {
+        let url = "https://assets.grok.com/users/test/generated/fake/image.jpg";
+        let media_start = media_job_start_script(url, false).unwrap();
+        assert!(media_start.contains("response.url || target"));
+        assert!(media_start.contains("parsed.port !== \"443\""));
+        let blob_start = media_job_start_script(url, true).unwrap();
+        assert!(blob_start.contains("var webviewOnly = true"));
+        assert!(blob_start.contains("targetUrl.protocol === \"blob:\""));
+        assert!(blob_start.contains("targetUrl.origin === location.origin"));
+        let start = media_chunk_start_script(url, 0, CHUNK_BYTES as u64).unwrap();
+        assert!(start.contains(&format!("end - start > {CHUNK_BYTES}")));
+        let cleanup = media_job_poll_script(url, true).unwrap();
+        assert!(cleanup.contains("delete jobs[url]"));
+        assert!(!cleanup.contains("state !== \"loading\""));
+    }
+
+    #[test]
+    fn bridge_rejects_oversized_eval_payload() {
+        let oversized = "x".repeat(MAX_BRIDGE_PAYLOAD_BYTES + 1);
+        assert!(decode_eval_json::<MediaJob>(&oversized).is_err());
+    }
+}

--- a/src-tauri/src/wallpaper_grok_album/media_store.rs
+++ b/src-tauri/src/wallpaper_grok_album/media_store.rs
@@ -1,0 +1,293 @@
+use std::collections::HashMap;
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, LazyLock, Weak};
+
+use parking_lot::Mutex;
+use sha2::{Digest, Sha256};
+use tokio::sync::{Mutex as AsyncMutex, OwnedMutexGuard};
+
+use crate::wallpaper_source::{
+    self, WallpaperFetchResult, WallpaperSearchCancellation, MAX_DOWNLOAD_BYTES,
+};
+
+const CACHE_EXTENSIONS: [&str; 7] = ["jpg", "png", "gif", "webp", "avif", "mp4", "webm"];
+
+type MediaLock = AsyncMutex<()>;
+
+static MEDIA_LOCKS: LazyLock<Mutex<HashMap<String, Weak<MediaLock>>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+fn sha256_hex(value: &[u8]) -> String {
+    let digest = Sha256::digest(value);
+    let mut output = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        use std::fmt::Write as _;
+        let _ = write!(output, "{byte:02x}");
+    }
+    output
+}
+
+fn media_key(url: &str) -> String {
+    sha256_hex(url.as_bytes())
+}
+
+fn originals_dir() -> PathBuf {
+    wallpaper_source::wallpapers_root()
+        .join("grok_album")
+        .join("originals")
+}
+
+fn media_path(key: &str, extension: &str) -> PathBuf {
+    originals_dir().join(format!("{key}.{extension}"))
+}
+
+fn remove_file_if_present(path: &Path) -> Result<(), String> {
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(format!("remove cached media: {error}")),
+    }
+}
+
+fn remove_other_variants(key: &str, keep: Option<&Path>) -> Result<(), String> {
+    for extension in CACHE_EXTENSIONS {
+        let candidate = media_path(key, extension);
+        if keep.is_some_and(|path| path == candidate) {
+            continue;
+        }
+        remove_file_if_present(&candidate)?;
+    }
+    Ok(())
+}
+
+fn cached_result(path: &Path) -> Result<Option<WallpaperFetchResult>, String> {
+    let metadata = match fs::metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(format!("stat cached media: {error}")),
+    };
+    if !metadata.is_file() || metadata.len() < 64 || metadata.len() > MAX_DOWNLOAD_BYTES {
+        remove_file_if_present(path)?;
+        return Ok(None);
+    }
+
+    let bytes = match fs::read(path) {
+        Ok(bytes) => bytes,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(format!("read cached media: {error}")),
+    };
+    let Ok((mime, extension)) = wallpaper_source::validate_fetched_media_bytes("", &bytes) else {
+        remove_file_if_present(path)?;
+        return Ok(None);
+    };
+    let actual_extension = path
+        .extension()
+        .and_then(|value| value.to_str())
+        .unwrap_or("");
+    if !actual_extension.eq_ignore_ascii_case(extension) {
+        remove_file_if_present(path)?;
+        return Ok(None);
+    }
+
+    let name = path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .ok_or_else(|| "cached media name unavailable".to_string())?
+        .to_string();
+    crate::path_scope::grant_path(path);
+    Ok(Some(WallpaperFetchResult {
+        path: path.display().to_string(),
+        mime: mime.to_string(),
+        bytes: bytes.len() as u64,
+        name,
+    }))
+}
+
+pub(super) fn lookup(url: &str) -> Result<Option<WallpaperFetchResult>, String> {
+    let key = media_key(url);
+    for extension in CACHE_EXTENSIONS {
+        let path = media_path(&key, extension);
+        if let Some(result) = cached_result(&path)? {
+            remove_other_variants(&key, Some(&path))?;
+            return Ok(Some(result));
+        }
+    }
+    Ok(None)
+}
+
+fn lock_for_url(url: &str) -> Arc<MediaLock> {
+    let key = media_key(url);
+    let mut locks = MEDIA_LOCKS.lock();
+    locks.retain(|_, lock| lock.strong_count() > 0);
+    if let Some(lock) = locks.get(&key).and_then(Weak::upgrade) {
+        return lock;
+    }
+    let lock = Arc::new(AsyncMutex::new(()));
+    locks.insert(key, Arc::downgrade(&lock));
+    lock
+}
+
+pub(super) async fn acquire(
+    url: &str,
+    cancellation: &WallpaperSearchCancellation,
+) -> Result<OwnedMutexGuard<()>, String> {
+    let lock = lock_for_url(url);
+    let cancellation_wait = cancellation.clone();
+    tokio::select! {
+        biased;
+        _ = cancellation_wait.cancelled() => {
+            Err("download_failed: album media cancelled".to_string())
+        }
+        guard = lock.lock_owned() => Ok(guard),
+    }
+}
+
+fn write_new_file(path: &Path, bytes: &[u8]) -> Result<(), String> {
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)
+        .map_err(|error| format!("create cached media: {error}"))?;
+    file.write_all(bytes)
+        .map_err(|error| format!("write cached media: {error}"))?;
+    file.flush()
+        .map_err(|error| format!("flush cached media: {error}"))
+}
+
+pub(super) fn save(
+    url: &str,
+    content_type: &str,
+    bytes: Vec<u8>,
+) -> Result<WallpaperFetchResult, String> {
+    if let Some(result) = lookup(url)? {
+        return Ok(result);
+    }
+    let (mime, extension) = wallpaper_source::validate_fetched_media_bytes(content_type, &bytes)?;
+    let key = media_key(url);
+    let directory = originals_dir();
+    fs::create_dir_all(&directory).map_err(|error| format!("create media cache: {error}"))?;
+    remove_other_variants(&key, None)?;
+
+    let path = media_path(&key, extension);
+    let temporary = directory.join(format!(".{key}-{}.partial", uuid::Uuid::new_v4().simple()));
+    if let Err(error) = write_new_file(&temporary, &bytes) {
+        let _ = remove_file_if_present(&temporary);
+        return Err(error);
+    }
+    if let Err(error) = fs::rename(&temporary, &path) {
+        let _ = remove_file_if_present(&temporary);
+        if let Some(result) = lookup(url)? {
+            return Ok(result);
+        }
+        return Err(format!("commit cached media: {error}"));
+    }
+
+    crate::path_scope::grant_path(&path);
+    let name = path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .ok_or_else(|| "cached media name unavailable".to_string())?
+        .to_string();
+    Ok(WallpaperFetchResult {
+        path: path.display().to_string(),
+        mime: mime.to_string(),
+        bytes: bytes.len() as u64,
+        name,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use futures_util::future::join_all;
+
+    use super::*;
+
+    fn test_png() -> Vec<u8> {
+        let mut bytes = vec![0u8; 128];
+        bytes[..8].copy_from_slice(b"\x89PNG\r\n\x1a\n");
+        bytes
+    }
+
+    fn test_home(label: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "grok-app-album-media-{label}-{}-{}",
+            std::process::id(),
+            uuid::Uuid::new_v4().simple()
+        ))
+    }
+
+    #[test]
+    fn stable_cache_reuses_one_validated_file_and_rebuilds_damage() {
+        let _environment = crate::paths::APP_HOME_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        let home = test_home("reuse");
+        // SAFETY: test-only mutation serialized by APP_HOME_ENV_LOCK.
+        unsafe { std::env::set_var("GROK_APP_HOME", &home) };
+        let url = "https://assets.grok.com/users/test/generated/stable.png";
+
+        let first = save(url, "image/png", test_png()).expect("initial save");
+        let second = lookup(url).expect("cache lookup").expect("cache hit");
+        assert_eq!(first.path, second.path);
+        assert_eq!(second.mime, "image/png");
+
+        fs::write(&first.path, vec![b'x'; 128]).expect("corrupt cache");
+        assert!(lookup(url).expect("corrupt lookup").is_none());
+        assert!(!Path::new(&first.path).exists());
+        let rebuilt = save(url, "image/png", test_png()).expect("rebuild corrupt cache");
+        assert_eq!(first.path, rebuilt.path);
+
+        fs::remove_file(&rebuilt.path).expect("delete cache");
+        assert!(lookup(url).expect("deleted lookup").is_none());
+        let restored = save(url, "image/png", test_png()).expect("restore deleted cache");
+        assert_eq!(first.path, restored.path);
+
+        unsafe { std::env::remove_var("GROK_APP_HOME") };
+        let _ = fs::remove_dir_all(home);
+    }
+
+    #[test]
+    fn concurrent_requests_commit_one_stable_file() {
+        let _environment = crate::paths::APP_HOME_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        let home = test_home("concurrent");
+        // SAFETY: test-only mutation serialized by APP_HOME_ENV_LOCK.
+        unsafe { std::env::set_var("GROK_APP_HOME", &home) };
+        let url = "https://assets.grok.com/users/test/generated/concurrent.png";
+        let writes = AtomicUsize::new(0);
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("test runtime");
+        let results = runtime.block_on(async {
+            let requests = (0..8).map(|_| async {
+                let cancellation = WallpaperSearchCancellation::default();
+                let _guard = acquire(url, &cancellation).await.expect("media lock");
+                if let Some(result) = lookup(url).expect("cache lookup") {
+                    return result;
+                }
+                writes.fetch_add(1, Ordering::SeqCst);
+                tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+                save(url, "image/png", test_png()).expect("save")
+            });
+            join_all(requests).await
+        });
+        assert_eq!(writes.load(Ordering::SeqCst), 1);
+        assert!(results.iter().all(|result| result.path == results[0].path));
+        let files = fs::read_dir(originals_dir())
+            .expect("originals directory")
+            .filter_map(Result::ok)
+            .filter(|entry| entry.path().is_file())
+            .collect::<Vec<_>>();
+        assert_eq!(files.len(), 1);
+
+        unsafe { std::env::remove_var("GROK_APP_HOME") };
+        let _ = fs::remove_dir_all(home);
+    }
+}

--- a/src-tauri/src/wallpaper_grok_album/model.rs
+++ b/src-tauri/src/wallpaper_grok_album/model.rs
@@ -1,0 +1,107 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GrokAlbumStatus {
+    Closed,
+    Loading,
+    Verification,
+    SignIn,
+    Ready,
+    OtherPage,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GrokAlbumMedia {
+    pub media_url: String,
+    pub thumbnail_url: Option<String>,
+    pub kind: String,
+    pub width: Option<u32>,
+    pub height: Option<u32>,
+    pub created_at: Option<String>,
+    pub post_id: Option<String>,
+    #[serde(skip_serializing)]
+    pub(super) webview_only: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GrokAlbumSnapshot {
+    pub status: GrokAlbumStatus,
+    pub items: Vec<GrokAlbumMedia>,
+    pub total: usize,
+    pub can_load_more: bool,
+    pub new_items: usize,
+    pub prefetch_skipped: bool,
+    pub page_changed: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GrokAlbumThumbnail {
+    pub(super) data_url: String,
+    pub(super) width: u32,
+    pub(super) height: u32,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct RawAlbumSnapshot {
+    #[serde(default)]
+    pub(super) ready_state: String,
+    #[serde(default)]
+    pub(super) has_app_shell: bool,
+    #[serde(default)]
+    pub(super) has_security_challenge: bool,
+    #[serde(default)]
+    pub(super) recovery_state: String,
+    #[serde(default)]
+    pub(super) items: Vec<RawAlbumMedia>,
+    #[serde(default)]
+    pub(super) page_epoch: u64,
+    #[serde(default)]
+    pub(super) scroll_top: f64,
+    #[serde(default)]
+    pub(super) scroll_height: f64,
+    #[serde(default)]
+    pub(super) viewport_height: f64,
+    #[serde(default)]
+    pub(super) at_bottom: bool,
+    #[serde(default)]
+    pub(super) bridge_error: bool,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct RawAlbumMedia {
+    #[serde(default)]
+    pub(super) media_url: String,
+    #[serde(default)]
+    pub(super) thumbnail_url: Option<String>,
+    #[serde(default)]
+    pub(super) kind: String,
+    #[serde(default)]
+    pub(super) width: Option<u32>,
+    #[serde(default)]
+    pub(super) height: Option<u32>,
+    #[serde(default)]
+    pub(super) created_at: Option<String>,
+    #[serde(default)]
+    pub(super) post_id: Option<String>,
+    #[serde(default)]
+    pub(super) webview_only: bool,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct RawAlbumThumbnailJob {
+    #[serde(default)]
+    pub(super) state: String,
+    #[serde(default)]
+    pub(super) data_url: String,
+    #[serde(default)]
+    pub(super) width: u32,
+    #[serde(default)]
+    pub(super) height: u32,
+}

--- a/src-tauri/src/wallpaper_grok_album/request_registry.rs
+++ b/src-tauri/src/wallpaper_grok_album/request_registry.rs
@@ -1,0 +1,139 @@
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::time::{Duration, Instant};
+
+use parking_lot::Mutex;
+
+use crate::wallpaper_source::WallpaperSearchCancellation;
+
+const PRE_CANCEL_TTL: Duration = Duration::from_secs(30);
+const PRE_CANCEL_CAPACITY: usize = 128;
+const CANCEL_BATCH_LIMIT: usize = 64;
+
+#[derive(Default)]
+struct AlbumRequestRegistry {
+    active: HashMap<String, WallpaperSearchCancellation>,
+    pre_cancelled: VecDeque<(String, Instant)>,
+}
+
+impl AlbumRequestRegistry {
+    fn purge_pre_cancelled(&mut self, now: Instant) {
+        self.pre_cancelled
+            .retain(|(_, created)| now.duration_since(*created) < PRE_CANCEL_TTL);
+    }
+
+    fn record_pre_cancel(&mut self, request_id: &str, now: Instant) {
+        self.purge_pre_cancelled(now);
+        self.pre_cancelled.retain(|(id, _)| id != request_id);
+        while self.pre_cancelled.len() >= PRE_CANCEL_CAPACITY {
+            self.pre_cancelled.pop_front();
+        }
+        self.pre_cancelled.push_back((request_id.to_string(), now));
+    }
+
+    fn take_pre_cancel(&mut self, request_id: &str, now: Instant) -> bool {
+        self.purge_pre_cancelled(now);
+        let found = self.pre_cancelled.iter().any(|(id, _)| id == request_id);
+        self.pre_cancelled.retain(|(id, _)| id != request_id);
+        found
+    }
+}
+
+static REQUESTS: std::sync::LazyLock<Mutex<AlbumRequestRegistry>> =
+    std::sync::LazyLock::new(|| Mutex::new(AlbumRequestRegistry::default()));
+
+pub(super) struct ActiveAlbumRequest {
+    request_id: String,
+    pub(super) cancellation: WallpaperSearchCancellation,
+}
+
+impl Drop for ActiveAlbumRequest {
+    fn drop(&mut self) {
+        REQUESTS.lock().active.remove(&self.request_id);
+    }
+}
+
+fn validate_request_id(request_id: &str) -> Result<&str, String> {
+    let request_id = request_id.trim();
+    uuid::Uuid::parse_str(request_id).map_err(|_| "album_request_invalid".to_string())?;
+    Ok(request_id)
+}
+
+pub(super) fn register(request_id: &str) -> Result<ActiveAlbumRequest, String> {
+    let request_id = validate_request_id(request_id)?;
+    let cancellation = WallpaperSearchCancellation::default();
+    let mut requests = REQUESTS.lock();
+    if requests.active.contains_key(request_id) {
+        return Err("album_request_in_use".to_string());
+    }
+    if requests.take_pre_cancel(request_id, Instant::now()) {
+        cancellation.cancel();
+    }
+    requests
+        .active
+        .insert(request_id.to_string(), cancellation.clone());
+    Ok(ActiveAlbumRequest {
+        request_id: request_id.to_string(),
+        cancellation,
+    })
+}
+
+pub(super) fn cancel(request_ids: &[String]) -> Result<usize, String> {
+    if request_ids.len() > CANCEL_BATCH_LIMIT {
+        return Err("album_request_cancel_batch_too_large".to_string());
+    }
+    let request_ids = request_ids
+        .iter()
+        .map(|request_id| validate_request_id(request_id).map(str::to_string))
+        .collect::<Result<HashSet<_>, _>>()?;
+    let mut requests = REQUESTS.lock();
+    let mut active = Vec::new();
+    for request_id in &request_ids {
+        if let Some(cancellation) = requests.active.get(request_id).cloned() {
+            active.push(cancellation);
+        } else {
+            requests.record_pre_cancel(request_id, Instant::now());
+        }
+    }
+    drop(requests);
+    let count = active.len();
+    for cancellation in active {
+        cancellation.cancel();
+    }
+    Ok(count)
+}
+
+fn cancel_all_in(requests: &Mutex<AlbumRequestRegistry>) -> usize {
+    let active = requests.lock().active.values().cloned().collect::<Vec<_>>();
+    let count = active.len();
+    for cancellation in active {
+        cancellation.cancel();
+    }
+    count
+}
+
+pub(super) fn cancel_all() -> usize {
+    cancel_all_in(&REQUESTS)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cancel_all_reports_and_cancels_active_album_requests() {
+        let first = WallpaperSearchCancellation::default();
+        let second = WallpaperSearchCancellation::default();
+        let requests = Mutex::new(AlbumRequestRegistry {
+            active: HashMap::from([
+                (uuid::Uuid::new_v4().to_string(), first.clone()),
+                (uuid::Uuid::new_v4().to_string(), second.clone()),
+            ]),
+            pre_cancelled: VecDeque::new(),
+        });
+
+        assert_eq!(cancel_all_in(&requests), 2);
+        assert!(first.is_cancelled());
+        assert!(second.is_cancelled());
+        assert_eq!(cancel_all_in(&requests), 2);
+    }
+}

--- a/src-tauri/src/wallpaper_grok_album/script_tests.rs
+++ b/src-tauri/src/wallpaper_grok_album/script_tests.rs
@@ -1,0 +1,47 @@
+use super::*;
+
+#[test]
+fn fixed_scripts_remain_bundled_and_thumbnail_templates_are_fully_bound() {
+    assert!(BRIDGE_MARKER_SCRIPT.contains("__GROK_APP_SAVED_READ_ONLY__"));
+    assert!(BRIDGE_MARKER_SCRIPT.contains("__GROK_APP_SAVED_PAGE_STATE__"));
+    assert!(BRIDGE_MARKER_SCRIPT.contains("MutationObserver"));
+    assert!(SIGNED_OUT_RECOVERY_SCRIPT.contains("https://grok.com/"));
+    assert!(SIGNED_OUT_RECOVERY_SCRIPT.contains("__GROK_APP_SAVED_RECOVERY_STATE__"));
+    assert!(SIGNED_OUT_RECOVERY_SCRIPT.contains("shellSignature"));
+    assert!(SIGNED_OUT_RECOVERY_SCRIPT.contains("stableSamples >= MIN_STABLE_SAMPLES"));
+    assert!(SIGNED_OUT_RECOVERY_SCRIPT.contains("stableAge >= MIN_STABLE_AGE_MS"));
+    assert!(SIGNED_OUT_RECOVERY_SCRIPT.contains("pageAge >= MIN_PAGE_AGE_MS"));
+    assert!(SIGNED_OUT_RECOVERY_SCRIPT.contains("phase = \"challenge\""));
+    assert!(SIGNED_OUT_RECOVERY_SCRIPT.contains("phase = \"redirecting\""));
+    assert!(SNAPSHOT_SCRIPT.contains("assets.grok.com"));
+    assert!(SNAPSHOT_SCRIPT.contains("recoveryState"));
+    assert!(SNAPSHOT_SCRIPT.contains("hasSecurityChallenge"));
+    assert!(SNAPSHOT_SCRIPT.contains("/cdn-cgi/challenge-platform/"));
+    assert!(SNAPSHOT_SCRIPT.contains("/cdn-cgi/styles/challenges.css"));
+    assert!(SNAPSHOT_SCRIPT.contains("!hasAppShell && hasChallengeAsset"));
+    assert!(SNAPSHOT_SCRIPT.contains("webviewOnly"));
+    assert!(SNAPSHOT_SCRIPT.contains("url.protocol === \"blob:\""));
+    assert!(SCROLL_MORE_SCRIPT.contains("scrollTo"));
+    assert!(SCROLL_MORE_SCRIPT.contains("__GROK_APP_ALBUM_SCROLL_RESTORE__"));
+    assert!(SCROLL_RESTORE_SCRIPT.contains("delete window.__GROK_APP_ALBUM_SCROLL_RESTORE__"));
+
+    let url = "https://assets.grok.com/users/test/generated/fake/image.jpg";
+    let start = thumbnail_job_start_script(url).unwrap();
+    let poll = thumbnail_job_poll_script(url, true).unwrap();
+    for script in [&start, &poll] {
+        assert!(script.contains(url));
+        assert!(!script.contains("__URL__"));
+        assert!(!script.contains("__MAX_"));
+        assert!(!script.contains("__REMOVE__"));
+    }
+    assert!(start.contains(&MAX_THUMB_SOURCE_BYTES.to_string()));
+    assert!(start.contains(&MAX_THUMB_HEADER_BYTES.to_string()));
+    assert!(start.contains(&crate::image_thumb::UNTRUSTED_THUMB_MAX_DIMENSION.to_string()));
+    assert!(start.contains(&crate::image_thumb::UNTRUSTED_THUMB_MAX_PIXELS.to_string()));
+    assert!(start.contains("dimensionsFromHeader"));
+    assert!(start.contains("blob.slice(0,"));
+    assert!(start.contains("createImageBitmap(payload.blob)"));
+    assert!(start.contains("response.url || url"));
+    assert!(start.contains("finalUrl.hostname !== \"assets.grok.com\""));
+    assert!(poll.contains("if (true)"));
+}

--- a/src-tauri/src/wallpaper_grok_album/scroll_more.js
+++ b/src-tauri/src/wallpaper_grok_album/scroll_more.js
@@ -1,0 +1,71 @@
+(function () {
+  try {
+    function generatedMediaUrl(node) {
+      var candidates = node && node.tagName === "VIDEO"
+        ? [node.currentSrc, node.src, node.poster]
+        : [node && (node.currentSrc || node.src)];
+      return candidates.some(function (raw) {
+        if (!raw) return false;
+        try {
+          var text = String(raw);
+          if (text.length > 4096) return false;
+          var url = new URL(text, location.href);
+          return url.protocol === "https:" && url.hostname === "assets.grok.com" &&
+            (!url.port || url.port === "443") && url.pathname.indexOf("/generated/") >= 0;
+        } catch (_) {
+          return false;
+        }
+      });
+    }
+
+    function albumScrollRoot(nodes) {
+      var counts = new Map();
+      nodes.forEach(function (node) {
+        var current = node && node.parentElement;
+        while (current) {
+          try {
+            var style = getComputedStyle(current);
+            var scrollable = (style.overflowY === "auto" || style.overflowY === "scroll") &&
+              current.clientHeight > 0 && current.scrollHeight > current.clientHeight + 1;
+            if (scrollable) counts.set(current, (counts.get(current) || 0) + 1);
+          } catch (_) {}
+          current = current.parentElement;
+        }
+      });
+      var best = null;
+      var bestCount = 0;
+      var bestRange = -1;
+      counts.forEach(function (count, node) {
+        var range = Number(node.scrollHeight || 0) - Number(node.clientHeight || 0);
+        if (count > bestCount || (count === bestCount && range > bestRange)) {
+          best = node;
+          bestCount = count;
+          bestRange = range;
+        }
+      });
+      return best || document.scrollingElement || document.documentElement || document.body;
+    }
+
+    var mediaNodes = Array.prototype.filter.call(
+      document.querySelectorAll('img, video'),
+      generatedMediaUrl
+    );
+    var root = albumScrollRoot(mediaNodes);
+    var restore = window.__GROK_APP_ALBUM_SCROLL_RESTORE__;
+    if (!restore || restore.root !== root) {
+      window.__GROK_APP_ALBUM_SCROLL_RESTORE__ = {
+        root: root,
+        top: Number((root && root.scrollTop) || 0)
+      };
+    }
+    var height = Number((root && root.scrollHeight) || 0);
+    if (root && typeof root.scrollTo === "function") {
+      root.scrollTo({ top: height, left: 0, behavior: "auto" });
+    } else if (root) {
+      root.scrollTop = height;
+    }
+    return "ok";
+  } catch (_) {
+    return "blocked";
+  }
+})();

--- a/src-tauri/src/wallpaper_grok_album/scroll_restore.js
+++ b/src-tauri/src/wallpaper_grok_album/scroll_restore.js
@@ -1,0 +1,19 @@
+(function () {
+  try {
+    var restore = window.__GROK_APP_ALBUM_SCROLL_RESTORE__;
+    delete window.__GROK_APP_ALBUM_SCROLL_RESTORE__;
+    if (!restore || !restore.root) return "empty";
+    var root = restore.root;
+    var top = Number(restore.top || 0);
+    if (!Number.isFinite(top) || top < 0) top = 0;
+    if (typeof root.scrollTo === "function") {
+      root.scrollTo({ top: top, left: 0, behavior: "auto" });
+    } else {
+      root.scrollTop = top;
+    }
+    return "ok";
+  } catch (_) {
+    try { delete window.__GROK_APP_ALBUM_SCROLL_RESTORE__; } catch (_) {}
+    return "blocked";
+  }
+})();

--- a/src-tauri/src/wallpaper_grok_album/signed_out_recovery.js
+++ b/src-tauri/src/wallpaper_grok_album/signed_out_recovery.js
@@ -1,0 +1,176 @@
+(function () {
+  try {
+    if (window.top !== window || location.protocol !== "https:" || location.hostname !== "grok.com" ||
+        location.pathname.indexOf("/imagine/saved") !== 0) return;
+
+    var phase = "waiting";
+    var startedAt = monotonicNow();
+    var stableSince = 0;
+    var stableSamples = 0;
+    var lastShellSignature = "";
+    var timer = 0;
+    var observer = null;
+    var SAMPLE_INTERVAL_MS = 500;
+    var MIN_PAGE_AGE_MS = 12000;
+    var MIN_STABLE_AGE_MS = 3000;
+    var MIN_STABLE_SAMPLES = 6;
+
+    Object.defineProperty(window, "__GROK_APP_SAVED_RECOVERY_STATE__", {
+      get: function () { return phase; },
+      configurable: false,
+      enumerable: false
+    });
+
+    function monotonicNow() {
+      try {
+        if (window.performance && typeof window.performance.now === "function") {
+          return window.performance.now();
+        }
+      } catch (_) {}
+      return Date.now();
+    }
+
+    function isSavedRoute() {
+      try {
+        return location.protocol === "https:" && location.hostname === "grok.com" &&
+          location.pathname.indexOf("/imagine/saved") === 0;
+      } catch (_) {
+        return false;
+      }
+    }
+
+    function hasAppShell() {
+      try {
+        return !!document.querySelector("main");
+      } catch (_) {
+        return false;
+      }
+    }
+
+    function hasSecurityChallenge() {
+      try {
+        var surface = document.querySelector(
+          'iframe[src*="/cdn-cgi/challenge-platform/"], #challenge-stage, #challenge-running, #challenge-body-text, form#challenge-form, input[name="cf-turnstile-response"], textarea[name="cf-turnstile-response"], [data-translate="challenge_headline"]'
+        );
+        var asset = document.querySelector(
+          'script[src*="/cdn-cgi/challenge-platform/"], link[href*="/cdn-cgi/styles/challenges.css"]'
+        );
+        return !!surface || (!hasAppShell() && !!asset);
+      } catch (_) {
+        return false;
+      }
+    }
+
+    function shellSignature() {
+      try {
+        var body = document.body;
+        if (!body) return "";
+        var root = body.firstElementChild;
+        var descendants = body.getElementsByTagName("*").length;
+        var height = document.documentElement ? document.documentElement.scrollHeight : 0;
+        return [
+          body.childElementCount,
+          root ? root.tagName : "",
+          root ? root.childElementCount : 0,
+          descendants,
+          height
+        ].join(":");
+      } catch (_) {
+        return "";
+      }
+    }
+
+    function resetStability() {
+      stableSince = 0;
+      stableSamples = 0;
+      lastShellSignature = "";
+    }
+
+    function stopWatching() {
+      if (timer) {
+        window.clearTimeout(timer);
+        timer = 0;
+      }
+      if (observer) {
+        observer.disconnect();
+        observer = null;
+      }
+    }
+
+    function scheduleSample() {
+      if (timer) return;
+      timer = window.setTimeout(function () {
+        timer = 0;
+        samplePage();
+      }, SAMPLE_INTERVAL_MS);
+    }
+
+    function samplePage() {
+      try {
+        if (!isSavedRoute()) {
+          stopWatching();
+          return;
+        }
+        if (hasAppShell()) {
+          phase = "ready";
+          stopWatching();
+          return;
+        }
+        if (hasSecurityChallenge()) {
+          phase = "challenge";
+          resetStability();
+          scheduleSample();
+          return;
+        }
+
+        phase = "waiting";
+        if (document.readyState !== "complete" || !document.body) {
+          resetStability();
+          scheduleSample();
+          return;
+        }
+
+        var now = monotonicNow();
+        var signature = shellSignature();
+        if (!signature || signature !== lastShellSignature) {
+          lastShellSignature = signature;
+          stableSince = now;
+          stableSamples = 1;
+        } else {
+          stableSamples += 1;
+        }
+
+        var pageAge = now - startedAt;
+        var stableAge = stableSince > 0 ? now - stableSince : 0;
+        if (pageAge >= MIN_PAGE_AGE_MS && stableAge >= MIN_STABLE_AGE_MS &&
+            stableSamples >= MIN_STABLE_SAMPLES) {
+          phase = "redirecting";
+          stopWatching();
+          location.replace("https://grok.com/");
+          return;
+        }
+      } catch (_) {}
+      scheduleSample();
+    }
+
+    if (typeof MutationObserver === "function") {
+      observer = new MutationObserver(function () {
+        try {
+          if (!isSavedRoute()) {
+            stopWatching();
+          } else if (hasAppShell()) {
+            phase = "ready";
+            stopWatching();
+          } else if (hasSecurityChallenge()) {
+            phase = "challenge";
+            resetStability();
+          }
+        } catch (_) {}
+      });
+      observer.observe(document, { childList: true, subtree: true });
+    }
+    document.addEventListener("DOMContentLoaded", scheduleSample, { once: true });
+    window.addEventListener("load", scheduleSample, { once: true });
+    scheduleSample();
+  } catch (_) {}
+})();

--- a/src-tauri/src/wallpaper_grok_album/snapshot.js
+++ b/src-tauri/src/wallpaper_grok_album/snapshot.js
@@ -1,0 +1,221 @@
+(function () {
+  try {
+    var items = [];
+    var seen = Object.create(null);
+
+    function generatedMediaUrl(node) {
+      var candidates = node && node.tagName === "VIDEO"
+        ? [node.currentSrc, node.src, node.poster]
+        : [node && (node.currentSrc || node.src)];
+      for (var i = 0; i < candidates.length; i += 1) {
+        var raw = candidates[i];
+        if (!raw) continue;
+        try {
+          var text = String(raw);
+          if (text.length > 4096) continue;
+          var url = new URL(text, location.href);
+          if (url.protocol === "https:" &&
+              url.hostname === "assets.grok.com" &&
+              (!url.port || url.port === "443") &&
+              url.pathname.indexOf("/generated/") >= 0) {
+            return url.href;
+          }
+        } catch (_) {}
+      }
+      return null;
+    }
+
+    function videoAssetUrl(video) {
+      var candidates = [video && video.currentSrc, video && video.src];
+      if (video && video.querySelectorAll) {
+        Array.prototype.forEach.call(video.querySelectorAll("source[src]"), function (source) {
+          candidates.push(source.src || source.getAttribute("src"));
+        });
+      }
+      for (var i = 0; i < candidates.length; i += 1) {
+        var clean = cleanUrl(candidates[i]);
+        if (clean) return clean;
+      }
+      return null;
+    }
+
+    function isLocalBlobVideo(video) {
+      try {
+        var raw = String((video && (video.currentSrc || video.src)) || "");
+        var url = new URL(raw, location.href);
+        return url.protocol === "blob:" && url.origin === location.origin;
+      } catch (_) {
+        return false;
+      }
+    }
+
+    function albumScrollRoot(nodes) {
+      var counts = new Map();
+      nodes.forEach(function (node) {
+        var current = node && node.parentElement;
+        while (current) {
+          try {
+            var style = getComputedStyle(current);
+            var scrollable = (style.overflowY === "auto" || style.overflowY === "scroll") &&
+              current.clientHeight > 0 && current.scrollHeight > current.clientHeight + 1;
+            if (scrollable) counts.set(current, (counts.get(current) || 0) + 1);
+          } catch (_) {}
+          current = current.parentElement;
+        }
+      });
+      var best = null;
+      var bestCount = 0;
+      var bestRange = -1;
+      counts.forEach(function (count, node) {
+        var range = Number(node.scrollHeight || 0) - Number(node.clientHeight || 0);
+        if (count > bestCount || (count === bestCount && range > bestRange)) {
+          best = node;
+          bestCount = count;
+          bestRange = range;
+        }
+      });
+      return best || document.scrollingElement || document.documentElement || document.body;
+    }
+
+    function cleanUrl(raw) {
+      if (!raw) return null;
+      try {
+        var text = String(raw);
+        if (text.length > 4096) return null;
+        var url = new URL(text, location.href);
+        if (url.protocol !== "https:" || url.hostname !== "assets.grok.com") return null;
+        if (url.port && url.port !== "443") return null;
+        if (url.pathname.indexOf("/generated/") < 0) return null;
+        var clean = new URL(url.origin + url.pathname);
+        url.searchParams.forEach(function (value, key) {
+          var normalized = String(key).toLowerCase();
+          var allowed =
+            (normalized === "format" && /^[a-z0-9]{1,8}$/i.test(value)) ||
+            ((normalized === "w" || normalized === "h" ||
+              normalized === "width" || normalized === "height") &&
+              /^\d{1,6}$/.test(value)) ||
+            (normalized === "cache" && (value === "0" || value === "1"));
+          if (allowed) clean.searchParams.append(normalized, value);
+        });
+        return clean.href.length <= 4096 ? clean.href : null;
+      } catch (_) {
+        return null;
+      }
+    }
+
+    function postIdFor(node) {
+      try {
+        var link = node && node.closest ? node.closest('a[href]') : null;
+        if (!link) return null;
+        var path = new URL(link.href, location.href).pathname;
+        var match = path.match(/\/(?:post|share)\/([A-Za-z0-9_-]{4,128})(?:\/|$)/);
+        return match ? match[1] : null;
+      } catch (_) {
+        return null;
+      }
+    }
+
+    function createdAtFor(node) {
+      try {
+        var scope = node && node.closest ? node.closest('a, article, [data-testid], div') : null;
+        var time = scope && scope.querySelector ? scope.querySelector('time[datetime]') : null;
+        var raw = (time && time.getAttribute('datetime')) ||
+          (scope && scope.getAttribute && scope.getAttribute('data-created-at')) ||
+          (node && node.getAttribute && node.getAttribute('data-created-at')) || "";
+        return raw ? String(raw).slice(0, 64) : null;
+      } catch (_) {
+        return null;
+      }
+    }
+
+    function mediaIdentity(raw) {
+      try {
+        var url = new URL(raw);
+        return url.origin + url.pathname;
+      } catch (_) {
+        return null;
+      }
+    }
+
+    function add(node, rawMedia, rawThumb, kind, webviewOnly) {
+      if (items.length >= 320) return;
+      var mediaUrl = cleanUrl(rawMedia);
+      var identity = mediaIdentity(mediaUrl);
+      if (!mediaUrl || !identity || seen[identity]) return;
+      var thumbnailUrl = cleanUrl(rawThumb) || (kind === "image" ? mediaUrl : null);
+      if (kind === "video" && !thumbnailUrl) return;
+      seen[identity] = true;
+      var width = Number((node && (node.videoWidth || node.naturalWidth || node.width)) || 0);
+      var height = Number((node && (node.videoHeight || node.naturalHeight || node.height)) || 0);
+      items.push({
+        mediaUrl: mediaUrl,
+        thumbnailUrl: thumbnailUrl,
+        kind: kind,
+        width: Number.isFinite(width) && width > 0 ? Math.round(width) : null,
+        height: Number.isFinite(height) && height > 0 ? Math.round(height) : null,
+        createdAt: createdAtFor(node),
+        postId: postIdFor(node),
+        webviewOnly: !!webviewOnly
+      });
+    }
+
+    var mediaNodes = Array.prototype.filter.call(
+      document.querySelectorAll('img, video'),
+      function (node) { return !!generatedMediaUrl(node); }
+    );
+    var root = albumScrollRoot(mediaNodes);
+    var albumNodes = mediaNodes.filter(function (node) {
+      return root === document.scrollingElement || root === document.documentElement ||
+        root === document.body || (root.contains && root.contains(node));
+    });
+
+    albumNodes.filter(function (node) { return node.tagName === "VIDEO"; }).forEach(function (video) {
+      var media = videoAssetUrl(video);
+      var poster = cleanUrl(video.poster);
+      if (media) {
+        add(video, media, poster, "video", false);
+      } else if (poster && isLocalBlobVideo(video)) {
+        // The opaque blob URL remains inside this isolated page. The Host uses
+        // the allowlisted poster only as a lookup anchor when preview is asked.
+        add(video, poster, poster, "video", true);
+      }
+    });
+    albumNodes.filter(function (node) { return node.tagName === "IMG"; }).forEach(function (img) {
+      add(img, img.currentSrc || img.src, img.currentSrc || img.src, "image", false);
+    });
+
+    var hasAppShell = !!document.querySelector('main');
+    var hasChallengeSurface = !!document.querySelector(
+      'iframe[src*="/cdn-cgi/challenge-platform/"], #challenge-stage, #challenge-running, #challenge-body-text, form#challenge-form, input[name="cf-turnstile-response"], textarea[name="cf-turnstile-response"], [data-translate="challenge_headline"]'
+    );
+    var hasChallengeAsset = !!document.querySelector(
+      'script[src*="/cdn-cgi/challenge-platform/"], link[href*="/cdn-cgi/styles/challenges.css"]'
+    );
+    var top = Number((root && root.scrollTop) || 0);
+    var height = Number((root && root.scrollHeight) || 0);
+    var viewport = Number((root && root.clientHeight) || window.innerHeight || 0);
+    return JSON.stringify({
+      version: 1,
+      readyState: String(document.readyState || ""),
+      hasAppShell: hasAppShell,
+      hasSecurityChallenge: hasChallengeSurface || (!hasAppShell && hasChallengeAsset),
+      recoveryState: String(window.__GROK_APP_SAVED_RECOVERY_STATE__ || "").slice(0, 32),
+      pageEpoch: Number((window.__GROK_APP_SAVED_PAGE_STATE__ || {}).epoch || 0),
+      items: items.slice(0, 320),
+      scrollTop: top,
+      scrollHeight: height,
+      viewportHeight: viewport,
+      atBottom: height > 0 && top + viewport >= height - 96
+    });
+  } catch (_) {
+    return JSON.stringify({
+      version: 1,
+      readyState: "",
+      hasAppShell: false,
+      hasSecurityChallenge: false,
+      recoveryState: "",
+      items: [],
+      bridgeError: true
+    });
+  }
+})();

--- a/src-tauri/src/wallpaper_grok_album/tests.rs
+++ b/src-tauri/src/wallpaper_grok_album/tests.rs
@@ -1,0 +1,319 @@
+use super::*;
+
+#[tokio::test]
+async fn first_success_uses_fastest_route_and_survives_one_failure() {
+    let (value, route) = first_success(
+        std::future::pending::<Result<u8, String>>(),
+        std::future::ready(Ok(7)),
+    )
+    .await
+    .unwrap();
+    assert_eq!(value, 7);
+    assert_eq!(route, AlbumFetchRoute::Host);
+
+    let (value, route) = first_success(
+        std::future::ready(Err("webview failed".to_string())),
+        std::future::ready(Ok(9)),
+    )
+    .await
+    .unwrap();
+    assert_eq!(value, 9);
+    assert_eq!(route, AlbumFetchRoute::Host);
+}
+
+fn capability_label_matches(pattern: &str, label: &str) -> bool {
+    assert!(
+        !pattern.chars().any(|c| matches!(c, '[' | ']' | '{' | '}')),
+        "complex capability label patterns require an album security review: {pattern}"
+    );
+    let pattern = pattern.as_bytes();
+    let label = label.as_bytes();
+    let mut previous = vec![false; label.len() + 1];
+    previous[0] = true;
+    for token in pattern {
+        let mut current = vec![false; label.len() + 1];
+        if *token == b'*' {
+            current[0] = previous[0];
+            for index in 1..=label.len() {
+                current[index] = previous[index] || current[index - 1];
+            }
+        } else {
+            for index in 1..=label.len() {
+                current[index] = previous[index - 1]
+                    && (*token == b'?' || token.eq_ignore_ascii_case(&label[index - 1]));
+            }
+        }
+        previous = current;
+    }
+    previous[label.len()]
+}
+
+#[test]
+fn navigation_is_https_and_first_party_or_supported_auth_only() {
+    for allowed in [
+        "https://grok.com/imagine/saved",
+        "https://accounts.x.ai/sign-in",
+        "https://x.com/i/oauth2/authorize",
+        "https://accounts.google.com/o/oauth2/v2/auth",
+        "https://appleid.apple.com/auth/authorize",
+    ] {
+        assert!(is_allowed_album_navigation(&Url::parse(allowed).unwrap()));
+    }
+    for denied in [
+        "http://grok.com/imagine/saved",
+        "https://grok.com.evil.example/imagine/saved",
+        "https://user@grok.com/imagine/saved",
+        "https://example.com/",
+    ] {
+        assert!(!is_allowed_album_navigation(&Url::parse(denied).unwrap()));
+    }
+}
+
+#[test]
+fn saved_page_requires_the_rendered_app_shell() {
+    let saved = Url::parse("https://grok.com/imagine/saved").unwrap();
+    assert_eq!(
+        classify_page(&saved, "complete", false, false, "waiting"),
+        GrokAlbumStatus::Loading
+    );
+    assert_eq!(
+        classify_page(&saved, "complete", true, false, "ready"),
+        GrokAlbumStatus::Ready
+    );
+    assert_eq!(
+        classify_page(&saved, "loading", false, false, "waiting"),
+        GrokAlbumStatus::Loading
+    );
+    assert_eq!(
+        classify_page(&saved, "complete", false, true, "waiting"),
+        GrokAlbumStatus::Verification
+    );
+    assert_eq!(
+        classify_page(&saved, "complete", false, false, "challenge"),
+        GrokAlbumStatus::Verification
+    );
+    assert_eq!(
+        classify_page(&saved, "complete", false, false, "redirecting"),
+        GrokAlbumStatus::SignIn
+    );
+}
+
+#[test]
+fn media_bridge_strips_unapproved_query_values_and_rejects_other_assets() {
+    let safe = sanitize_media_url(
+        "https://assets.grok.com/users/test/generated/fake/image.jpg?width=2048&cache=1&token=secret#x",
+    )
+    .unwrap();
+    assert!(safe.contains("width=2048"));
+    assert!(safe.contains("cache=1"));
+    assert!(!safe.contains("token"));
+    assert!(!safe.contains('#'));
+    assert!(sanitize_media_url("https://assets.grok.com/users/test/avatar.jpg").is_none());
+    assert!(sanitize_media_url("https://evil.example/generated/image.jpg").is_none());
+    let oversized = format!(
+        "https://assets.grok.com/users/test/generated/{}/image.jpg",
+        "x".repeat(MAX_MEDIA_URL_LENGTH)
+    );
+    assert!(sanitize_media_url(&oversized).is_none());
+}
+
+#[test]
+fn blob_video_uses_an_allowlisted_poster_anchor_without_serializing_bridge_state() {
+    let poster = "https://assets.grok.com/users/test/generated/video/poster.jpg";
+    let item = sanitize_raw_item(RawAlbumMedia {
+        media_url: poster.to_string(),
+        thumbnail_url: Some(poster.to_string()),
+        kind: "video".to_string(),
+        webview_only: true,
+        ..RawAlbumMedia::default()
+    })
+    .expect("blob-backed video anchor should pass validation");
+    assert!(item.webview_only);
+    let serialized = serde_json::to_string(&item).unwrap();
+    assert!(!serialized.contains("webviewOnly"));
+    assert!(!serialized.contains("blob:"));
+
+    assert!(sanitize_raw_item(RawAlbumMedia {
+        media_url: poster.to_string(),
+        thumbnail_url: Some(poster.to_string()),
+        kind: "image".to_string(),
+        webview_only: true,
+        ..RawAlbumMedia::default()
+    })
+    .is_none());
+}
+
+#[test]
+fn closed_window_forgets_in_memory_album_items() {
+    clear_cache();
+    assert_eq!(
+        merge_cache(vec![
+            GrokAlbumMedia {
+                media_url: "https://assets.grok.com/users/test/generated/fake/image.jpg?width=1024"
+                    .to_string(),
+                thumbnail_url: None,
+                kind: "image".to_string(),
+                width: None,
+                height: None,
+                created_at: None,
+                post_id: None,
+                webview_only: false,
+            },
+            GrokAlbumMedia {
+                media_url: "https://assets.grok.com/users/test/generated/fake/image.jpg?width=2048"
+                    .to_string(),
+                thumbnail_url: None,
+                kind: "image".to_string(),
+                width: None,
+                height: None,
+                created_at: None,
+                post_id: None,
+                webview_only: false,
+            },
+        ]),
+        1
+    );
+    let snapshot = closed_snapshot();
+    assert_eq!(snapshot.status, GrokAlbumStatus::Closed);
+    assert_eq!(snapshot.total, 0);
+    assert!(snapshot.items.is_empty());
+    assert!(cached_items().is_empty());
+}
+
+#[test]
+fn stale_page_revision_cannot_repopulate_the_album_cache() {
+    let mut cache = AlbumCache::default();
+    let stale_revision = cache.revision;
+    cache.revision = cache.revision.wrapping_add(1);
+    let item = GrokAlbumMedia {
+        media_url: "https://assets.grok.com/users/test/generated/fake/stale.jpg".to_string(),
+        thumbnail_url: None,
+        kind: "image".to_string(),
+        width: None,
+        height: None,
+        created_at: None,
+        post_id: None,
+        webview_only: false,
+    };
+
+    assert_eq!(
+        merge_cache_items_at_revision(&mut cache, vec![item], stale_revision),
+        None
+    );
+    assert!(cache.items.is_empty());
+}
+
+#[test]
+fn spa_page_epoch_and_disjoint_top_snapshot_replace_previous_account_media() {
+    fn item(name: &str) -> GrokAlbumMedia {
+        GrokAlbumMedia {
+            media_url: format!("https://assets.grok.com/users/test/generated/{name}/image.jpg"),
+            thumbnail_url: None,
+            kind: "image".to_string(),
+            width: None,
+            height: None,
+            created_at: None,
+            post_id: None,
+            webview_only: false,
+        }
+    }
+
+    let mut cache = AlbumCache::default();
+    let revision = cache.revision;
+    let (added, reset) =
+        reconcile_cache_items_at_revision(&mut cache, vec![item("account-a")], revision, 1, 0.0)
+            .unwrap();
+    assert_eq!(added, 1);
+    assert!(!reset);
+
+    let revision = cache.revision;
+    let (_, reset) =
+        reconcile_cache_items_at_revision(&mut cache, vec![item("account-b")], revision, 2, 0.0)
+            .unwrap();
+    assert!(reset);
+    assert_eq!(cache.items, vec![item("account-b")]);
+
+    let revision = cache.revision;
+    let (_, reset) =
+        reconcile_cache_items_at_revision(&mut cache, vec![item("account-c")], revision, 2, 0.0)
+            .unwrap();
+    assert!(reset, "a disjoint top-of-page gallery is a new dataset");
+    assert_eq!(cache.items, vec![item("account-c")]);
+}
+
+#[test]
+fn empty_ready_page_requires_two_snapshots_before_forgetting_cached_media() {
+    let item = GrokAlbumMedia {
+        media_url: "https://assets.grok.com/users/test/generated/account-a/image.jpg".to_string(),
+        thumbnail_url: None,
+        kind: "image".to_string(),
+        width: None,
+        height: None,
+        created_at: None,
+        post_id: None,
+        webview_only: false,
+    };
+    let mut cache = AlbumCache::default();
+    let revision = cache.revision;
+    reconcile_cache_items_at_revision(&mut cache, vec![item.clone()], revision, 1, 0.0).unwrap();
+
+    let revision = cache.revision;
+    let (_, reset) =
+        reconcile_cache_items_at_revision(&mut cache, Vec::new(), revision, 1, 0.0).unwrap();
+    assert!(!reset);
+    assert_eq!(cache.items, vec![item]);
+
+    let revision = cache.revision;
+    let (_, reset) =
+        reconcile_cache_items_at_revision(&mut cache, Vec::new(), revision, 1, 0.0).unwrap();
+    assert!(reset);
+    assert!(cache.items.is_empty());
+}
+
+#[test]
+fn thumbnail_cancel_tombstone_handles_ipc_reordering() {
+    let request_id = uuid::Uuid::new_v4().to_string();
+    assert_eq!(
+        cancel_album_requests(std::slice::from_ref(&request_id)).unwrap(),
+        0
+    );
+    let request = register_album_request(&request_id).unwrap();
+    assert!(request.cancellation.is_cancelled());
+}
+
+#[test]
+fn eval_snapshot_accepts_direct_and_nested_json() {
+    let direct = r#"{"readyState":"complete","hasSecurityChallenge":true,"items":[]}"#;
+    let decoded = decode_eval_snapshot(direct).unwrap();
+    assert_eq!(decoded.ready_state, "complete");
+    assert!(decoded.has_security_challenge);
+    let nested = serde_json::to_string(direct).unwrap();
+    assert_eq!(
+        decode_eval_snapshot(&nested).unwrap().ready_state,
+        "complete"
+    );
+}
+
+#[test]
+fn remote_album_window_has_no_capability_entry() {
+    let capabilities = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("capabilities");
+    for entry in std::fs::read_dir(capabilities).unwrap() {
+        let path = entry.unwrap().path();
+        if path.extension().and_then(|value| value.to_str()) != Some("json") {
+            continue;
+        }
+        let raw = std::fs::read_to_string(&path).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        for field in ["windows", "webviews"] {
+            let labels = value[field].as_array().cloned().unwrap_or_default();
+            assert!(
+                !labels
+                    .iter()
+                    .filter_map(|entry| entry.as_str())
+                    .any(|pattern| { capability_label_matches(pattern, WINDOW_LABEL) }),
+                "remote album window unexpectedly matches {field} in {}",
+                path.display()
+            );
+        }
+    }
+}

--- a/src-tauri/src/wallpaper_grok_album/thumbnail_poll.js
+++ b/src-tauri/src/wallpaper_grok_album/thumbnail_poll.js
@@ -1,0 +1,16 @@
+(function () {
+  try {
+    var key = __URL__;
+    var jobs = window.__GROK_APP_ALBUM_THUMB_JOBS__;
+    var job = jobs && jobs[key];
+    if (!job) return JSON.stringify({ state: "error" });
+    var result = JSON.stringify(job);
+    if (__REMOVE__) {
+      try { if (job.controller) job.controller.abort(); } catch (_) {}
+      delete jobs[key];
+    }
+    return result;
+  } catch (_) {
+    return JSON.stringify({ state: "error" });
+  }
+})()

--- a/src-tauri/src/wallpaper_grok_album/thumbnail_start.js
+++ b/src-tauri/src/wallpaper_grok_album/thumbnail_start.js
@@ -1,0 +1,173 @@
+(function () {
+  try {
+    var url = __URL__;
+    var key = url;
+    var jobs = window.__GROK_APP_ALBUM_THUMB_JOBS__ ||
+      (window.__GROK_APP_ALBUM_THUMB_JOBS__ = Object.create(null));
+    if (jobs[key] && jobs[key].state === "loading") {
+      return JSON.stringify({ state: "loading" });
+    }
+    var controller = typeof AbortController === "function" ? new AbortController() : null;
+    jobs[key] = { state: "loading", controller: controller };
+    var timer = window.setTimeout(function () {
+      try { if (controller) controller.abort(); } catch (_) {}
+    }, 12000);
+
+    function fail() {
+      window.clearTimeout(timer);
+      jobs[key] = { state: "error" };
+    }
+
+    function dimensionsAreSafe(width, height) {
+      return Number.isFinite(width) && Number.isFinite(height) &&
+        width > 0 && height > 0 &&
+        width <= __MAX_DIMENSION__ && height <= __MAX_DIMENSION__ &&
+        width * height <= __MAX_PIXELS__;
+    }
+
+    function dimensionsFromHeader(buffer) {
+      var bytes = new Uint8Array(buffer);
+      var length = bytes.length;
+      if (length >= 24 && bytes[0] === 0x89 && bytes[1] === 0x50 &&
+          bytes[2] === 0x4e && bytes[3] === 0x47 && bytes[4] === 0x0d &&
+          bytes[5] === 0x0a && bytes[6] === 0x1a && bytes[7] === 0x0a) {
+        var pngWidth = ((bytes[16] * 0x1000000) + (bytes[17] << 16) +
+          (bytes[18] << 8) + bytes[19]) >>> 0;
+        var pngHeight = ((bytes[20] * 0x1000000) + (bytes[21] << 16) +
+          (bytes[22] << 8) + bytes[23]) >>> 0;
+        return [pngWidth, pngHeight];
+      }
+      if (length >= 10 && bytes[0] === 0x47 && bytes[1] === 0x49 &&
+          bytes[2] === 0x46 && bytes[3] === 0x38 &&
+          (bytes[4] === 0x37 || bytes[4] === 0x39) && bytes[5] === 0x61) {
+        return [bytes[6] | (bytes[7] << 8), bytes[8] | (bytes[9] << 8)];
+      }
+      if (length < 4 || bytes[0] !== 0xff || bytes[1] !== 0xd8) return null;
+      var cursor = 2;
+      while (cursor + 3 < length) {
+        while (cursor < length && bytes[cursor] !== 0xff) cursor += 1;
+        while (cursor < length && bytes[cursor] === 0xff) cursor += 1;
+        if (cursor >= length) return null;
+        var marker = bytes[cursor++];
+        if (marker === 0xd8 || marker === 0xd9 ||
+            (marker >= 0xd0 && marker <= 0xd7)) continue;
+        if (cursor + 1 >= length) return null;
+        var segmentLength = (bytes[cursor] << 8) | bytes[cursor + 1];
+        if (segmentLength < 2 || cursor + segmentLength > length) return null;
+        var isStartOfFrame = marker === 0xc0 || marker === 0xc1 ||
+          marker === 0xc2 || marker === 0xc3 || marker === 0xc5 ||
+          marker === 0xc6 || marker === 0xc7 || marker === 0xc9 ||
+          marker === 0xca || marker === 0xcb || marker === 0xcd ||
+          marker === 0xce || marker === 0xcf;
+        if (isStartOfFrame && segmentLength >= 7) {
+          return [
+            (bytes[cursor + 5] << 8) | bytes[cursor + 6],
+            (bytes[cursor + 3] << 8) | bytes[cursor + 4]
+          ];
+        }
+        cursor += segmentLength;
+      }
+      return null;
+    }
+
+    function encode(source, width, height) {
+      try {
+        if (!dimensionsAreSafe(width, height)) return fail();
+        var scale = Math.min(1, 480 / Math.max(width, height));
+        var outWidth = Math.max(1, Math.round(width * scale));
+        var outHeight = Math.max(1, Math.round(height * scale));
+        var canvas = document.createElement("canvas");
+        canvas.width = outWidth;
+        canvas.height = outHeight;
+        var context = canvas.getContext("2d", { alpha: false });
+        if (!context) return fail();
+        context.drawImage(source, 0, 0, outWidth, outHeight);
+        var dataUrl = canvas.toDataURL("image/jpeg", 0.78);
+        window.clearTimeout(timer);
+        if (!dataUrl || dataUrl.indexOf("data:image/jpeg;base64,") !== 0 ||
+            dataUrl.length > __MAX_DATA_URL__) return fail();
+        jobs[key] = {
+          state: "ready",
+          dataUrl: dataUrl,
+          width: width,
+          height: height
+        };
+      } catch (_) {
+        fail();
+      }
+    }
+
+    fetch(url, {
+      credentials: "include",
+      mode: "cors",
+      cache: "force-cache",
+      redirect: "follow",
+      signal: controller ? controller.signal : undefined
+    })
+      .then(function (response) {
+        if (!response.ok) throw new Error("status");
+        var finalUrl = new URL(response.url || url, location.href);
+        if (finalUrl.protocol !== "https:" || finalUrl.hostname !== "assets.grok.com" ||
+            (finalUrl.port && finalUrl.port !== "443") || finalUrl.username ||
+            finalUrl.password || finalUrl.pathname.indexOf("/generated/") < 0) {
+          throw new Error("redirect");
+        }
+        var type = String(response.headers.get("content-type") || "").toLowerCase();
+        var length = Number(response.headers.get("content-length") || 0);
+        if (type.indexOf("image/") !== 0 || length > __MAX_SOURCE_BYTES__) {
+          throw new Error("type");
+        }
+        return response.blob();
+      })
+      .then(function (blob) {
+        if (!blob || !blob.size || blob.size > __MAX_SOURCE_BYTES__) {
+          throw new Error("size");
+        }
+        return blob.slice(0, __MAX_HEADER_BYTES__).arrayBuffer().then(function (buffer) {
+          var dimensions = dimensionsFromHeader(buffer);
+          if (!dimensions || !dimensionsAreSafe(dimensions[0], dimensions[1])) {
+            throw new Error("dimensions");
+          }
+          return { blob: blob, width: dimensions[0], height: dimensions[1] };
+        });
+      })
+      .then(function (payload) {
+        if (typeof createImageBitmap === "function") {
+          return createImageBitmap(payload.blob).then(function (bitmap) {
+            if (bitmap.width !== payload.width || bitmap.height !== payload.height) {
+              try { bitmap.close(); } catch (_) {}
+              throw new Error("dimensions");
+            }
+            encode(bitmap, bitmap.width, bitmap.height);
+            try { bitmap.close(); } catch (_) {}
+          });
+        }
+        return new Promise(function (resolve, reject) {
+          var objectUrl = URL.createObjectURL(payload.blob);
+          var image = new Image();
+          image.onload = function () {
+            try {
+              if (image.naturalWidth !== payload.width ||
+                  image.naturalHeight !== payload.height) {
+                reject(new Error("dimensions"));
+                return;
+              }
+              encode(image, image.naturalWidth, image.naturalHeight);
+              resolve();
+            } finally {
+              URL.revokeObjectURL(objectUrl);
+            }
+          };
+          image.onerror = function () {
+            URL.revokeObjectURL(objectUrl);
+            reject(new Error("decode"));
+          };
+          image.src = objectUrl;
+        });
+      })
+      .catch(fail);
+    return JSON.stringify({ state: "loading" });
+  } catch (_) {
+    return JSON.stringify({ state: "error" });
+  }
+})()

--- a/src-tauri/src/wallpaper_source.rs
+++ b/src-tauri/src/wallpaper_source.rs
@@ -1,5 +1,5 @@
 //! Wallpaper source: X search + Imagine generate via headless Grok CLI,
-//! plus allowlisted media download into the app wallpaper library.
+//! plus allowlisted X / Imagine / Grok-album media download into the library.
 
 #![allow(dead_code)] // residual-clippy: kind_from_mime
 use std::fs;
@@ -2360,6 +2360,25 @@ pub async fn fetch_media(url: &str, source: Option<&str>) -> Result<WallpaperFet
     if Path::new(&normalized).is_file() {
         return file_to_fetch_result(Path::new(&normalized));
     }
+
+    let (content_type, bytes) = fetch_remote_media_bytes(&normalized, source).await?;
+    save_fetched_media_bytes(&normalized, source, &content_type, bytes)
+}
+
+/// Fetch a validated remote wallpaper without writing it to disk.
+///
+/// Grok album downloads race this credential-free Host request against the
+/// isolated signed-in WebView, then pass only the winning byte stream through
+/// the common signature check and save path. Keeping the write outside the
+/// race prevents duplicate files when both routes finish together.
+pub(crate) async fn fetch_remote_media_bytes(
+    url: &str,
+    source: Option<&str>,
+) -> Result<(String, Vec<u8>), String> {
+    let normalized = normalize_media_url(url);
+    if normalized.is_empty() || Path::new(&normalized).is_file() {
+        return Err("url_blocked".into());
+    }
     if !is_allowed_media_url(&normalized) {
         return Err("url_blocked".into());
     }
@@ -2375,9 +2394,17 @@ pub async fn fetch_media(url: &str, source: Option<&str>) -> Result<WallpaperFet
     .build()
     .map_err(|e| format!("http client: {e}"))?;
 
-    let mut resp = client
+    let mut request = client
         .get(&normalized)
-        .header("Accept", "image/avif,image/webp,image/*,video/*,*/*;q=0.8")
+        .header("Accept", "image/avif,image/webp,image/*,video/*,*/*;q=0.8");
+    if normalized_download_source(source) == "grok_album" {
+        request = request
+            .header(reqwest::header::REFERER, "https://grok.com/imagine/saved")
+            .header("sec-fetch-dest", "image")
+            .header("sec-fetch-mode", "no-cors")
+            .header("sec-fetch-site", "same-site");
+    }
+    let mut resp = request
         .send()
         .await
         .map_err(|_| "download_failed: network".to_string())?;
@@ -2402,15 +2429,22 @@ pub async fn fetch_media(url: &str, source: Option<&str>) -> Result<WallpaperFet
     if bytes.len() < 64 {
         return Err("download_failed: too small".into());
     }
-    let media = detect_media_signature(&bytes)
-        .filter(|media| content_type_matches_signature(&content_type, *media))
-        .ok_or_else(|| "download_failed: invalid media signature".to_string())?;
+    Ok((content_type, bytes))
+}
 
-    let src = match source {
-        Some("imagine") => "imagine",
-        _ => "x",
-    };
-    let ext = media.extension();
+pub(crate) fn save_fetched_media_bytes(
+    url: &str,
+    source: Option<&str>,
+    content_type: &str,
+    bytes: Vec<u8>,
+) -> Result<WallpaperFetchResult, String> {
+    let normalized = normalize_media_url(url);
+    if normalized.is_empty() || !is_allowed_media_url(&normalized) {
+        return Err("url_blocked".into());
+    }
+    let (mime, ext) = validate_fetched_media_bytes(content_type, &bytes)?;
+
+    let src = normalized_download_source(source);
     let name = format!(
         "{}-{}.{}",
         chrono::Local::now().format("%H%M%S"),
@@ -2424,10 +2458,21 @@ pub async fn fetch_media(url: &str, source: Option<&str>) -> Result<WallpaperFet
 
     Ok(WallpaperFetchResult {
         path: path.display().to_string(),
-        mime: media.mime().to_string(),
+        mime: mime.to_string(),
         bytes: bytes.len() as u64,
         name,
     })
+}
+
+fn normalized_download_source(source: Option<&str>) -> &'static str {
+    match source {
+        Some("imagine") => "imagine",
+        Some("grok_album") => "grok_album",
+        Some("openverse") => "openverse",
+        Some("pexels") => "pexels",
+        Some("web") => "web",
+        _ => "x",
+    }
 }
 
 pub(crate) fn validate_fetched_media_bytes(
@@ -2824,11 +2869,24 @@ pub fn ensure_wallpaper_dirs() {
     let root = wallpapers_root();
     let _ = fs::create_dir_all(root.join("x"));
     let _ = fs::create_dir_all(root.join("imagine"));
+    let _ = fs::create_dir_all(root.join("grok_album"));
+    let _ = fs::create_dir_all(root.join("grok_album").join("originals"));
     let _ = fs::create_dir_all(root.join("library"));
 }
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn download_source_keeps_grok_album_separate() {
+        assert_eq!(normalized_download_source(Some("grok_album")), "grok_album");
+        assert_eq!(normalized_download_source(Some("imagine")), "imagine");
+        assert_eq!(normalized_download_source(Some("openverse")), "openverse");
+        assert_eq!(normalized_download_source(Some("pexels")), "pexels");
+        assert_eq!(normalized_download_source(Some("web")), "web");
+        assert_eq!(normalized_download_source(Some("unknown")), "x");
+        assert_eq!(normalized_download_source(None), "x");
+    }
+
     #[tokio::test]
     async fn cancellation_wakes_waiters_and_prevents_cli_start() {
         let cancellation = WallpaperSearchCancellation::default();


### PR DESCRIPTION
## Summary

- 建立独立持久的 `https://grok.com/imagine/saved` WebView，窗口不授予任何 Tauri capability
- 限制顶层导航、拒绝新窗口和下载，只允许 Host 执行固定打包脚本并返回有界媒体 DTO
- 为 Windows/Linux 手动 HTTP/SOCKS5 代理显式固定 WebView 路由，不支持的路由失败关闭；代理变更时销毁旧窗口
- 缩略图和选中原图并发竞速登录 WebView与无凭据 Host 路径，共用 URL、重定向、大小、MIME、真实签名校验及唯一落盘
- 增加页面身份、缓存失效、固定脚本、请求取消、媒体竞速/损坏恢复和代理安全边界测试

## Review boundary

依赖 #1088–#1099；其中直接依赖 #1099。本 PR 在堆叠分支上的独立增量只有提交 `be6f5a31`，可按 `228852eb..be6f5a31` 审阅。

这一层只注册 Host/桥接命令，不在来源选择器中显示 Grok Saved；页面入口、15 locale 和交互测试放在下一批。它不导出 Cookie、Token、storage、headers 或原始响应，不复用 Build OAuth，也不调用未公开 Grok consumer REST API。

未发现精确对应 Grok Saved 壁纸来源的既有 Issue。

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Documentation
- [ ] Refactor / chore

## Checklist

- [x] `pnpm typecheck`
- [x] `pnpm test`（599 files / 7115 tests）
- [x] `pnpm lint`
- [x] `python scripts/check-code-quality-gates.py --mode final`
- [x] `python scripts/publish-website-downloads.py --self-test`
- [x] `pnpm build:ui`
- [x] `pnpm deps:check`
- [x] `pnpm audit:prod`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] Windows manifest harness（1796 passed / 1 ignored；Saved 专项 19，WebView 代理专项 3）
- [x] No `window.confirm` / `prompt` / `alert`
- [x] `docs/llm-wiki/wallpaper-search.md` and delivery plan updated
- [x] No secrets, tokens, cookies, `auth.json`, or local agent homes included
