### PR TITLE
feat(wallpaper): 增加本地媒体目录与稳定分页

### DIFF
--- a/docs/llm-wiki/wallpaper-search.md
+++ b/docs/llm-wiki/wallpaper-search.md
@@ -255,3 +255,29 @@ more” appends deduplicated results while leaving current cards selectable.
 Paging failures preserve the gallery and continuation for retry. The separate
 prefetch follow-up described above adds one-page-ahead loading without changing
 this page's visible controls.
+
+## Local library catalog Host contract
+
+The local wallpaper library keeps its media files in the existing wallpaper
+root and stores only bounded metadata in an atomic `.catalog.json`. Records have
+a stable media ID, source and purpose, favorite state, known dimensions, optional
+prompt/generation lineage, and sanitized HTTPS attribution fields. Remote media
+identity is stored as a source-scoped SHA-256 key; raw media URLs, credentials,
+headers and private album responses are not written to the catalog.
+
+`wallpaper_library_page` filters the complete scanned library by query, media
+kind and purpose before paging. A page contains at most 96 items (48 by default)
+and uses a query- and page-size-bound snapshot cursor. At most eight snapshots
+live for 30 minutes. Images sort before videos, then by descending modification
+time and path. New files appear on a new snapshot; files deleted during paging
+are skipped without shifting the remaining snapshot order. Hidden entries,
+symbolic links and paths outside the wallpaper root are never traversed.
+
+`wallpaper_library_remember` accepts only an existing, signature-validated media
+file inside the wallpaper root. It bounds text metadata, strips query strings and
+fragments from public attribution URLs, and can change favorite state without
+deleting the file. `wallpaper_library_lookup` accepts at most 96 source/media URL
+pairs and returns only unchanged local files; replacements at the same path get a
+new identity and cannot inherit an old remote-origin association. Lookup by media
+ID applies the same containment, signature and replacement checks. The legacy
+list and delete commands remain registered for existing clients.

--- a/src-tauri/src/commands/misc_p1.rs
+++ b/src-tauri/src/commands/misc_p1.rs
@@ -1175,11 +1175,59 @@ pub async fn wallpaper_library_list(
 }
 
 #[tauri::command]
+pub async fn wallpaper_library_page(
+    query: crate::wallpaper_library::LibraryQuery,
+    cursor: Option<String>,
+    limit: Option<u32>,
+) -> Result<crate::wallpaper_library::LibraryPage, String> {
+    crate::wallpaper_source::ensure_wallpaper_dirs();
+    tauri::async_runtime::spawn_blocking(move || {
+        crate::wallpaper_library::list(query, cursor.as_deref(), limit)
+    })
+    .await
+    .map_err(|e| format!("wallpaper_library_page: {e}"))?
+}
+
+#[tauri::command]
+pub async fn wallpaper_library_remember(
+    path: String,
+    metadata: crate::wallpaper_catalog::SourceMetadata,
+    favorite: Option<bool>,
+) -> Result<crate::wallpaper_catalog::MediaRecord, String> {
+    crate::wallpaper_source::ensure_wallpaper_dirs();
+    tauri::async_runtime::spawn_blocking(move || {
+        crate::wallpaper_catalog::remember(&path, metadata, favorite)
+    })
+    .await
+    .map_err(|e| format!("wallpaper_library_remember: {e}"))?
+}
+
+#[tauri::command]
 pub async fn wallpaper_library_delete(path: String) -> Result<(), String> {
     crate::wallpaper_source::ensure_wallpaper_dirs();
     tauri::async_runtime::spawn_blocking(move || crate::wallpaper_source::library_delete(&path))
         .await
         .map_err(|e| format!("wallpaper_library_delete: {e}"))?
+}
+
+#[tauri::command]
+pub async fn wallpaper_library_lookup(
+    requests: Vec<crate::wallpaper_catalog::MediaLookup>,
+) -> Result<Vec<crate::wallpaper_catalog::MediaMatch>, String> {
+    crate::wallpaper_source::ensure_wallpaper_dirs();
+    tauri::async_runtime::spawn_blocking(move || crate::wallpaper_catalog::lookup(&requests))
+        .await
+        .map_err(|e| format!("wallpaper_library_lookup: {e}"))?
+}
+
+#[tauri::command]
+pub async fn wallpaper_library_find_by_id(
+    id: String,
+) -> Result<Option<crate::wallpaper_source::WallpaperLibraryEntry>, String> {
+    crate::wallpaper_source::ensure_wallpaper_dirs();
+    tauri::async_runtime::spawn_blocking(move || crate::wallpaper_catalog::find_by_id(&id))
+        .await
+        .map_err(|e| format!("wallpaper_library_find_by_id: {e}"))?
 }
 
 /// Headless probe: `grok -p … --output-format streaming-messages-json` (CLI 0.2.117+).

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -224,7 +224,9 @@ mod voice_stt;
 
 mod voice_tools;
 
+mod wallpaper_catalog;
 mod wallpaper_grok_album;
+mod wallpaper_library;
 mod wallpaper_provider_search;
 mod wallpaper_remote_commands;
 mod wallpaper_remote_media;
@@ -1723,6 +1725,14 @@ pub fn run() {
             commands::wallpaper_imagine,
 
             commands::wallpaper_library_list,
+
+            commands::wallpaper_library_page,
+
+            commands::wallpaper_library_remember,
+
+            commands::wallpaper_library_lookup,
+
+            commands::wallpaper_library_find_by_id,
 
             commands::wallpaper_library_delete,
 

--- a/src-tauri/src/wallpaper_catalog.rs
+++ b/src-tauri/src/wallpaper_catalog.rs
@@ -1,0 +1,701 @@
+//! Persistent media provenance and user intent, separate from scan snapshots.
+
+use crate::{
+    store_lock,
+    wallpaper_source::{self, WallpaperLibraryEntry},
+};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::{collections::BTreeMap, fs, path::Path};
+
+const MAX_CATALOG_BYTES: u64 = 64 * 1024 * 1024;
+const MAX_RECORDS: usize = 100_000;
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct GenerationParameters {
+    pub operation: String,
+    pub aspect_ratio: Option<String>,
+    pub resolution: Option<String>,
+    pub duration: Option<u32>,
+    pub requested_model: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct MediaRecord {
+    pub id: String,
+    pub source: String,
+    pub source_url: Option<String>,
+    pub source_name: Option<String>,
+    pub author_name: Option<String>,
+    pub author_url: Option<String>,
+    pub license: Option<String>,
+    pub license_url: Option<String>,
+    pub title: Option<String>,
+    pub width: Option<u32>,
+    pub height: Option<u32>,
+    pub prompt: Option<String>,
+    pub generation: Option<GenerationParameters>,
+    pub parent_id: Option<String>,
+    pub favorite: bool,
+    pub purpose: String,
+    pub bytes: u64,
+    pub modified_ms: u64,
+}
+
+#[derive(Default, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct SourceMetadata {
+    pub source: Option<String>,
+    pub media_url: Option<String>,
+    pub source_url: Option<String>,
+    pub source_name: Option<String>,
+    pub author_name: Option<String>,
+    pub author_url: Option<String>,
+    pub license: Option<String>,
+    pub license_url: Option<String>,
+    pub title: Option<String>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct Catalog {
+    version: u32,
+    records: BTreeMap<String, MediaRecord>,
+    #[serde(default)]
+    origins: BTreeMap<String, String>,
+}
+
+impl Catalog {
+    fn insert(&mut self, relative: String, record: MediaRecord) {
+        if self
+            .records
+            .get(&relative)
+            .is_some_and(|old| old.id != record.id)
+        {
+            self.origins.retain(|_, path| path != &relative);
+        }
+        self.records.insert(relative, record);
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct MediaLookup {
+    pub source: String,
+    pub media_url: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct MediaMatch {
+    pub index: usize,
+    pub path: String,
+    pub metadata: MediaRecord,
+}
+
+fn origin_key(source: &str, raw: &str) -> Option<String> {
+    if !matches!(
+        source,
+        "x" | "web" | "openverse" | "pexels" | "grok_album" | "imagine"
+    ) || raw.len() > 16_384
+    {
+        return None;
+    }
+    let mut url = url::Url::parse(raw).ok()?;
+    if url.scheme() != "https"
+        || url.host_str().is_none()
+        || !url.username().is_empty()
+        || url.password().is_some()
+    {
+        return None;
+    }
+    url.set_fragment(None);
+    Some(hex::encode(Sha256::digest(
+        format!("{source}\n{url}").as_bytes(),
+    )))
+}
+
+fn key(root: &Path, path: &Path) -> Result<String, String> {
+    let root = root.canonicalize().map_err(|_| "path_not_allowed")?;
+    let canonical = path.canonicalize().map_err(|_| "path_not_allowed")?;
+    let relative = canonical
+        .strip_prefix(root)
+        .map_err(|_| "path_not_allowed")?;
+    if relative
+        .components()
+        .any(|p| p.as_os_str().to_string_lossy().starts_with('.'))
+    {
+        return Err("path_not_allowed".into());
+    }
+    let relative = relative.to_string_lossy().replace('\\', "/");
+    Ok(if cfg!(windows) {
+        relative.to_lowercase()
+    } else {
+        relative
+    })
+}
+
+fn stable_id(key: &str) -> String {
+    format!("media-{}", hex::encode(Sha256::digest(key.as_bytes())))
+}
+
+fn read(path: &Path) -> Result<Catalog, String> {
+    match fs::metadata(path) {
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(Catalog {
+                version: 1,
+                records: BTreeMap::new(),
+                origins: BTreeMap::new(),
+            })
+        }
+        Err(_) => return Err("catalog_read_failed".into()),
+        Ok(meta) if meta.len() > MAX_CATALOG_BYTES => return Err("catalog_too_large".into()),
+        Ok(_) => {}
+    }
+    let data = fs::read(path).map_err(|_| "catalog_read_failed")?;
+    let catalog: Catalog = serde_json::from_slice(&data).map_err(|_| "catalog_invalid")?;
+    if catalog.version != 1
+        || catalog.records.len() > MAX_RECORDS
+        || catalog.origins.len() > MAX_RECORDS
+    {
+        return Err("catalog_invalid".into());
+    }
+    Ok(catalog)
+}
+
+fn transaction<T>(
+    root: &Path,
+    body: impl FnOnce(&mut Catalog) -> Result<T, String>,
+) -> Result<T, String> {
+    let path = root.join(".catalog.json");
+    store_lock::with_exclusive_lock(&path, || {
+        let mut catalog = read(&path)?;
+        let previous = catalog.records.clone();
+        let previous_origins = catalog.origins.clone();
+        let result = body(&mut catalog)?;
+        if catalog.records != previous || catalog.origins != previous_origins {
+            if catalog.records.len() > MAX_RECORDS || catalog.origins.len() > MAX_RECORDS {
+                return Err("catalog_too_large".into());
+            }
+            let bytes = serde_json::to_vec(&catalog).map_err(|_| "catalog_write_failed")?;
+            if bytes.len() as u64 > MAX_CATALOG_BYTES {
+                return Err("catalog_too_large".into());
+            }
+            store_lock::write_bytes_replace(&path, &bytes).map_err(|_| "catalog_write_failed")?;
+        }
+        Ok(result)
+    })
+}
+
+fn record_for(
+    root: &Path,
+    path: &Path,
+    previous: Option<&MediaRecord>,
+) -> Result<MediaRecord, String> {
+    let relative = key(root, path)?;
+    let stat = fs::metadata(path).map_err(|_| "catalog_read_failed")?;
+    if !stat.is_file() {
+        return Err("path_not_allowed".into());
+    }
+    let modified_ms = stat
+        .modified()
+        .ok()
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0);
+    if let Some(saved) = previous.filter(|r| r.bytes == stat.len() && r.modified_ms == modified_ms)
+    {
+        return Ok(saved.clone());
+    }
+    let dimensions = image::ImageReader::open(path)
+        .ok()
+        .and_then(|r| r.with_guessed_format().ok())
+        .and_then(|r| r.into_dimensions().ok());
+    let source = relative
+        .split('/')
+        .next()
+        .filter(|s| {
+            matches!(
+                *s,
+                "x" | "web" | "openverse" | "pexels" | "grok_album" | "imagine"
+            )
+        })
+        .unwrap_or("library")
+        .to_string();
+    Ok(MediaRecord {
+        // A replacement is a new work, even if it reuses a known filename.
+        // Keep legacy IDs for unchanged files; never revive an old parent or
+        // remote-origin association after a scan accepts the replacement.
+        id: if previous.is_some() {
+            stable_id(&format!("{relative}:{}", uuid::Uuid::new_v4()))
+        } else {
+            stable_id(&relative)
+        },
+        purpose: if source == "imagine" {
+            "generated"
+        } else {
+            "cache"
+        }
+        .into(),
+        source,
+        source_url: None,
+        source_name: None,
+        author_name: None,
+        author_url: None,
+        license: None,
+        license_url: None,
+        title: None,
+        width: dimensions.map(|d| d.0),
+        height: dimensions.map(|d| d.1),
+        prompt: None,
+        generation: None,
+        parent_id: None,
+        favorite: false,
+        bytes: stat.len(),
+        modified_ms,
+    })
+}
+
+fn public_url(value: Option<String>) -> Option<String> {
+    let mut url = url::Url::parse(value.as_deref()?).ok()?;
+    if url.scheme() != "https"
+        || url.host_str().is_none()
+        || !url.username().is_empty()
+        || url.password().is_some()
+    {
+        return None;
+    }
+    url.set_query(None);
+    url.set_fragment(None);
+    (url.as_str().len() <= 2_048).then(|| url.to_string())
+}
+
+fn bounded(value: Option<String>, limit: usize) -> Option<String> {
+    value
+        .map(|s| {
+            s.chars()
+                .filter(|c| !c.is_control())
+                .take(limit)
+                .collect::<String>()
+        })
+        .filter(|s| !s.trim().is_empty())
+}
+
+pub(crate) fn hydrate(root: &Path, rows: &mut [WallpaperLibraryEntry]) -> Result<(), String> {
+    transaction(root, |catalog| {
+        for row in rows {
+            let path = Path::new(&row.path);
+            // Files may disappear between directory enumeration and this transaction.
+            if !path.is_file() {
+                continue;
+            }
+            let relative = key(root, path)?;
+            let record = record_for(root, path, catalog.records.get(&relative))?;
+            row.metadata = Some(record.clone());
+            catalog.insert(relative, record);
+        }
+        Ok(())
+    })
+}
+
+pub(crate) fn remember(
+    path: &str,
+    metadata: SourceMetadata,
+    favorite: Option<bool>,
+) -> Result<MediaRecord, String> {
+    remember_at(
+        &wallpaper_source::wallpapers_root(),
+        Path::new(path),
+        metadata,
+        favorite,
+    )
+}
+
+fn remember_at(
+    root: &Path,
+    path: &Path,
+    metadata: SourceMetadata,
+    favorite: Option<bool>,
+) -> Result<MediaRecord, String> {
+    let relative = key(root, path)?;
+    let kind = if path
+        .extension()
+        .and_then(|s| s.to_str())
+        .is_some_and(|ext| matches!(ext.to_lowercase().as_str(), "mp4" | "webm"))
+    {
+        wallpaper_source::LocalWallpaperMediaKind::Video
+    } else {
+        wallpaper_source::LocalWallpaperMediaKind::Image
+    };
+    wallpaper_source::validate_local_wallpaper_media(path, kind)?;
+    let origin = metadata
+        .source
+        .as_deref()
+        .zip(metadata.media_url.as_deref())
+        .and_then(|(source, url)| origin_key(source, url));
+    transaction(root, |catalog| {
+        let mut record = record_for(root, path, catalog.records.get(&relative))?;
+        if let Some(source) = metadata.source.filter(|s| {
+            matches!(
+                s.as_str(),
+                "x" | "web" | "openverse" | "pexels" | "grok_album"
+            )
+        }) {
+            record.source = source;
+        }
+        if let Some(value) = public_url(metadata.source_url) {
+            record.source_url = Some(value);
+        }
+        if let Some(value) = bounded(metadata.source_name, 200) {
+            record.source_name = Some(value);
+        }
+        if let Some(value) = bounded(metadata.author_name, 200) {
+            record.author_name = Some(value);
+        }
+        if let Some(value) = public_url(metadata.author_url) {
+            record.author_url = Some(value);
+        }
+        if let Some(value) = bounded(metadata.license, 200) {
+            record.license = Some(value);
+        }
+        if let Some(value) = public_url(metadata.license_url) {
+            record.license_url = Some(value);
+        }
+        if let Some(value) = bounded(metadata.title, 500) {
+            record.title = Some(value);
+        }
+        if let Some(favorite) = favorite {
+            record.favorite = favorite;
+        }
+        catalog.insert(relative.clone(), record.clone());
+        if let Some(origin) = origin {
+            catalog.origins.insert(origin, relative.clone());
+        }
+        Ok(record)
+    })
+}
+
+pub(crate) fn lookup(requests: &[MediaLookup]) -> Result<Vec<MediaMatch>, String> {
+    lookup_at(&wallpaper_source::wallpapers_root(), requests)
+}
+
+fn lookup_at(root: &Path, requests: &[MediaLookup]) -> Result<Vec<MediaMatch>, String> {
+    if requests.len() > 96 {
+        return Err("catalog_lookup_limit".into());
+    }
+    store_lock::with_exclusive_lock(&root.join(".catalog.json"), || {
+        let catalog = read(&root.join(".catalog.json"))?;
+        let mut matches = Vec::new();
+        for (index, request) in requests.iter().enumerate() {
+            let Some(origin) = origin_key(&request.source, &request.media_url) else {
+                continue;
+            };
+            let Some(relative) = catalog.origins.get(&origin) else {
+                continue;
+            };
+            let Some(record) = catalog.records.get(relative) else {
+                continue;
+            };
+            let path = root.join(relative);
+            if !path.is_file() || key(root, &path).as_ref() != Ok(relative) {
+                continue;
+            }
+            let current = record_for(root, &path, Some(record))?;
+            // A replacement file at the same path is no longer this remote media.
+            if current != *record {
+                continue;
+            }
+            crate::path_scope::grant_path(&path);
+            matches.push(MediaMatch {
+                index,
+                path: crate::process_util::strip_extended_path_prefix(&path.to_string_lossy()),
+                metadata: current,
+            });
+        }
+        Ok(matches)
+    })
+}
+
+pub(crate) fn find_by_id(id: &str) -> Result<Option<WallpaperLibraryEntry>, String> {
+    find_by_id_at(&wallpaper_source::wallpapers_root(), id)
+}
+
+fn find_by_id_at(root: &Path, id: &str) -> Result<Option<WallpaperLibraryEntry>, String> {
+    if id.len() != 70
+        || !id.starts_with("media-")
+        || !id[6..].bytes().all(|c| c.is_ascii_hexdigit())
+    {
+        return Err("catalog_invalid_id".into());
+    }
+    store_lock::with_exclusive_lock(&root.join(".catalog.json"), || {
+        let catalog = read(&root.join(".catalog.json"))?;
+        let Some((relative, record)) = catalog.records.iter().find(|(_, record)| record.id == id)
+        else {
+            return Ok(None);
+        };
+        let path = root.join(relative);
+        if !path.is_file() || key(root, &path).as_ref() != Ok(relative) {
+            return Ok(None);
+        }
+        if record_for(root, &path, Some(record))? != *record {
+            return Ok(None);
+        }
+        let video = path
+            .extension()
+            .and_then(|s| s.to_str())
+            .is_some_and(|ext| matches!(ext.to_lowercase().as_str(), "mp4" | "webm"));
+        wallpaper_source::validate_local_wallpaper_media(
+            &path,
+            if video {
+                wallpaper_source::LocalWallpaperMediaKind::Video
+            } else {
+                wallpaper_source::LocalWallpaperMediaKind::Image
+            },
+        )?;
+        crate::path_scope::grant_path(&path);
+        Ok(Some(WallpaperLibraryEntry {
+            path: crate::process_util::strip_extended_path_prefix(&path.to_string_lossy()),
+            name: path
+                .file_name()
+                .unwrap_or_default()
+                .to_string_lossy()
+                .into_owned(),
+            source: record.source.clone(),
+            kind: if video { "video" } else { "image" }.into(),
+            bytes: record.bytes,
+            modified_ms: record.modified_ms,
+            metadata: Some(record.clone()),
+        }))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    fn fixture() -> (PathBuf, PathBuf) {
+        let root =
+            std::env::temp_dir().join(format!("grok-wallpaper-catalog-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(&root).unwrap();
+        let path = root.join("original.png");
+        image::RgbImage::new(24, 12).save(&path).unwrap();
+        (root, path)
+    }
+
+    #[test]
+    fn favorite_and_provenance_survive_reread() {
+        let (root, path) = fixture();
+        let media_url = "https://cdn.example.org/photo.jpg?size=large";
+        let saved = remember_at(
+            &root,
+            &path,
+            SourceMetadata {
+                source: Some("openverse".into()),
+                media_url: Some(media_url.into()),
+                source_url: Some("https://example.org/photo?token=secret#fragment".into()),
+                ..Default::default()
+            },
+            Some(true),
+        )
+        .unwrap();
+        assert!(saved.favorite);
+        assert_eq!(saved.width, Some(24));
+        assert_eq!(saved.height, Some(12));
+        assert_eq!(
+            saved.source_url.as_deref(),
+            Some("https://example.org/photo")
+        );
+        let restored = remember_at(&root, &path, SourceMetadata::default(), Some(false)).unwrap();
+        assert!(!restored.favorite);
+        assert_eq!(saved.id, restored.id);
+        assert_eq!(saved.source, restored.source);
+        let matches = lookup_at(
+            &root,
+            &[MediaLookup {
+                source: "openverse".into(),
+                media_url: format!("{media_url}#preview"),
+            }],
+        )
+        .unwrap();
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].metadata.id, saved.id);
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn author_metadata_is_bounded_sanitized_and_legacy_compatible() {
+        let (root, path) = fixture();
+        let saved = remember_at(
+            &root,
+            &path,
+            SourceMetadata {
+                source_name: Some("Openverse".into()),
+                author_name: Some(format!("A\n{}", "名".repeat(220))),
+                author_url: Some("https://example.org/author?token=private#fragment".into()),
+                ..Default::default()
+            },
+            None,
+        )
+        .unwrap();
+        let restored = remember_at(&root, &path, SourceMetadata::default(), None).unwrap();
+        assert_eq!(saved, restored);
+        assert_eq!(restored.author_name.unwrap().chars().count(), 200);
+        assert_eq!(
+            restored.author_url.as_deref(),
+            Some("https://example.org/author")
+        );
+        let mut legacy = serde_json::to_value(saved).unwrap();
+        for field in ["sourceName", "authorName", "authorUrl"] {
+            legacy.as_object_mut().unwrap().remove(field);
+        }
+        let legacy: MediaRecord = serde_json::from_value(legacy).unwrap();
+        assert!(
+            legacy.source_name.is_none()
+                && legacy.author_name.is_none()
+                && legacy.author_url.is_none()
+        );
+        assert_eq!(legacy.width, Some(24));
+        assert!(public_url(Some("https://user:pass@example.org/author".into())).is_none());
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn parent_lookup_rejects_replaced_missing_and_outside_records() {
+        let (root, path) = fixture();
+        let saved = remember_at(&root, &path, SourceMetadata::default(), None).unwrap();
+        assert!(find_by_id_at(&root, &saved.id).unwrap().is_some());
+        assert!(find_by_id_at(&root, "../private").is_err());
+        image::RgbImage::new(60, 30).save(&path).unwrap();
+        assert!(find_by_id_at(&root, &saved.id).unwrap().is_none());
+        fs::remove_file(&path).unwrap();
+        assert!(find_by_id_at(&root, &saved.id).unwrap().is_none());
+        let (outside_root, outside) = fixture();
+        transaction(&root, |catalog| {
+            catalog.records.clear();
+            catalog
+                .records
+                .insert(outside.to_string_lossy().into_owned(), saved.clone());
+            Ok(())
+        })
+        .unwrap();
+        assert!(find_by_id_at(&root, &saved.id).unwrap().is_none());
+        fs::remove_dir_all(root).unwrap();
+        fs::remove_dir_all(outside_root).unwrap();
+    }
+
+    #[test]
+    fn remote_lookup_survives_reread_and_rejects_changed_or_missing_files() {
+        let (root, path) = fixture();
+        let url = "https://cdn.example.test/photo?id=one";
+        let saved = remember_at(
+            &root,
+            &path,
+            SourceMetadata {
+                source: Some("openverse".into()),
+                media_url: Some(url.into()),
+                ..Default::default()
+            },
+            Some(true),
+        )
+        .unwrap();
+        let requests = vec![
+            MediaLookup {
+                source: "pexels".into(),
+                media_url: url.into(),
+            },
+            MediaLookup {
+                source: "openverse".into(),
+                media_url: format!("{url}#preview"),
+            },
+            MediaLookup {
+                source: "openverse".into(),
+                media_url: "https://cdn.example.test/photo?id=two".into(),
+            },
+        ];
+        let matches = lookup_at(&root, &requests).unwrap();
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].index, 1);
+        assert_eq!(matches[0].metadata, saved);
+        assert!(!fs::read_to_string(root.join(".catalog.json"))
+            .unwrap()
+            .contains(url));
+        image::RgbImage::new(60, 30).save(&path).unwrap();
+        assert!(lookup_at(&root, &requests).unwrap().is_empty());
+        fs::remove_file(&path).unwrap();
+        assert!(lookup_at(&root, &requests).unwrap().is_empty());
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn refresh_cannot_reassociate_replacement_with_old_origin() {
+        let (root, path) = fixture();
+        let url = "https://cdn.example.test/original.png";
+        let original = remember_at(
+            &root,
+            &path,
+            SourceMetadata {
+                source: Some("web".into()),
+                media_url: Some(url.into()),
+                ..Default::default()
+            },
+            Some(true),
+        )
+        .unwrap();
+        image::RgbImage::new(60, 30).save(&path).unwrap();
+        let mut rows = Vec::new();
+        wallpaper_source::collect_library(&root, &root, &mut rows);
+        hydrate(&root, &mut rows).unwrap();
+        let replacement = rows[0].metadata.as_ref().unwrap().clone();
+        assert_ne!(replacement.id, original.id);
+        assert!(!replacement.favorite);
+        assert!(find_by_id_at(&root, &original.id).unwrap().is_none());
+        assert!(find_by_id_at(&root, &replacement.id).unwrap().is_some());
+        assert!(lookup_at(
+            &root,
+            &[MediaLookup {
+                source: "web".into(),
+                media_url: url.into(),
+            }]
+        )
+        .unwrap()
+        .is_empty());
+
+        hydrate(&root, &mut rows).unwrap();
+        assert_eq!(rows[0].metadata.as_ref().unwrap().id, replacement.id);
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn rejects_lookup_abuse_and_reads_legacy_catalogs() {
+        let (root, _) = fixture();
+        fs::write(root.join(".catalog.json"), br#"{"version":1,"records":{}}"#).unwrap();
+        assert!(lookup_at(&root, &[]).unwrap().is_empty());
+        let requests = (0..97)
+            .map(|_| MediaLookup {
+                source: "x".into(),
+                media_url: "https://example.test/photo".into(),
+            })
+            .collect::<Vec<_>>();
+        assert!(lookup_at(&root, &requests).is_err());
+        assert!(origin_key("x", "https://user:pass@example.test/photo").is_none());
+        assert!(origin_key("x", "file:///private.png").is_none());
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn rejects_outside_files_and_preserves_a_corrupt_catalog() {
+        let (root, original) = fixture();
+        let (other_root, outside) = fixture();
+        assert!(remember_at(&root, &outside, SourceMetadata::default(), Some(true)).is_err());
+        let invalid = root.join("invalid.png");
+        fs::write(&invalid, b"not an image").unwrap();
+        assert!(remember_at(&root, &invalid, SourceMetadata::default(), None).is_err());
+        let catalog = root.join(".catalog.json");
+        fs::write(&catalog, b"corrupt").unwrap();
+        assert!(remember_at(&root, &original, SourceMetadata::default(), Some(true)).is_err());
+        assert_eq!(fs::read(&catalog).unwrap(), b"corrupt");
+        fs::remove_dir_all(root).unwrap();
+        fs::remove_dir_all(other_root).unwrap();
+    }
+}

--- a/src-tauri/src/wallpaper_library.rs
+++ b/src-tauri/src/wallpaper_library.rs
@@ -1,0 +1,365 @@
+//! Bounded library snapshots keep paging stable while files change on disk.
+
+use crate::wallpaper_source::{self, WallpaperLibraryEntry};
+use parking_lot::Mutex;
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::VecDeque,
+    path::{Path, PathBuf},
+    sync::{Arc, OnceLock},
+    time::{Duration, Instant},
+};
+
+const SNAPSHOT_TTL: Duration = Duration::from_secs(30 * 60);
+const MAX_SNAPSHOTS: usize = 8;
+const MAX_ENTRIES: usize = 100_000;
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct LibraryQuery {
+    #[serde(default)]
+    pub query: String,
+    #[serde(default)]
+    pub kind: String,
+    #[serde(default)]
+    pub purpose: String,
+}
+
+impl LibraryQuery {
+    fn normalize(mut self) -> Result<Self, String> {
+        self.query = self.query.trim().to_lowercase();
+        if self.query.chars().count() > 500 {
+            return Err("invalid_query".into());
+        }
+        if self.kind.is_empty() {
+            self.kind = "all".into();
+        }
+        if !matches!(self.kind.as_str(), "all" | "image" | "video") {
+            return Err("invalid_query".into());
+        }
+        if self.purpose.is_empty() {
+            self.purpose = "all".into();
+        }
+        if !matches!(
+            self.purpose.as_str(),
+            "all" | "favorites" | "generated" | "cache"
+        ) {
+            return Err("invalid_query".into());
+        }
+        Ok(self)
+    }
+}
+
+#[derive(Clone, Debug, Default, Serialize)]
+pub(crate) struct KindCounts {
+    pub all: usize,
+    pub image: usize,
+    pub video: usize,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct LibraryPage {
+    pub items: Vec<WallpaperLibraryEntry>,
+    pub next_cursor: Option<String>,
+    pub total: usize,
+    pub kind_counts: KindCounts,
+}
+
+struct Snapshot {
+    id: uuid::Uuid,
+    root: PathBuf,
+    query: LibraryQuery,
+    rows: Vec<WallpaperLibraryEntry>,
+    counts: KindCounts,
+    created: Instant,
+    page_size: usize,
+}
+
+#[derive(Default)]
+struct LibrarySnapshots {
+    snapshots: VecDeque<Arc<Snapshot>>,
+}
+
+impl LibrarySnapshots {
+    fn insert(&mut self, snapshot: Snapshot) -> Arc<Snapshot> {
+        self.snapshots
+            .retain(|s| s.created.elapsed() < SNAPSHOT_TTL);
+        while self.snapshots.len() >= MAX_SNAPSHOTS {
+            self.snapshots.pop_front();
+        }
+        let snapshot = Arc::new(snapshot);
+        self.snapshots.push_back(snapshot.clone());
+        snapshot
+    }
+
+    fn resume(
+        &self,
+        cursor: &str,
+        root: &Path,
+        query: &LibraryQuery,
+        size: usize,
+    ) -> Result<(Arc<Snapshot>, usize), String> {
+        let (id, offset) = cursor.split_once(':').ok_or("invalid_cursor")?;
+        let id = uuid::Uuid::parse_str(id).map_err(|_| "invalid_cursor")?;
+        let offset: usize = offset.parse().map_err(|_| "invalid_cursor")?;
+        let snapshot = self
+            .snapshots
+            .iter()
+            .find(|s| s.id == id)
+            .ok_or("cursor_expired")?;
+        if snapshot.created.elapsed() >= SNAPSHOT_TTL {
+            return Err("cursor_expired".into());
+        }
+        if snapshot.root != root
+            || snapshot.query != *query
+            || snapshot.page_size != size
+            || offset == 0
+            || offset >= snapshot.rows.len()
+            || !offset.is_multiple_of(size)
+        {
+            return Err("invalid_cursor".into());
+        }
+        Ok((snapshot.clone(), offset))
+    }
+}
+
+static SNAPSHOTS: OnceLock<Mutex<LibrarySnapshots>> = OnceLock::new();
+
+fn snapshot(root: &Path, query: LibraryQuery, page_size: usize) -> Result<Snapshot, String> {
+    let query = query.normalize()?;
+    let mut rows = Vec::new();
+    wallpaper_source::collect_library(root, root, &mut rows);
+    if rows.len() > MAX_ENTRIES {
+        return Err("library_too_large".into());
+    }
+    crate::wallpaper_catalog::hydrate(root, &mut rows)?;
+    rows.retain(|e| {
+        query.purpose == "all"
+            || e.metadata.as_ref().is_some_and(|r| {
+                if query.purpose == "favorites" {
+                    r.favorite
+                } else {
+                    r.purpose == query.purpose
+                }
+            })
+    });
+    rows.retain(|e| {
+        query.query.is_empty()
+            || format!(
+                "{} {} {} {}",
+                e.name,
+                e.source,
+                e.metadata
+                    .as_ref()
+                    .and_then(|r| r.prompt.as_deref())
+                    .unwrap_or(""),
+                e.metadata
+                    .as_ref()
+                    .and_then(|r| r.title.as_deref())
+                    .unwrap_or("")
+            )
+            .to_lowercase()
+            .contains(&query.query)
+    });
+    let counts = KindCounts {
+        all: rows.len(),
+        image: rows.iter().filter(|e| e.kind == "image").count(),
+        video: rows.iter().filter(|e| e.kind == "video").count(),
+    };
+    rows.retain(|e| query.kind == "all" || e.kind == query.kind);
+    rows.sort_by(|a, b| {
+        (a.kind != "image", std::cmp::Reverse(a.modified_ms), &a.path).cmp(&(
+            b.kind != "image",
+            std::cmp::Reverse(b.modified_ms),
+            &b.path,
+        ))
+    });
+    Ok(Snapshot {
+        id: uuid::Uuid::new_v4(),
+        root: root.to_path_buf(),
+        query,
+        rows,
+        counts,
+        created: Instant::now(),
+        page_size,
+    })
+}
+
+fn page(snapshot: &Snapshot, offset: usize) -> LibraryPage {
+    let end = (offset + snapshot.page_size).min(snapshot.rows.len());
+    LibraryPage {
+        items: snapshot.rows[offset..end]
+            .iter()
+            .filter(|row| {
+                Path::new(&row.path).is_file()
+                    && wallpaper_source::is_path_under_dir(Path::new(&row.path), &snapshot.root)
+            })
+            .cloned()
+            .collect(),
+        next_cursor: (end < snapshot.rows.len()).then(|| format!("{}:{end}", snapshot.id)),
+        total: snapshot.rows.len(),
+        kind_counts: snapshot.counts.clone(),
+    }
+}
+
+pub(crate) fn list(
+    query: LibraryQuery,
+    cursor: Option<&str>,
+    limit: Option<u32>,
+) -> Result<LibraryPage, String> {
+    let root = wallpaper_source::wallpapers_root();
+    let query = query.normalize()?;
+    let limit = limit.unwrap_or(48);
+    if !(1..=96).contains(&limit) {
+        return Err("invalid_query".into());
+    }
+    let limit = limit as usize;
+    let snapshots = SNAPSHOTS.get_or_init(|| Mutex::new(LibrarySnapshots::default()));
+    let (snapshot, offset) = if let Some(cursor) = cursor {
+        snapshots.lock().resume(cursor, &root, &query, limit)?
+    } else {
+        let current = snapshot(&root, query, limit)?;
+        (snapshots.lock().insert(current), 0)
+    };
+    let result = page(&snapshot, offset);
+    for row in &result.items {
+        crate::path_scope::grant_path(Path::new(&row.path));
+    }
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn fixture() -> PathBuf {
+        let root = std::env::temp_dir().join(format!("grok-library-page-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(&root).unwrap();
+        for i in 0..251 {
+            fs::write(
+                root.join(format!(
+                    "item-{i:03}.{}",
+                    if i % 3 == 0 { "mp4" } else { "png" }
+                )),
+                b"fixture",
+            )
+            .unwrap();
+        }
+        fs::write(root.join(".catalog-preview.png"), b"internal").unwrap();
+        root
+    }
+
+    #[test]
+    fn full_snapshot_pages_without_repeats_and_filters_beyond_first_page() {
+        let root = fixture();
+        let query = LibraryQuery::default().normalize().unwrap();
+        let mut store = LibrarySnapshots::default();
+        let snapshot = store.insert(snapshot(&root, query.clone(), 48).unwrap());
+        let mut current = page(&snapshot, 0);
+        let mut paths = Vec::new();
+        loop {
+            paths.extend(current.items.into_iter().map(|e| e.path));
+            let Some(cursor) = current.next_cursor else {
+                break;
+            };
+            let (snapshot, offset) = store.resume(&cursor, &root, &query, 48).unwrap();
+            current = page(&snapshot, offset);
+        }
+        assert_eq!(paths.len(), 251);
+        paths.sort();
+        paths.dedup();
+        assert_eq!(paths.len(), 251);
+        let filtered = super::snapshot(
+            &root,
+            LibraryQuery {
+                query: "item-250".into(),
+                kind: "image".into(),
+                ..Default::default()
+            },
+            48,
+        )
+        .unwrap();
+        assert_eq!(page(&filtered, 0).items.len(), 1);
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn filters_saved_favorites_and_prompts_across_the_whole_library() {
+        let root = fixture();
+        let path = root.join("item-250.png");
+        image::RgbImage::new(40, 20).save(&path).unwrap();
+        let mut rows = vec![];
+        wallpaper_source::collect_library(&root, &root, &mut rows);
+        crate::wallpaper_catalog::hydrate(&root, &mut rows).unwrap();
+        let file = root.join(".catalog.json");
+        let mut catalog: serde_json::Value =
+            serde_json::from_slice(&fs::read(&file).unwrap()).unwrap();
+        catalog["records"]["item-250.png"]["favorite"] = true.into();
+        catalog["records"]["item-250.png"]["prompt"] = "Secret mountain dawn".into();
+        fs::write(&file, serde_json::to_vec(&catalog).unwrap()).unwrap();
+        let found = snapshot(
+            &root,
+            LibraryQuery {
+                query: "mountain".into(),
+                purpose: "favorites".into(),
+                ..Default::default()
+            },
+            48,
+        )
+        .unwrap();
+        assert_eq!(found.rows.len(), 1);
+        assert_eq!(found.rows[0].name, "item-250.png");
+        assert_eq!(found.rows[0].metadata.as_ref().unwrap().width, Some(40));
+        let empty = snapshot(
+            &root,
+            LibraryQuery {
+                purpose: "generated".into(),
+                ..Default::default()
+            },
+            48,
+        )
+        .unwrap();
+        assert!(empty.rows.is_empty());
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn snapshot_keeps_order_across_changes_and_rejects_mismatched_cursor() {
+        let root = fixture();
+        let query = LibraryQuery::default().normalize().unwrap();
+        let mut store = LibrarySnapshots::default();
+        let mut initial = snapshot(&root, query.clone(), 48).unwrap();
+        for row in &mut initial.rows {
+            row.modified_ms = 123;
+        }
+        initial.rows.sort_by(|a, b| a.path.cmp(&b.path));
+        let snapshot = store.insert(initial);
+        let first = page(&snapshot, 0);
+        let cursor = first.next_cursor.unwrap();
+        let removed = snapshot.rows[48].path.clone();
+        fs::remove_file(removed).unwrap();
+        fs::write(root.join("new.png"), b"new").unwrap();
+        let (same, offset) = store.resume(&cursor, &root, &query, 48).unwrap();
+        let next = page(&same, offset);
+        assert_eq!(next.items.len(), 47);
+        assert!(!next.items.iter().any(|row| row.name == "new.png"));
+        assert!(store.resume("bad", &root, &query, 48).is_err());
+        assert!(store.resume(&cursor, &root, &query, 24).is_err());
+        assert!(store
+            .resume(
+                &cursor,
+                &root,
+                &LibraryQuery {
+                    query: "new".into(),
+                    kind: "all".into(),
+                    ..Default::default()
+                },
+                48
+            )
+            .is_err());
+        assert_eq!(super::snapshot(&root, query, 48).unwrap().rows.len(), 251);
+        fs::remove_dir_all(root).unwrap();
+    }
+}

--- a/src-tauri/src/wallpaper_source.rs
+++ b/src-tauri/src/wallpaper_source.rs
@@ -288,6 +288,19 @@ pub struct WallpaperFetchResult {
     pub name: String,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum LocalWallpaperMediaKind {
+    Image,
+    Video,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct ValidatedLocalWallpaperMedia {
+    pub(crate) mime: &'static str,
+    pub(crate) extension: &'static str,
+    pub(crate) bytes: u64,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct WallpaperLibraryEntry {
@@ -297,6 +310,8 @@ pub struct WallpaperLibraryEntry {
     pub kind: String,
     pub bytes: u64,
     pub modified_ms: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<crate::wallpaper_catalog::MediaRecord>,
 }
 
 // ── Paths ───────────────────────────────────────────────────────────────────
@@ -1444,6 +1459,10 @@ impl DetectedMedia {
         )
     }
 
+    fn is_video(self) -> bool {
+        matches!(self, Self::Mp4 | Self::Webm)
+    }
+
     fn mime(self) -> &'static str {
         match self {
             Self::Jpeg => "image/jpeg",
@@ -2500,6 +2519,40 @@ pub(crate) fn validate_fetched_media_bytes(
     Ok((media.mime(), media.extension()))
 }
 
+pub(crate) fn validate_local_wallpaper_media(
+    path: &Path,
+    expected: LocalWallpaperMediaKind,
+) -> Result<ValidatedLocalWallpaperMedia, String> {
+    let metadata = fs::metadata(path).map_err(|_| "imagine_failed".to_string())?;
+    if !metadata.is_file() || metadata.len() == 0 || metadata.len() > MAX_DOWNLOAD_BYTES {
+        return Err("imagine_failed".into());
+    }
+
+    let mut prefix = Vec::with_capacity(
+        usize::try_from(metadata.len().min(MAX_IMAGE_PROBE_BYTES as u64)).unwrap_or_default(),
+    );
+    fs::File::open(path)
+        .and_then(|file| {
+            file.take(MAX_IMAGE_PROBE_BYTES as u64)
+                .read_to_end(&mut prefix)
+        })
+        .map_err(|_| "imagine_failed".to_string())?;
+    let media = detect_media_signature(&prefix).ok_or_else(|| "imagine_failed".to_string())?;
+    let kind_matches = match expected {
+        LocalWallpaperMediaKind::Image => media.is_image(),
+        LocalWallpaperMediaKind::Video => media.is_video(),
+    };
+    if !kind_matches {
+        return Err("imagine_failed".into());
+    }
+
+    Ok(ValidatedLocalWallpaperMedia {
+        mime: media.mime(),
+        extension: media.extension(),
+        bytes: metadata.len(),
+    })
+}
+
 fn file_to_fetch_result(path: &Path) -> Result<WallpaperFetchResult, String> {
     let meta = fs::metadata(path).map_err(|e| format!("stat: {e}"))?;
     let name = path
@@ -2755,13 +2808,35 @@ pub fn library_list(limit: Option<u32>) -> Result<Vec<WallpaperLibraryEntry>, St
     Ok(all)
 }
 
-fn collect_library(root: &Path, dir: &Path, out: &mut Vec<WallpaperLibraryEntry>) {
+fn is_library_media_extension(ext: &str) -> bool {
+    matches!(
+        ext,
+        "jpg" | "jpeg" | "png" | "webp" | "avif" | "gif" | "mp4" | "webm"
+    )
+}
+
+fn library_media_kind(ext: &str) -> &'static str {
+    if matches!(ext, "mp4" | "webm") {
+        "video"
+    } else {
+        "image"
+    }
+}
+
+pub(crate) fn collect_library(root: &Path, dir: &Path, out: &mut Vec<WallpaperLibraryEntry>) {
     let rd = match fs::read_dir(dir) {
         Ok(r) => r,
         Err(_) => return,
     };
     for e in rd.flatten() {
         let path = e.path();
+        // Do not expose catalog internals, follow links, or recurse outside the library.
+        if e.file_name().to_string_lossy().starts_with('.')
+            || e.file_type().is_ok_and(|kind| kind.is_symlink())
+            || !is_path_under_dir(&path, root)
+        {
+            continue;
+        }
         if path.is_dir() {
             collect_library(root, &path, out);
             continue;
@@ -2771,10 +2846,7 @@ fn collect_library(root: &Path, dir: &Path, out: &mut Vec<WallpaperLibraryEntry>
             .and_then(|s| s.to_str())
             .unwrap_or("")
             .to_ascii_lowercase();
-        if !matches!(
-            ext.as_str(),
-            "jpg" | "jpeg" | "png" | "webp" | "gif" | "mp4" | "webm"
-        ) {
+        if !is_library_media_extension(&ext) {
             continue;
         }
         let meta = match e.metadata() {
@@ -2799,11 +2871,7 @@ fn collect_library(root: &Path, dir: &Path, out: &mut Vec<WallpaperLibraryEntry>
             .and_then(|s| s.to_str())
             .unwrap_or("file")
             .to_string();
-        let kind = if matches!(ext.as_str(), "mp4" | "webm") {
-            "video"
-        } else {
-            "image"
-        };
+        let kind = library_media_kind(&ext);
         out.push(WallpaperLibraryEntry {
             path: path.display().to_string(),
             name,
@@ -2811,6 +2879,7 @@ fn collect_library(root: &Path, dir: &Path, out: &mut Vec<WallpaperLibraryEntry>
             kind: kind.into(),
             bytes: meta.len(),
             modified_ms,
+            metadata: None,
         });
     }
 }


### PR DESCRIPTION
## Summary

- 在现有壁纸目录内增加原子化 `.catalog.json`，保存稳定媒体 ID、收藏、用途、已知尺寸及净化后的来源/作者/许可信息。
- 增加完整图库的 Host 分页：搜索、类型与用途筛选作用于全量扫描结果；游标绑定查询和页大小，最多保留 8 个 30 分钟快照。
- 增加来源 URL 哈希匹配和媒体 ID 查找；只返回壁纸根目录内、内容未被替换且签名有效的本地媒体。
- 扫描时拒绝隐藏项、符号链接和越界路径，并保留原有列表/删除接口供旧客户端使用。
- 更新 `docs/llm-wiki/wallpaper-search.md` 的 Host 契约。

## 基底与审阅边界

- 基底：`upstream/main@8a1fe180`，已包含 #1102、#1103 及此前壁纸来源 PR。
- 本 PR 独立增量：`8a1fe180..72f81f09`。
- 未发现与“本地壁纸库分页 / 收藏目录 / 来源元数据”精确对应的 Issue，因此不自动关联关闭项。
- 本 PR 不自动合并，等待维护者审核。
- UI hold：不适用；本 PR 不修改用户可见界面、布局或文案。

## 不包含

- catalog/library 前端客户端、图库页面与交互。
- Imagine 生图、改图、图生视频的目录写入接线。
- 来源浏览历史、媒体详情、父图导航与批量文件管理。
- 代理、账户、认证、Cookie、Token 或 Pexels Key 变更。

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Documentation
- [ ] Refactor / chore

## Verification

- `pnpm typecheck`
- `pnpm test`：608 files / 7,177 tests passed
- `pnpm lint`
- `pnpm build:ui`（仅仓库既有 Rollup 分块告警）
- `python scripts/check-code-quality-gates.py --mode final`
- `python scripts/publish-website-downloads.py --self-test`
- `pnpm deps:check`
- `pnpm audit --prod --audit-level moderate`：No known vulnerabilities
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- Windows Rust harness：1,806 passed / 1 ignored / 0 failed
- 变更文件凭据形态扫描：clean

## Checklist

- [x] I ran `pnpm typecheck` and `pnpm test`
- [x] I ran `cargo test` in `src-tauri`（通过仓库 Windows manifest harness 运行）
- [x] User-facing strings go through `src/i18n/messages.ts`（本 PR 无新增用户可见文案）
- [x] No `window.confirm` / `prompt` / `alert` for product dialogs
- [x] Docs / `docs/llm-wiki` updated if behavior changed
- [x] No secrets (`secrets.json`, tokens, `auth.json`) included