### PR TITLE
feat(wallpaper): 接入本地图库完整搜索与分页

### DIFF
--- a/docs/llm-wiki/wallpaper-search.md
+++ b/docs/llm-wiki/wallpaper-search.md
@@ -255,3 +255,29 @@ more” appends deduplicated results while leaving current cards selectable.
 Paging failures preserve the gallery and continuation for retry. The separate
 prefetch follow-up described above adds one-page-ahead loading without changing
 this page's visible controls.
+
+## Local library catalog Host contract
+
+The local wallpaper library keeps its media files in the existing wallpaper
+root and stores only bounded metadata in an atomic `.catalog.json`. Records have
+a stable media ID, source and purpose, favorite state, known dimensions, optional
+prompt/generation lineage, and sanitized HTTPS attribution fields. Remote media
+identity is stored as a source-scoped SHA-256 key; raw media URLs, credentials,
+headers and private album responses are not written to the catalog.
+
+`wallpaper_library_page` filters the complete scanned library by query, media
+kind and purpose before paging. A page contains at most 96 items (48 by default)
+and uses a query- and page-size-bound snapshot cursor. At most eight snapshots
+live for 30 minutes. Images sort before videos, then by descending modification
+time and path. New files appear on a new snapshot; files deleted during paging
+are skipped without shifting the remaining snapshot order. Hidden entries,
+symbolic links and paths outside the wallpaper root are never traversed.
+
+`wallpaper_library_remember` accepts only an existing, signature-validated media
+file inside the wallpaper root. It bounds text metadata, strips query strings and
+fragments from public attribution URLs, and can change favorite state without
+deleting the file. `wallpaper_library_lookup` accepts at most 96 source/media URL
+pairs and returns only unchanged local files; replacements at the same path get a
+new identity and cannot inherit an old remote-origin association. Lookup by media
+ID applies the same containment, signature and replacement checks. The legacy
+list and delete commands remain registered for existing clients.

--- a/src-tauri/src/commands/misc_p1.rs
+++ b/src-tauri/src/commands/misc_p1.rs
@@ -1175,11 +1175,59 @@ pub async fn wallpaper_library_list(
 }
 
 #[tauri::command]
+pub async fn wallpaper_library_page(
+    query: crate::wallpaper_library::LibraryQuery,
+    cursor: Option<String>,
+    limit: Option<u32>,
+) -> Result<crate::wallpaper_library::LibraryPage, String> {
+    crate::wallpaper_source::ensure_wallpaper_dirs();
+    tauri::async_runtime::spawn_blocking(move || {
+        crate::wallpaper_library::list(query, cursor.as_deref(), limit)
+    })
+    .await
+    .map_err(|e| format!("wallpaper_library_page: {e}"))?
+}
+
+#[tauri::command]
+pub async fn wallpaper_library_remember(
+    path: String,
+    metadata: crate::wallpaper_catalog::SourceMetadata,
+    favorite: Option<bool>,
+) -> Result<crate::wallpaper_catalog::MediaRecord, String> {
+    crate::wallpaper_source::ensure_wallpaper_dirs();
+    tauri::async_runtime::spawn_blocking(move || {
+        crate::wallpaper_catalog::remember(&path, metadata, favorite)
+    })
+    .await
+    .map_err(|e| format!("wallpaper_library_remember: {e}"))?
+}
+
+#[tauri::command]
 pub async fn wallpaper_library_delete(path: String) -> Result<(), String> {
     crate::wallpaper_source::ensure_wallpaper_dirs();
     tauri::async_runtime::spawn_blocking(move || crate::wallpaper_source::library_delete(&path))
         .await
         .map_err(|e| format!("wallpaper_library_delete: {e}"))?
+}
+
+#[tauri::command]
+pub async fn wallpaper_library_lookup(
+    requests: Vec<crate::wallpaper_catalog::MediaLookup>,
+) -> Result<Vec<crate::wallpaper_catalog::MediaMatch>, String> {
+    crate::wallpaper_source::ensure_wallpaper_dirs();
+    tauri::async_runtime::spawn_blocking(move || crate::wallpaper_catalog::lookup(&requests))
+        .await
+        .map_err(|e| format!("wallpaper_library_lookup: {e}"))?
+}
+
+#[tauri::command]
+pub async fn wallpaper_library_find_by_id(
+    id: String,
+) -> Result<Option<crate::wallpaper_source::WallpaperLibraryEntry>, String> {
+    crate::wallpaper_source::ensure_wallpaper_dirs();
+    tauri::async_runtime::spawn_blocking(move || crate::wallpaper_catalog::find_by_id(&id))
+        .await
+        .map_err(|e| format!("wallpaper_library_find_by_id: {e}"))?
 }
 
 /// Headless probe: `grok -p … --output-format streaming-messages-json` (CLI 0.2.117+).

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -224,7 +224,9 @@ mod voice_stt;
 
 mod voice_tools;
 
+mod wallpaper_catalog;
 mod wallpaper_grok_album;
+mod wallpaper_library;
 mod wallpaper_provider_search;
 mod wallpaper_remote_commands;
 mod wallpaper_remote_media;
@@ -1723,6 +1725,14 @@ pub fn run() {
             commands::wallpaper_imagine,
 
             commands::wallpaper_library_list,
+
+            commands::wallpaper_library_page,
+
+            commands::wallpaper_library_remember,
+
+            commands::wallpaper_library_lookup,
+
+            commands::wallpaper_library_find_by_id,
 
             commands::wallpaper_library_delete,
 

--- a/src-tauri/src/wallpaper_catalog.rs
+++ b/src-tauri/src/wallpaper_catalog.rs
@@ -1,0 +1,701 @@
+//! Persistent media provenance and user intent, separate from scan snapshots.
+
+use crate::{
+    store_lock,
+    wallpaper_source::{self, WallpaperLibraryEntry},
+};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::{collections::BTreeMap, fs, path::Path};
+
+const MAX_CATALOG_BYTES: u64 = 64 * 1024 * 1024;
+const MAX_RECORDS: usize = 100_000;
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct GenerationParameters {
+    pub operation: String,
+    pub aspect_ratio: Option<String>,
+    pub resolution: Option<String>,
+    pub duration: Option<u32>,
+    pub requested_model: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct MediaRecord {
+    pub id: String,
+    pub source: String,
+    pub source_url: Option<String>,
+    pub source_name: Option<String>,
+    pub author_name: Option<String>,
+    pub author_url: Option<String>,
+    pub license: Option<String>,
+    pub license_url: Option<String>,
+    pub title: Option<String>,
+    pub width: Option<u32>,
+    pub height: Option<u32>,
+    pub prompt: Option<String>,
+    pub generation: Option<GenerationParameters>,
+    pub parent_id: Option<String>,
+    pub favorite: bool,
+    pub purpose: String,
+    pub bytes: u64,
+    pub modified_ms: u64,
+}
+
+#[derive(Default, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct SourceMetadata {
+    pub source: Option<String>,
+    pub media_url: Option<String>,
+    pub source_url: Option<String>,
+    pub source_name: Option<String>,
+    pub author_name: Option<String>,
+    pub author_url: Option<String>,
+    pub license: Option<String>,
+    pub license_url: Option<String>,
+    pub title: Option<String>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct Catalog {
+    version: u32,
+    records: BTreeMap<String, MediaRecord>,
+    #[serde(default)]
+    origins: BTreeMap<String, String>,
+}
+
+impl Catalog {
+    fn insert(&mut self, relative: String, record: MediaRecord) {
+        if self
+            .records
+            .get(&relative)
+            .is_some_and(|old| old.id != record.id)
+        {
+            self.origins.retain(|_, path| path != &relative);
+        }
+        self.records.insert(relative, record);
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct MediaLookup {
+    pub source: String,
+    pub media_url: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct MediaMatch {
+    pub index: usize,
+    pub path: String,
+    pub metadata: MediaRecord,
+}
+
+fn origin_key(source: &str, raw: &str) -> Option<String> {
+    if !matches!(
+        source,
+        "x" | "web" | "openverse" | "pexels" | "grok_album" | "imagine"
+    ) || raw.len() > 16_384
+    {
+        return None;
+    }
+    let mut url = url::Url::parse(raw).ok()?;
+    if url.scheme() != "https"
+        || url.host_str().is_none()
+        || !url.username().is_empty()
+        || url.password().is_some()
+    {
+        return None;
+    }
+    url.set_fragment(None);
+    Some(hex::encode(Sha256::digest(
+        format!("{source}\n{url}").as_bytes(),
+    )))
+}
+
+fn key(root: &Path, path: &Path) -> Result<String, String> {
+    let root = root.canonicalize().map_err(|_| "path_not_allowed")?;
+    let canonical = path.canonicalize().map_err(|_| "path_not_allowed")?;
+    let relative = canonical
+        .strip_prefix(root)
+        .map_err(|_| "path_not_allowed")?;
+    if relative
+        .components()
+        .any(|p| p.as_os_str().to_string_lossy().starts_with('.'))
+    {
+        return Err("path_not_allowed".into());
+    }
+    let relative = relative.to_string_lossy().replace('\\', "/");
+    Ok(if cfg!(windows) {
+        relative.to_lowercase()
+    } else {
+        relative
+    })
+}
+
+fn stable_id(key: &str) -> String {
+    format!("media-{}", hex::encode(Sha256::digest(key.as_bytes())))
+}
+
+fn read(path: &Path) -> Result<Catalog, String> {
+    match fs::metadata(path) {
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(Catalog {
+                version: 1,
+                records: BTreeMap::new(),
+                origins: BTreeMap::new(),
+            })
+        }
+        Err(_) => return Err("catalog_read_failed".into()),
+        Ok(meta) if meta.len() > MAX_CATALOG_BYTES => return Err("catalog_too_large".into()),
+        Ok(_) => {}
+    }
+    let data = fs::read(path).map_err(|_| "catalog_read_failed")?;
+    let catalog: Catalog = serde_json::from_slice(&data).map_err(|_| "catalog_invalid")?;
+    if catalog.version != 1
+        || catalog.records.len() > MAX_RECORDS
+        || catalog.origins.len() > MAX_RECORDS
+    {
+        return Err("catalog_invalid".into());
+    }
+    Ok(catalog)
+}
+
+fn transaction<T>(
+    root: &Path,
+    body: impl FnOnce(&mut Catalog) -> Result<T, String>,
+) -> Result<T, String> {
+    let path = root.join(".catalog.json");
+    store_lock::with_exclusive_lock(&path, || {
+        let mut catalog = read(&path)?;
+        let previous = catalog.records.clone();
+        let previous_origins = catalog.origins.clone();
+        let result = body(&mut catalog)?;
+        if catalog.records != previous || catalog.origins != previous_origins {
+            if catalog.records.len() > MAX_RECORDS || catalog.origins.len() > MAX_RECORDS {
+                return Err("catalog_too_large".into());
+            }
+            let bytes = serde_json::to_vec(&catalog).map_err(|_| "catalog_write_failed")?;
+            if bytes.len() as u64 > MAX_CATALOG_BYTES {
+                return Err("catalog_too_large".into());
+            }
+            store_lock::write_bytes_replace(&path, &bytes).map_err(|_| "catalog_write_failed")?;
+        }
+        Ok(result)
+    })
+}
+
+fn record_for(
+    root: &Path,
+    path: &Path,
+    previous: Option<&MediaRecord>,
+) -> Result<MediaRecord, String> {
+    let relative = key(root, path)?;
+    let stat = fs::metadata(path).map_err(|_| "catalog_read_failed")?;
+    if !stat.is_file() {
+        return Err("path_not_allowed".into());
+    }
+    let modified_ms = stat
+        .modified()
+        .ok()
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0);
+    if let Some(saved) = previous.filter(|r| r.bytes == stat.len() && r.modified_ms == modified_ms)
+    {
+        return Ok(saved.clone());
+    }
+    let dimensions = image::ImageReader::open(path)
+        .ok()
+        .and_then(|r| r.with_guessed_format().ok())
+        .and_then(|r| r.into_dimensions().ok());
+    let source = relative
+        .split('/')
+        .next()
+        .filter(|s| {
+            matches!(
+                *s,
+                "x" | "web" | "openverse" | "pexels" | "grok_album" | "imagine"
+            )
+        })
+        .unwrap_or("library")
+        .to_string();
+    Ok(MediaRecord {
+        // A replacement is a new work, even if it reuses a known filename.
+        // Keep legacy IDs for unchanged files; never revive an old parent or
+        // remote-origin association after a scan accepts the replacement.
+        id: if previous.is_some() {
+            stable_id(&format!("{relative}:{}", uuid::Uuid::new_v4()))
+        } else {
+            stable_id(&relative)
+        },
+        purpose: if source == "imagine" {
+            "generated"
+        } else {
+            "cache"
+        }
+        .into(),
+        source,
+        source_url: None,
+        source_name: None,
+        author_name: None,
+        author_url: None,
+        license: None,
+        license_url: None,
+        title: None,
+        width: dimensions.map(|d| d.0),
+        height: dimensions.map(|d| d.1),
+        prompt: None,
+        generation: None,
+        parent_id: None,
+        favorite: false,
+        bytes: stat.len(),
+        modified_ms,
+    })
+}
+
+fn public_url(value: Option<String>) -> Option<String> {
+    let mut url = url::Url::parse(value.as_deref()?).ok()?;
+    if url.scheme() != "https"
+        || url.host_str().is_none()
+        || !url.username().is_empty()
+        || url.password().is_some()
+    {
+        return None;
+    }
+    url.set_query(None);
+    url.set_fragment(None);
+    (url.as_str().len() <= 2_048).then(|| url.to_string())
+}
+
+fn bounded(value: Option<String>, limit: usize) -> Option<String> {
+    value
+        .map(|s| {
+            s.chars()
+                .filter(|c| !c.is_control())
+                .take(limit)
+                .collect::<String>()
+        })
+        .filter(|s| !s.trim().is_empty())
+}
+
+pub(crate) fn hydrate(root: &Path, rows: &mut [WallpaperLibraryEntry]) -> Result<(), String> {
+    transaction(root, |catalog| {
+        for row in rows {
+            let path = Path::new(&row.path);
+            // Files may disappear between directory enumeration and this transaction.
+            if !path.is_file() {
+                continue;
+            }
+            let relative = key(root, path)?;
+            let record = record_for(root, path, catalog.records.get(&relative))?;
+            row.metadata = Some(record.clone());
+            catalog.insert(relative, record);
+        }
+        Ok(())
+    })
+}
+
+pub(crate) fn remember(
+    path: &str,
+    metadata: SourceMetadata,
+    favorite: Option<bool>,
+) -> Result<MediaRecord, String> {
+    remember_at(
+        &wallpaper_source::wallpapers_root(),
+        Path::new(path),
+        metadata,
+        favorite,
+    )
+}
+
+fn remember_at(
+    root: &Path,
+    path: &Path,
+    metadata: SourceMetadata,
+    favorite: Option<bool>,
+) -> Result<MediaRecord, String> {
+    let relative = key(root, path)?;
+    let kind = if path
+        .extension()
+        .and_then(|s| s.to_str())
+        .is_some_and(|ext| matches!(ext.to_lowercase().as_str(), "mp4" | "webm"))
+    {
+        wallpaper_source::LocalWallpaperMediaKind::Video
+    } else {
+        wallpaper_source::LocalWallpaperMediaKind::Image
+    };
+    wallpaper_source::validate_local_wallpaper_media(path, kind)?;
+    let origin = metadata
+        .source
+        .as_deref()
+        .zip(metadata.media_url.as_deref())
+        .and_then(|(source, url)| origin_key(source, url));
+    transaction(root, |catalog| {
+        let mut record = record_for(root, path, catalog.records.get(&relative))?;
+        if let Some(source) = metadata.source.filter(|s| {
+            matches!(
+                s.as_str(),
+                "x" | "web" | "openverse" | "pexels" | "grok_album"
+            )
+        }) {
+            record.source = source;
+        }
+        if let Some(value) = public_url(metadata.source_url) {
+            record.source_url = Some(value);
+        }
+        if let Some(value) = bounded(metadata.source_name, 200) {
+            record.source_name = Some(value);
+        }
+        if let Some(value) = bounded(metadata.author_name, 200) {
+            record.author_name = Some(value);
+        }
+        if let Some(value) = public_url(metadata.author_url) {
+            record.author_url = Some(value);
+        }
+        if let Some(value) = bounded(metadata.license, 200) {
+            record.license = Some(value);
+        }
+        if let Some(value) = public_url(metadata.license_url) {
+            record.license_url = Some(value);
+        }
+        if let Some(value) = bounded(metadata.title, 500) {
+            record.title = Some(value);
+        }
+        if let Some(favorite) = favorite {
+            record.favorite = favorite;
+        }
+        catalog.insert(relative.clone(), record.clone());
+        if let Some(origin) = origin {
+            catalog.origins.insert(origin, relative.clone());
+        }
+        Ok(record)
+    })
+}
+
+pub(crate) fn lookup(requests: &[MediaLookup]) -> Result<Vec<MediaMatch>, String> {
+    lookup_at(&wallpaper_source::wallpapers_root(), requests)
+}
+
+fn lookup_at(root: &Path, requests: &[MediaLookup]) -> Result<Vec<MediaMatch>, String> {
+    if requests.len() > 96 {
+        return Err("catalog_lookup_limit".into());
+    }
+    store_lock::with_exclusive_lock(&root.join(".catalog.json"), || {
+        let catalog = read(&root.join(".catalog.json"))?;
+        let mut matches = Vec::new();
+        for (index, request) in requests.iter().enumerate() {
+            let Some(origin) = origin_key(&request.source, &request.media_url) else {
+                continue;
+            };
+            let Some(relative) = catalog.origins.get(&origin) else {
+                continue;
+            };
+            let Some(record) = catalog.records.get(relative) else {
+                continue;
+            };
+            let path = root.join(relative);
+            if !path.is_file() || key(root, &path).as_ref() != Ok(relative) {
+                continue;
+            }
+            let current = record_for(root, &path, Some(record))?;
+            // A replacement file at the same path is no longer this remote media.
+            if current != *record {
+                continue;
+            }
+            crate::path_scope::grant_path(&path);
+            matches.push(MediaMatch {
+                index,
+                path: crate::process_util::strip_extended_path_prefix(&path.to_string_lossy()),
+                metadata: current,
+            });
+        }
+        Ok(matches)
+    })
+}
+
+pub(crate) fn find_by_id(id: &str) -> Result<Option<WallpaperLibraryEntry>, String> {
+    find_by_id_at(&wallpaper_source::wallpapers_root(), id)
+}
+
+fn find_by_id_at(root: &Path, id: &str) -> Result<Option<WallpaperLibraryEntry>, String> {
+    if id.len() != 70
+        || !id.starts_with("media-")
+        || !id[6..].bytes().all(|c| c.is_ascii_hexdigit())
+    {
+        return Err("catalog_invalid_id".into());
+    }
+    store_lock::with_exclusive_lock(&root.join(".catalog.json"), || {
+        let catalog = read(&root.join(".catalog.json"))?;
+        let Some((relative, record)) = catalog.records.iter().find(|(_, record)| record.id == id)
+        else {
+            return Ok(None);
+        };
+        let path = root.join(relative);
+        if !path.is_file() || key(root, &path).as_ref() != Ok(relative) {
+            return Ok(None);
+        }
+        if record_for(root, &path, Some(record))? != *record {
+            return Ok(None);
+        }
+        let video = path
+            .extension()
+            .and_then(|s| s.to_str())
+            .is_some_and(|ext| matches!(ext.to_lowercase().as_str(), "mp4" | "webm"));
+        wallpaper_source::validate_local_wallpaper_media(
+            &path,
+            if video {
+                wallpaper_source::LocalWallpaperMediaKind::Video
+            } else {
+                wallpaper_source::LocalWallpaperMediaKind::Image
+            },
+        )?;
+        crate::path_scope::grant_path(&path);
+        Ok(Some(WallpaperLibraryEntry {
+            path: crate::process_util::strip_extended_path_prefix(&path.to_string_lossy()),
+            name: path
+                .file_name()
+                .unwrap_or_default()
+                .to_string_lossy()
+                .into_owned(),
+            source: record.source.clone(),
+            kind: if video { "video" } else { "image" }.into(),
+            bytes: record.bytes,
+            modified_ms: record.modified_ms,
+            metadata: Some(record.clone()),
+        }))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    fn fixture() -> (PathBuf, PathBuf) {
+        let root =
+            std::env::temp_dir().join(format!("grok-wallpaper-catalog-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(&root).unwrap();
+        let path = root.join("original.png");
+        image::RgbImage::new(24, 12).save(&path).unwrap();
+        (root, path)
+    }
+
+    #[test]
+    fn favorite_and_provenance_survive_reread() {
+        let (root, path) = fixture();
+        let media_url = "https://cdn.example.org/photo.jpg?size=large";
+        let saved = remember_at(
+            &root,
+            &path,
+            SourceMetadata {
+                source: Some("openverse".into()),
+                media_url: Some(media_url.into()),
+                source_url: Some("https://example.org/photo?token=secret#fragment".into()),
+                ..Default::default()
+            },
+            Some(true),
+        )
+        .unwrap();
+        assert!(saved.favorite);
+        assert_eq!(saved.width, Some(24));
+        assert_eq!(saved.height, Some(12));
+        assert_eq!(
+            saved.source_url.as_deref(),
+            Some("https://example.org/photo")
+        );
+        let restored = remember_at(&root, &path, SourceMetadata::default(), Some(false)).unwrap();
+        assert!(!restored.favorite);
+        assert_eq!(saved.id, restored.id);
+        assert_eq!(saved.source, restored.source);
+        let matches = lookup_at(
+            &root,
+            &[MediaLookup {
+                source: "openverse".into(),
+                media_url: format!("{media_url}#preview"),
+            }],
+        )
+        .unwrap();
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].metadata.id, saved.id);
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn author_metadata_is_bounded_sanitized_and_legacy_compatible() {
+        let (root, path) = fixture();
+        let saved = remember_at(
+            &root,
+            &path,
+            SourceMetadata {
+                source_name: Some("Openverse".into()),
+                author_name: Some(format!("A\n{}", "名".repeat(220))),
+                author_url: Some("https://example.org/author?token=private#fragment".into()),
+                ..Default::default()
+            },
+            None,
+        )
+        .unwrap();
+        let restored = remember_at(&root, &path, SourceMetadata::default(), None).unwrap();
+        assert_eq!(saved, restored);
+        assert_eq!(restored.author_name.unwrap().chars().count(), 200);
+        assert_eq!(
+            restored.author_url.as_deref(),
+            Some("https://example.org/author")
+        );
+        let mut legacy = serde_json::to_value(saved).unwrap();
+        for field in ["sourceName", "authorName", "authorUrl"] {
+            legacy.as_object_mut().unwrap().remove(field);
+        }
+        let legacy: MediaRecord = serde_json::from_value(legacy).unwrap();
+        assert!(
+            legacy.source_name.is_none()
+                && legacy.author_name.is_none()
+                && legacy.author_url.is_none()
+        );
+        assert_eq!(legacy.width, Some(24));
+        assert!(public_url(Some("https://user:pass@example.org/author".into())).is_none());
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn parent_lookup_rejects_replaced_missing_and_outside_records() {
+        let (root, path) = fixture();
+        let saved = remember_at(&root, &path, SourceMetadata::default(), None).unwrap();
+        assert!(find_by_id_at(&root, &saved.id).unwrap().is_some());
+        assert!(find_by_id_at(&root, "../private").is_err());
+        image::RgbImage::new(60, 30).save(&path).unwrap();
+        assert!(find_by_id_at(&root, &saved.id).unwrap().is_none());
+        fs::remove_file(&path).unwrap();
+        assert!(find_by_id_at(&root, &saved.id).unwrap().is_none());
+        let (outside_root, outside) = fixture();
+        transaction(&root, |catalog| {
+            catalog.records.clear();
+            catalog
+                .records
+                .insert(outside.to_string_lossy().into_owned(), saved.clone());
+            Ok(())
+        })
+        .unwrap();
+        assert!(find_by_id_at(&root, &saved.id).unwrap().is_none());
+        fs::remove_dir_all(root).unwrap();
+        fs::remove_dir_all(outside_root).unwrap();
+    }
+
+    #[test]
+    fn remote_lookup_survives_reread_and_rejects_changed_or_missing_files() {
+        let (root, path) = fixture();
+        let url = "https://cdn.example.test/photo?id=one";
+        let saved = remember_at(
+            &root,
+            &path,
+            SourceMetadata {
+                source: Some("openverse".into()),
+                media_url: Some(url.into()),
+                ..Default::default()
+            },
+            Some(true),
+        )
+        .unwrap();
+        let requests = vec![
+            MediaLookup {
+                source: "pexels".into(),
+                media_url: url.into(),
+            },
+            MediaLookup {
+                source: "openverse".into(),
+                media_url: format!("{url}#preview"),
+            },
+            MediaLookup {
+                source: "openverse".into(),
+                media_url: "https://cdn.example.test/photo?id=two".into(),
+            },
+        ];
+        let matches = lookup_at(&root, &requests).unwrap();
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].index, 1);
+        assert_eq!(matches[0].metadata, saved);
+        assert!(!fs::read_to_string(root.join(".catalog.json"))
+            .unwrap()
+            .contains(url));
+        image::RgbImage::new(60, 30).save(&path).unwrap();
+        assert!(lookup_at(&root, &requests).unwrap().is_empty());
+        fs::remove_file(&path).unwrap();
+        assert!(lookup_at(&root, &requests).unwrap().is_empty());
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn refresh_cannot_reassociate_replacement_with_old_origin() {
+        let (root, path) = fixture();
+        let url = "https://cdn.example.test/original.png";
+        let original = remember_at(
+            &root,
+            &path,
+            SourceMetadata {
+                source: Some("web".into()),
+                media_url: Some(url.into()),
+                ..Default::default()
+            },
+            Some(true),
+        )
+        .unwrap();
+        image::RgbImage::new(60, 30).save(&path).unwrap();
+        let mut rows = Vec::new();
+        wallpaper_source::collect_library(&root, &root, &mut rows);
+        hydrate(&root, &mut rows).unwrap();
+        let replacement = rows[0].metadata.as_ref().unwrap().clone();
+        assert_ne!(replacement.id, original.id);
+        assert!(!replacement.favorite);
+        assert!(find_by_id_at(&root, &original.id).unwrap().is_none());
+        assert!(find_by_id_at(&root, &replacement.id).unwrap().is_some());
+        assert!(lookup_at(
+            &root,
+            &[MediaLookup {
+                source: "web".into(),
+                media_url: url.into(),
+            }]
+        )
+        .unwrap()
+        .is_empty());
+
+        hydrate(&root, &mut rows).unwrap();
+        assert_eq!(rows[0].metadata.as_ref().unwrap().id, replacement.id);
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn rejects_lookup_abuse_and_reads_legacy_catalogs() {
+        let (root, _) = fixture();
+        fs::write(root.join(".catalog.json"), br#"{"version":1,"records":{}}"#).unwrap();
+        assert!(lookup_at(&root, &[]).unwrap().is_empty());
+        let requests = (0..97)
+            .map(|_| MediaLookup {
+                source: "x".into(),
+                media_url: "https://example.test/photo".into(),
+            })
+            .collect::<Vec<_>>();
+        assert!(lookup_at(&root, &requests).is_err());
+        assert!(origin_key("x", "https://user:pass@example.test/photo").is_none());
+        assert!(origin_key("x", "file:///private.png").is_none());
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn rejects_outside_files_and_preserves_a_corrupt_catalog() {
+        let (root, original) = fixture();
+        let (other_root, outside) = fixture();
+        assert!(remember_at(&root, &outside, SourceMetadata::default(), Some(true)).is_err());
+        let invalid = root.join("invalid.png");
+        fs::write(&invalid, b"not an image").unwrap();
+        assert!(remember_at(&root, &invalid, SourceMetadata::default(), None).is_err());
+        let catalog = root.join(".catalog.json");
+        fs::write(&catalog, b"corrupt").unwrap();
+        assert!(remember_at(&root, &original, SourceMetadata::default(), Some(true)).is_err());
+        assert_eq!(fs::read(&catalog).unwrap(), b"corrupt");
+        fs::remove_dir_all(root).unwrap();
+        fs::remove_dir_all(other_root).unwrap();
+    }
+}

--- a/src-tauri/src/wallpaper_library.rs
+++ b/src-tauri/src/wallpaper_library.rs
@@ -1,0 +1,365 @@
+//! Bounded library snapshots keep paging stable while files change on disk.
+
+use crate::wallpaper_source::{self, WallpaperLibraryEntry};
+use parking_lot::Mutex;
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::VecDeque,
+    path::{Path, PathBuf},
+    sync::{Arc, OnceLock},
+    time::{Duration, Instant},
+};
+
+const SNAPSHOT_TTL: Duration = Duration::from_secs(30 * 60);
+const MAX_SNAPSHOTS: usize = 8;
+const MAX_ENTRIES: usize = 100_000;
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct LibraryQuery {
+    #[serde(default)]
+    pub query: String,
+    #[serde(default)]
+    pub kind: String,
+    #[serde(default)]
+    pub purpose: String,
+}
+
+impl LibraryQuery {
+    fn normalize(mut self) -> Result<Self, String> {
+        self.query = self.query.trim().to_lowercase();
+        if self.query.chars().count() > 500 {
+            return Err("invalid_query".into());
+        }
+        if self.kind.is_empty() {
+            self.kind = "all".into();
+        }
+        if !matches!(self.kind.as_str(), "all" | "image" | "video") {
+            return Err("invalid_query".into());
+        }
+        if self.purpose.is_empty() {
+            self.purpose = "all".into();
+        }
+        if !matches!(
+            self.purpose.as_str(),
+            "all" | "favorites" | "generated" | "cache"
+        ) {
+            return Err("invalid_query".into());
+        }
+        Ok(self)
+    }
+}
+
+#[derive(Clone, Debug, Default, Serialize)]
+pub(crate) struct KindCounts {
+    pub all: usize,
+    pub image: usize,
+    pub video: usize,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct LibraryPage {
+    pub items: Vec<WallpaperLibraryEntry>,
+    pub next_cursor: Option<String>,
+    pub total: usize,
+    pub kind_counts: KindCounts,
+}
+
+struct Snapshot {
+    id: uuid::Uuid,
+    root: PathBuf,
+    query: LibraryQuery,
+    rows: Vec<WallpaperLibraryEntry>,
+    counts: KindCounts,
+    created: Instant,
+    page_size: usize,
+}
+
+#[derive(Default)]
+struct LibrarySnapshots {
+    snapshots: VecDeque<Arc<Snapshot>>,
+}
+
+impl LibrarySnapshots {
+    fn insert(&mut self, snapshot: Snapshot) -> Arc<Snapshot> {
+        self.snapshots
+            .retain(|s| s.created.elapsed() < SNAPSHOT_TTL);
+        while self.snapshots.len() >= MAX_SNAPSHOTS {
+            self.snapshots.pop_front();
+        }
+        let snapshot = Arc::new(snapshot);
+        self.snapshots.push_back(snapshot.clone());
+        snapshot
+    }
+
+    fn resume(
+        &self,
+        cursor: &str,
+        root: &Path,
+        query: &LibraryQuery,
+        size: usize,
+    ) -> Result<(Arc<Snapshot>, usize), String> {
+        let (id, offset) = cursor.split_once(':').ok_or("invalid_cursor")?;
+        let id = uuid::Uuid::parse_str(id).map_err(|_| "invalid_cursor")?;
+        let offset: usize = offset.parse().map_err(|_| "invalid_cursor")?;
+        let snapshot = self
+            .snapshots
+            .iter()
+            .find(|s| s.id == id)
+            .ok_or("cursor_expired")?;
+        if snapshot.created.elapsed() >= SNAPSHOT_TTL {
+            return Err("cursor_expired".into());
+        }
+        if snapshot.root != root
+            || snapshot.query != *query
+            || snapshot.page_size != size
+            || offset == 0
+            || offset >= snapshot.rows.len()
+            || !offset.is_multiple_of(size)
+        {
+            return Err("invalid_cursor".into());
+        }
+        Ok((snapshot.clone(), offset))
+    }
+}
+
+static SNAPSHOTS: OnceLock<Mutex<LibrarySnapshots>> = OnceLock::new();
+
+fn snapshot(root: &Path, query: LibraryQuery, page_size: usize) -> Result<Snapshot, String> {
+    let query = query.normalize()?;
+    let mut rows = Vec::new();
+    wallpaper_source::collect_library(root, root, &mut rows);
+    if rows.len() > MAX_ENTRIES {
+        return Err("library_too_large".into());
+    }
+    crate::wallpaper_catalog::hydrate(root, &mut rows)?;
+    rows.retain(|e| {
+        query.purpose == "all"
+            || e.metadata.as_ref().is_some_and(|r| {
+                if query.purpose == "favorites" {
+                    r.favorite
+                } else {
+                    r.purpose == query.purpose
+                }
+            })
+    });
+    rows.retain(|e| {
+        query.query.is_empty()
+            || format!(
+                "{} {} {} {}",
+                e.name,
+                e.source,
+                e.metadata
+                    .as_ref()
+                    .and_then(|r| r.prompt.as_deref())
+                    .unwrap_or(""),
+                e.metadata
+                    .as_ref()
+                    .and_then(|r| r.title.as_deref())
+                    .unwrap_or("")
+            )
+            .to_lowercase()
+            .contains(&query.query)
+    });
+    let counts = KindCounts {
+        all: rows.len(),
+        image: rows.iter().filter(|e| e.kind == "image").count(),
+        video: rows.iter().filter(|e| e.kind == "video").count(),
+    };
+    rows.retain(|e| query.kind == "all" || e.kind == query.kind);
+    rows.sort_by(|a, b| {
+        (a.kind != "image", std::cmp::Reverse(a.modified_ms), &a.path).cmp(&(
+            b.kind != "image",
+            std::cmp::Reverse(b.modified_ms),
+            &b.path,
+        ))
+    });
+    Ok(Snapshot {
+        id: uuid::Uuid::new_v4(),
+        root: root.to_path_buf(),
+        query,
+        rows,
+        counts,
+        created: Instant::now(),
+        page_size,
+    })
+}
+
+fn page(snapshot: &Snapshot, offset: usize) -> LibraryPage {
+    let end = (offset + snapshot.page_size).min(snapshot.rows.len());
+    LibraryPage {
+        items: snapshot.rows[offset..end]
+            .iter()
+            .filter(|row| {
+                Path::new(&row.path).is_file()
+                    && wallpaper_source::is_path_under_dir(Path::new(&row.path), &snapshot.root)
+            })
+            .cloned()
+            .collect(),
+        next_cursor: (end < snapshot.rows.len()).then(|| format!("{}:{end}", snapshot.id)),
+        total: snapshot.rows.len(),
+        kind_counts: snapshot.counts.clone(),
+    }
+}
+
+pub(crate) fn list(
+    query: LibraryQuery,
+    cursor: Option<&str>,
+    limit: Option<u32>,
+) -> Result<LibraryPage, String> {
+    let root = wallpaper_source::wallpapers_root();
+    let query = query.normalize()?;
+    let limit = limit.unwrap_or(48);
+    if !(1..=96).contains(&limit) {
+        return Err("invalid_query".into());
+    }
+    let limit = limit as usize;
+    let snapshots = SNAPSHOTS.get_or_init(|| Mutex::new(LibrarySnapshots::default()));
+    let (snapshot, offset) = if let Some(cursor) = cursor {
+        snapshots.lock().resume(cursor, &root, &query, limit)?
+    } else {
+        let current = snapshot(&root, query, limit)?;
+        (snapshots.lock().insert(current), 0)
+    };
+    let result = page(&snapshot, offset);
+    for row in &result.items {
+        crate::path_scope::grant_path(Path::new(&row.path));
+    }
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn fixture() -> PathBuf {
+        let root = std::env::temp_dir().join(format!("grok-library-page-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(&root).unwrap();
+        for i in 0..251 {
+            fs::write(
+                root.join(format!(
+                    "item-{i:03}.{}",
+                    if i % 3 == 0 { "mp4" } else { "png" }
+                )),
+                b"fixture",
+            )
+            .unwrap();
+        }
+        fs::write(root.join(".catalog-preview.png"), b"internal").unwrap();
+        root
+    }
+
+    #[test]
+    fn full_snapshot_pages_without_repeats_and_filters_beyond_first_page() {
+        let root = fixture();
+        let query = LibraryQuery::default().normalize().unwrap();
+        let mut store = LibrarySnapshots::default();
+        let snapshot = store.insert(snapshot(&root, query.clone(), 48).unwrap());
+        let mut current = page(&snapshot, 0);
+        let mut paths = Vec::new();
+        loop {
+            paths.extend(current.items.into_iter().map(|e| e.path));
+            let Some(cursor) = current.next_cursor else {
+                break;
+            };
+            let (snapshot, offset) = store.resume(&cursor, &root, &query, 48).unwrap();
+            current = page(&snapshot, offset);
+        }
+        assert_eq!(paths.len(), 251);
+        paths.sort();
+        paths.dedup();
+        assert_eq!(paths.len(), 251);
+        let filtered = super::snapshot(
+            &root,
+            LibraryQuery {
+                query: "item-250".into(),
+                kind: "image".into(),
+                ..Default::default()
+            },
+            48,
+        )
+        .unwrap();
+        assert_eq!(page(&filtered, 0).items.len(), 1);
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn filters_saved_favorites_and_prompts_across_the_whole_library() {
+        let root = fixture();
+        let path = root.join("item-250.png");
+        image::RgbImage::new(40, 20).save(&path).unwrap();
+        let mut rows = vec![];
+        wallpaper_source::collect_library(&root, &root, &mut rows);
+        crate::wallpaper_catalog::hydrate(&root, &mut rows).unwrap();
+        let file = root.join(".catalog.json");
+        let mut catalog: serde_json::Value =
+            serde_json::from_slice(&fs::read(&file).unwrap()).unwrap();
+        catalog["records"]["item-250.png"]["favorite"] = true.into();
+        catalog["records"]["item-250.png"]["prompt"] = "Secret mountain dawn".into();
+        fs::write(&file, serde_json::to_vec(&catalog).unwrap()).unwrap();
+        let found = snapshot(
+            &root,
+            LibraryQuery {
+                query: "mountain".into(),
+                purpose: "favorites".into(),
+                ..Default::default()
+            },
+            48,
+        )
+        .unwrap();
+        assert_eq!(found.rows.len(), 1);
+        assert_eq!(found.rows[0].name, "item-250.png");
+        assert_eq!(found.rows[0].metadata.as_ref().unwrap().width, Some(40));
+        let empty = snapshot(
+            &root,
+            LibraryQuery {
+                purpose: "generated".into(),
+                ..Default::default()
+            },
+            48,
+        )
+        .unwrap();
+        assert!(empty.rows.is_empty());
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn snapshot_keeps_order_across_changes_and_rejects_mismatched_cursor() {
+        let root = fixture();
+        let query = LibraryQuery::default().normalize().unwrap();
+        let mut store = LibrarySnapshots::default();
+        let mut initial = snapshot(&root, query.clone(), 48).unwrap();
+        for row in &mut initial.rows {
+            row.modified_ms = 123;
+        }
+        initial.rows.sort_by(|a, b| a.path.cmp(&b.path));
+        let snapshot = store.insert(initial);
+        let first = page(&snapshot, 0);
+        let cursor = first.next_cursor.unwrap();
+        let removed = snapshot.rows[48].path.clone();
+        fs::remove_file(removed).unwrap();
+        fs::write(root.join("new.png"), b"new").unwrap();
+        let (same, offset) = store.resume(&cursor, &root, &query, 48).unwrap();
+        let next = page(&same, offset);
+        assert_eq!(next.items.len(), 47);
+        assert!(!next.items.iter().any(|row| row.name == "new.png"));
+        assert!(store.resume("bad", &root, &query, 48).is_err());
+        assert!(store.resume(&cursor, &root, &query, 24).is_err());
+        assert!(store
+            .resume(
+                &cursor,
+                &root,
+                &LibraryQuery {
+                    query: "new".into(),
+                    kind: "all".into(),
+                    ..Default::default()
+                },
+                48
+            )
+            .is_err());
+        assert_eq!(super::snapshot(&root, query, 48).unwrap().rows.len(), 251);
+        fs::remove_dir_all(root).unwrap();
+    }
+}

--- a/src-tauri/src/wallpaper_source.rs
+++ b/src-tauri/src/wallpaper_source.rs
@@ -288,6 +288,19 @@ pub struct WallpaperFetchResult {
     pub name: String,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum LocalWallpaperMediaKind {
+    Image,
+    Video,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct ValidatedLocalWallpaperMedia {
+    pub(crate) mime: &'static str,
+    pub(crate) extension: &'static str,
+    pub(crate) bytes: u64,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct WallpaperLibraryEntry {
@@ -297,6 +310,8 @@ pub struct WallpaperLibraryEntry {
     pub kind: String,
     pub bytes: u64,
     pub modified_ms: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<crate::wallpaper_catalog::MediaRecord>,
 }
 
 // ── Paths ───────────────────────────────────────────────────────────────────
@@ -1444,6 +1459,10 @@ impl DetectedMedia {
         )
     }
 
+    fn is_video(self) -> bool {
+        matches!(self, Self::Mp4 | Self::Webm)
+    }
+
     fn mime(self) -> &'static str {
         match self {
             Self::Jpeg => "image/jpeg",
@@ -2500,6 +2519,40 @@ pub(crate) fn validate_fetched_media_bytes(
     Ok((media.mime(), media.extension()))
 }
 
+pub(crate) fn validate_local_wallpaper_media(
+    path: &Path,
+    expected: LocalWallpaperMediaKind,
+) -> Result<ValidatedLocalWallpaperMedia, String> {
+    let metadata = fs::metadata(path).map_err(|_| "imagine_failed".to_string())?;
+    if !metadata.is_file() || metadata.len() == 0 || metadata.len() > MAX_DOWNLOAD_BYTES {
+        return Err("imagine_failed".into());
+    }
+
+    let mut prefix = Vec::with_capacity(
+        usize::try_from(metadata.len().min(MAX_IMAGE_PROBE_BYTES as u64)).unwrap_or_default(),
+    );
+    fs::File::open(path)
+        .and_then(|file| {
+            file.take(MAX_IMAGE_PROBE_BYTES as u64)
+                .read_to_end(&mut prefix)
+        })
+        .map_err(|_| "imagine_failed".to_string())?;
+    let media = detect_media_signature(&prefix).ok_or_else(|| "imagine_failed".to_string())?;
+    let kind_matches = match expected {
+        LocalWallpaperMediaKind::Image => media.is_image(),
+        LocalWallpaperMediaKind::Video => media.is_video(),
+    };
+    if !kind_matches {
+        return Err("imagine_failed".into());
+    }
+
+    Ok(ValidatedLocalWallpaperMedia {
+        mime: media.mime(),
+        extension: media.extension(),
+        bytes: metadata.len(),
+    })
+}
+
 fn file_to_fetch_result(path: &Path) -> Result<WallpaperFetchResult, String> {
     let meta = fs::metadata(path).map_err(|e| format!("stat: {e}"))?;
     let name = path
@@ -2755,13 +2808,35 @@ pub fn library_list(limit: Option<u32>) -> Result<Vec<WallpaperLibraryEntry>, St
     Ok(all)
 }
 
-fn collect_library(root: &Path, dir: &Path, out: &mut Vec<WallpaperLibraryEntry>) {
+fn is_library_media_extension(ext: &str) -> bool {
+    matches!(
+        ext,
+        "jpg" | "jpeg" | "png" | "webp" | "avif" | "gif" | "mp4" | "webm"
+    )
+}
+
+fn library_media_kind(ext: &str) -> &'static str {
+    if matches!(ext, "mp4" | "webm") {
+        "video"
+    } else {
+        "image"
+    }
+}
+
+pub(crate) fn collect_library(root: &Path, dir: &Path, out: &mut Vec<WallpaperLibraryEntry>) {
     let rd = match fs::read_dir(dir) {
         Ok(r) => r,
         Err(_) => return,
     };
     for e in rd.flatten() {
         let path = e.path();
+        // Do not expose catalog internals, follow links, or recurse outside the library.
+        if e.file_name().to_string_lossy().starts_with('.')
+            || e.file_type().is_ok_and(|kind| kind.is_symlink())
+            || !is_path_under_dir(&path, root)
+        {
+            continue;
+        }
         if path.is_dir() {
             collect_library(root, &path, out);
             continue;
@@ -2771,10 +2846,7 @@ fn collect_library(root: &Path, dir: &Path, out: &mut Vec<WallpaperLibraryEntry>
             .and_then(|s| s.to_str())
             .unwrap_or("")
             .to_ascii_lowercase();
-        if !matches!(
-            ext.as_str(),
-            "jpg" | "jpeg" | "png" | "webp" | "gif" | "mp4" | "webm"
-        ) {
+        if !is_library_media_extension(&ext) {
             continue;
         }
         let meta = match e.metadata() {
@@ -2799,11 +2871,7 @@ fn collect_library(root: &Path, dir: &Path, out: &mut Vec<WallpaperLibraryEntry>
             .and_then(|s| s.to_str())
             .unwrap_or("file")
             .to_string();
-        let kind = if matches!(ext.as_str(), "mp4" | "webm") {
-            "video"
-        } else {
-            "image"
-        };
+        let kind = library_media_kind(&ext);
         out.push(WallpaperLibraryEntry {
             path: path.display().to_string(),
             name,
@@ -2811,6 +2879,7 @@ fn collect_library(root: &Path, dir: &Path, out: &mut Vec<WallpaperLibraryEntry>
             kind: kind.into(),
             bytes: meta.len(),
             modified_ms,
+            metadata: None,
         });
     }
 }

--- a/src/components/WallpaperSourceModal.library.test.tsx
+++ b/src/components/WallpaperSourceModal.library.test.tsx
@@ -1,0 +1,195 @@
+/** @vitest-environment jsdom */
+import type { ReactNode } from "react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import "@/test/jsdomStubs";
+import type { WallpaperLibraryPage } from "@/lib/api/wallpaper";
+
+const mocks = vi.hoisted(() => ({
+  page: vi.fn(),
+  preview: vi.fn(),
+}));
+
+vi.mock("@/lib/api", () => ({
+  wallpaperLibraryPage: mocks.page,
+  wallpaperLibraryDelete: vi.fn(),
+  wallpaperRemoteSearch: vi.fn(),
+  wallpaperRemoteSearchMore: vi.fn(),
+  wallpaperRemoteSearchCancel: vi.fn(async () => true),
+  listenWallpaperRemoteSearchProgress: vi.fn(async () => () => {}),
+  listenWallpaperRemoteSearchBatch: vi.fn(async () => () => {}),
+  wallpaperRemoteCancelMediaRequests: vi.fn(async () => 0),
+  wallpaperGrokAlbumCancelRequests: vi.fn(async () => 0),
+  wallpaperGrokAlbumCancelAllRequests: vi.fn(async () => 0),
+  isDesktopHost: () => true,
+  isTauri: () => false,
+  settingsGet: vi.fn(async () => ({ wallpaperXSearchMode: "cli" })),
+  settingsSet: vi.fn(async () => ({})),
+  wallpaperXSearch: vi.fn(),
+  wallpaperXSearchMore: vi.fn(),
+  wallpaperXSearchCancel: vi.fn(async () => true),
+  listenWallpaperXSearchProgress: vi.fn(async () => () => {}),
+  listenWallpaperXSearchBatch: vi.fn(async () => () => {}),
+  wallpaperFetchMedia: vi.fn(),
+  wallpaperImagine: vi.fn(),
+  openExternalUrl: vi.fn(),
+}));
+
+vi.mock("@/components/ImageViewerContext", () => ({
+  useImageViewerOptional: () => ({ open: mocks.preview }),
+}));
+
+vi.mock("@/components/Select", () => ({
+  Select: ({
+    value,
+    options,
+    onChange,
+    "aria-label": ariaLabel,
+  }: {
+    value: string;
+    options: Array<{ value: string; label: string }>;
+    onChange: (value: string) => void;
+    "aria-label"?: string;
+  }) => (
+    <select
+      aria-label={ariaLabel}
+      value={value}
+      onChange={(event) => onChange(event.target.value)}
+    >
+      {options.map((option) => (
+        <option key={option.value} value={option.value}>
+          {option.label}
+        </option>
+      ))}
+    </select>
+  ),
+}));
+
+vi.mock("@/components/GlassModal", () => ({
+  GlassModal: ({
+    open,
+    children,
+    footer,
+  }: {
+    open: boolean;
+    children: ReactNode;
+    footer?: ReactNode;
+  }) => (open ? <div>{children}{footer}</div> : null),
+}));
+
+import { WallpaperSourceModal } from "./WallpaperSourceModal";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+function page(name: string, nextCursor: string | null = null): WallpaperLibraryPage {
+  return {
+    items: [
+      {
+        path: `C:/wallpapers/${name}.png`,
+        name,
+        source: "library",
+        kind: "image",
+        bytes: 100,
+        modifiedMs: 1,
+      },
+    ],
+    nextCursor,
+    total: 2,
+    kindCounts: { all: 2, image: 2, video: 0 },
+  };
+}
+
+const t = (key: string) => key;
+const cards = () =>
+  screen.getAllByRole("button", {
+    name: "settings.wallpaperSource.openPreview",
+  });
+
+function renderLibrary() {
+  return render(
+    <WallpaperSourceModal
+      open
+      initialTab="library"
+      t={t as never}
+      onClose={vi.fn()}
+      onPickFile={vi.fn()}
+    />,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("WallpaperSourceModal library paging", () => {
+  it("keeps loaded cards selectable while the next page is pending", async () => {
+    const pending = deferred<WallpaperLibraryPage>();
+    mocks.page
+      .mockResolvedValueOnce(page("first", "cursor-1"))
+      .mockReturnValueOnce(pending.promise);
+    renderLibrary();
+
+    const loadMore = await screen.findByRole("button", {
+      name: "settings.wallpaperSource.loadMore",
+    });
+    fireEvent.click(loadMore);
+    await waitFor(() => expect(mocks.page).toHaveBeenCalledTimes(2));
+
+    expect((cards()[0] as HTMLButtonElement).disabled).toBe(false);
+    fireEvent.click(cards()[0]);
+    await waitFor(() => expect(mocks.preview).toHaveBeenCalledTimes(1));
+
+    pending.resolve(page("second"));
+    await waitFor(() => expect(cards()).toHaveLength(2));
+  });
+
+  it("sends text, kind, and collection filters to the Host", async () => {
+    mocks.page.mockResolvedValue(page("result"));
+    renderLibrary();
+    await waitFor(() =>
+      expect(mocks.page).toHaveBeenCalledWith({ query: "", kind: "all" }),
+    );
+
+    fireEvent.change(
+      screen.getByPlaceholderText("settings.wallpaperSource.filterPlaceholder"),
+      { target: { value: "mountain" } },
+    );
+    await waitFor(() =>
+      expect(mocks.page).toHaveBeenCalledWith({
+        query: "mountain",
+        kind: "all",
+      }),
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /settings\.wallpaperSource\.kind\.image/,
+      }),
+    );
+    await waitFor(() =>
+      expect(mocks.page).toHaveBeenCalledWith({
+        query: "mountain",
+        kind: "image",
+      }),
+    );
+
+    fireEvent.change(
+      screen.getByLabelText("settings.wallpaperSource.library.collection"),
+      { target: { value: "favorites" } },
+    );
+    await waitFor(() =>
+      expect(mocks.page).toHaveBeenCalledWith({
+        query: "mountain",
+        kind: "image",
+        purpose: "favorites",
+      }),
+    );
+  });
+});

--- a/src/components/WallpaperSourceModal.tsx
+++ b/src/components/WallpaperSourceModal.tsx
@@ -13,6 +13,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useWallpaperProviderController } from "@/hooks/useWallpaperProviderController";
 import { useWallpaperGrokAlbum } from "@/hooks/useWallpaperGrokAlbum";
+import { useWallpaperLibrary } from "@/hooks/useWallpaperLibrary";
 import { createWallpaperRequestId } from "@/lib/wallpaperRequest";
 import { WallpaperProviderControls } from "./WallpaperProviderControls";
 import { GrokAlbumSourcePanel } from "./GrokAlbumSourcePanel";
@@ -22,6 +23,7 @@ import { WallpaperSourceTabs } from "./WallpaperSourceTabs";
 import { useWallpaperXSearch } from "@/hooks/useWallpaperXSearch";
 import { WallpaperXRouteControl } from "./WallpaperXRouteControl";
 import { GlassModal } from "@/components/GlassModal";
+import { Select } from "@/components/Select";
 import { WallpaperSourceControls } from "./WallpaperSourceControls";
 import { useImageViewerOptional } from "@/components/ImageViewerContext";
 import * as api from "@/lib/api";
@@ -31,10 +33,10 @@ import {
   appendWallpaperGalleryItems,
   errorCodeFromSearchResult,
   fileFromAbsolutePath,
-  libraryEntriesToGalleryItems,
   parseWallpaperSourceError,
   resolveApplySource,
   type WallpaperGalleryItem,
+  type WallpaperLibraryPurpose,
   type WallpaperSourceErrorCode,
 } from "@/lib/wallpaperSource";
 import {
@@ -150,6 +152,15 @@ export function WallpaperSourceModal({
   const [galleryFilter, setGalleryFilter] = useState("");
   const [kindFilter, setKindFilter] =
     useState<WallpaperGalleryKindFilter>("all");
+  const [libraryPurpose, setLibraryPurpose] =
+    useState<WallpaperLibraryPurpose>("all");
+  const library = useWallpaperLibrary(
+    open && tab === "library",
+    galleryFilter,
+    kindFilter,
+    open,
+    libraryPurpose,
+  );
   /** True after at least one search/generate finished this open. */
   const [hasSearched, setHasSearched] = useState(false);
   const [selectedId, setSelectedId] = useState<string | null>(null);
@@ -203,6 +214,7 @@ export function WallpaperSourceModal({
     xBusy ||
     routeSaving ||
     provider.busy ||
+    (tab === "library" && (library.busy || library.loadingMore)) ||
     (tab === "grok_album" && grokAlbum.busy);
   const close = useCallback(() => {
     void cancelX();
@@ -223,11 +235,27 @@ export function WallpaperSourceModal({
     setSelectedId(null);
     setPreviewingId(null);
     setGalleryFilter("");
-    setKindFilter(initialTab === "library" ? "image" : "all");
+    setKindFilter("all");
+    setLibraryPurpose("all");
     setHasSearched(false);
     setItems([]);
     setContinuation(null);
   }, [open, initialTab]);
+
+  useEffect(() => {
+    if (!open || tab !== "library") return;
+    setItems(library.items);
+    setHasSearched(library.hasLoaded);
+    setErrorCode(library.error);
+    setError(library.error ? errorMessage(t, library.error) : null);
+  }, [
+    open,
+    tab,
+    library.items,
+    library.hasLoaded,
+    library.error,
+    t,
+  ]);
 
   useEffect(() => {
     if (!open || tab !== "grok_album") return;
@@ -251,23 +279,28 @@ export function WallpaperSourceModal({
       ? progressiveItems
       : items;
   const kindCounts = useMemo(
-    () => countGalleryByKind(galleryItems),
-    [galleryItems],
+    () =>
+      tab === "library" ? library.kindCounts : countGalleryByKind(galleryItems),
+    [galleryItems, library.kindCounts, tab],
   );
 
   const visibleItems = useMemo(
     () =>
-      filterGalleryItems(galleryItems, {
-        query: galleryFilter,
-        kind: kindFilter,
-      }),
-    [galleryItems, galleryFilter, kindFilter],
+      tab === "library"
+        ? galleryItems
+        : filterGalleryItems(galleryItems, {
+            query: galleryFilter,
+            kind: kindFilter,
+          }),
+    [galleryItems, galleryFilter, kindFilter, tab],
   );
 
-  const filtersActive = wallpaperGalleryHasActiveFilters({
-    query: galleryFilter,
-    kind: kindFilter,
-  });
+  const filtersActive =
+    wallpaperGalleryHasActiveFilters({
+      query: galleryFilter,
+      kind: kindFilter,
+    }) ||
+    (tab === "library" && libraryPurpose !== "all");
 
   const emptyState = useMemo(() => {
     const base = resolveWallpaperGalleryEmptyState({
@@ -324,6 +357,7 @@ export function WallpaperSourceModal({
   const clearGalleryFilters = useCallback(() => {
     setGalleryFilter("");
     setKindFilter("all");
+    setLibraryPurpose("all");
   }, []);
 
   const changeTab = useCallback((nextTab: WallpaperSourceTab) => {
@@ -341,7 +375,8 @@ export function WallpaperSourceModal({
     setCiteSummary(null);
     setContinuation(null);
     setGalleryFilter("");
-    setKindFilter(nextTab === "library" ? "image" : "all");
+    setKindFilter("all");
+    if (nextTab === "library") setLibraryPurpose("all");
   }, [provider.cancel, tab]);
 
   const selected = useMemo(
@@ -493,44 +528,8 @@ export function WallpaperSourceModal({
   }, []);
 
   const loadLibrary = useCallback(async () => {
-    if (!isDesktopHost()) {
-      setErrorCode("generic");
-      setError(t("settings.wallpaperSource.err.desktopOnly"));
-      return;
-    }
-    setBusy(true);
-    setError(null);
-    setErrorCode(null);
-    setStatusHint(t("settings.wallpaperSource.libraryLoading"));
-    setSelectedId(null);
-    setGalleryFilter("");
-    // Static first: default kind chip to images (video still available via chip).
-    setKindFilter("image");
-    try {
-      const entries = await api.wallpaperLibraryList(96);
-      const list = libraryEntriesToGalleryItems(entries, { staticFirst: true });
-      setHasSearched(true);
-      setItems(list);
-      setError(null);
-      setErrorCode(null);
-    } catch (e) {
-      setHasSearched(true);
-      setItems([]);
-      const code = parseWallpaperSourceError(e);
-      setErrorCode(code);
-      setError(errorMessage(t, code));
-    } finally {
-      setBusy(false);
-      setStatusHint(null);
-    }
-  }, [t]);
-
-  useEffect(() => {
-    if (!open || tab !== "library") return;
-    void loadLibrary();
-    // loadLibrary is stable on `t`; re-run when opening library tab.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open, tab]);
+    library.refresh();
+  }, [library.refresh]);
 
   /**
    * Soft-delete a library file. Failures keep the card and show a soft warn —
@@ -562,6 +561,7 @@ export function WallpaperSourceModal({
       setStatusHint(t("settings.wallpaperSource.deleting"));
       try {
         await api.wallpaperLibraryDelete(path);
+        library.remove(item.id);
         dropItem(item.id);
         setError(null);
         setErrorCode(null);
@@ -577,7 +577,7 @@ export function WallpaperSourceModal({
         setStatusHint(null);
       }
     },
-    [busy, applying, previewingId, t, dropItem],
+    [busy, applying, previewingId, t, dropItem, library.remove],
   );
 
   /**
@@ -767,7 +767,8 @@ export function WallpaperSourceModal({
     (xBusy && !loadingMore) ||
     applying ||
     previewingId !== null;
-  const showGalleryFilters = galleryItems.length > 0 || filtersActive;
+  const showGalleryFilters =
+    tab === "library" || galleryItems.length > 0 || filtersActive;
   const softFailError =
     galleryErrorKind != null && isWallpaperGallerySoftFail(galleryErrorKind);
   // Error banner already carries detail for empty/error — avoid stacking the
@@ -956,7 +957,33 @@ export function WallpaperSourceModal({
           ) : null}
 
           {showGalleryFilters ? (
-            <div className="wallpaper-source-filters">
+            <div
+              className={
+                "wallpaper-source-filters" +
+                (tab === "library" ? " wallpaper-library-toolbar" : "")
+              }
+            >
+              {tab === "library" ? (
+                <Select
+                  className="wallpaper-library-toolbar__collection"
+                  value={libraryPurpose}
+                  options={(
+                    ["all", "favorites", "generated", "cache"] as const
+                  ).map((value) => ({
+                    value,
+                    label: t(
+                      `settings.wallpaperSource.library.${value}` as MessageKey,
+                    ),
+                  }))}
+                  onChange={(value) =>
+                    setLibraryPurpose(value as WallpaperLibraryPurpose)
+                  }
+                  aria-label={t(
+                    "settings.wallpaperSource.library.collection" as MessageKey,
+                  )}
+                  disabled={locked}
+                />
+              ) : null}
               <div
                 className="wallpaper-source-chips"
                 role="toolbar"
@@ -1057,6 +1084,22 @@ export function WallpaperSourceModal({
             >
               {t(
                 grokAlbum.loadingMore
+                  ? "settings.wallpaperSource.remote.progress.loadingMore"
+                  : "settings.wallpaperSource.loadMore",
+              )}
+            </button>
+          ) : null}
+          {tab === "library" && library.canLoadMore ? (
+            <button
+              type="button"
+              className="btn btn--ghost"
+              disabled={library.loadingMore || applying}
+              onClick={() => {
+                void library.loadMore();
+              }}
+            >
+              {t(
+                library.loadingMore
                   ? "settings.wallpaperSource.remote.progress.loadingMore"
                   : "settings.wallpaperSource.loadMore",
               )}

--- a/src/hooks/useWallpaperLibrary.test.tsx
+++ b/src/hooks/useWallpaperLibrary.test.tsx
@@ -1,0 +1,317 @@
+/** @vitest-environment jsdom */
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { WallpaperLibraryPage } from "@/lib/api/wallpaper";
+import type { WallpaperMediaRecord } from "@/lib/wallpaperSource";
+import { useWallpaperLibrary } from "./useWallpaperLibrary";
+
+const fetchPage = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/api", () => ({ wallpaperLibraryPage: fetchPage }));
+
+afterEach(() => {
+  cleanup();
+  vi.resetAllMocks();
+  vi.useRealTimers();
+});
+
+function page(
+  name: string,
+  nextCursor: string | null = null,
+): WallpaperLibraryPage {
+  return {
+    items: [
+      {
+        path: `/wallpapers/${name}.png`,
+        name,
+        source: "library",
+        kind: "image",
+        bytes: 100,
+        modifiedMs: 1,
+      },
+    ],
+    nextCursor,
+    total: 251,
+    kindCounts: { all: 251, image: 251, video: 0 },
+  };
+}
+
+function metadata(id: string, favorite: boolean): WallpaperMediaRecord {
+  return {
+    id,
+    source: "library",
+    sourceUrl: null,
+    license: null,
+    licenseUrl: null,
+    title: null,
+    width: null,
+    height: null,
+    prompt: null,
+    generation: null,
+    parentId: null,
+    favorite,
+    purpose: "cache",
+    bytes: 100,
+    modifiedMs: 1,
+  };
+}
+
+describe("useWallpaperLibrary", () => {
+  it.each([false, true])(
+    "keeps favorite edits when a pending page settles (failure: %s)",
+    async (fails) => {
+      let resolve!: (value: WallpaperLibraryPage) => void;
+      let reject!: (reason: Error) => void;
+      fetchPage
+        .mockResolvedValueOnce(page("first", "cursor-1"))
+        .mockReturnValueOnce(
+          new Promise<WallpaperLibraryPage>((done, fail) => {
+            resolve = done;
+            reject = fail;
+          }),
+        );
+      const { result } = renderHook(() =>
+        useWallpaperLibrary(true, "", "all"),
+      );
+      await waitFor(() => expect(result.current.canLoadMore).toBe(true));
+
+      let pending!: Promise<void>;
+      act(() => {
+        pending = result.current.loadMore();
+      });
+      act(() =>
+        result.current.updateItem({
+          ...result.current.items[0],
+          metadata: metadata("first", true),
+        }),
+      );
+      await act(async () => {
+        if (fails) reject(new Error("timeout"));
+        else resolve(page("second"));
+        await pending;
+      });
+
+      expect(result.current.items[0].metadata?.favorite).toBe(true);
+      expect(result.current.items).toHaveLength(fails ? 1 : 2);
+      expect(result.current.error).toBe(fails ? "timeout" : null);
+    },
+  );
+
+  it("keeps visible rows after expiry and renews the snapshot before paging", async () => {
+    vi.useFakeTimers();
+    fetchPage
+      .mockResolvedValueOnce(page("first", "expired-cursor"))
+      .mockResolvedValueOnce(page("fresh"));
+    const { result, rerender } = renderHook(() =>
+      useWallpaperLibrary(true, "", "all"),
+    );
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(21 * 60_000);
+    });
+    rerender();
+    expect(result.current.items[0].textPreview).toBe("first");
+    await act(async () => {
+      await result.current.loadMore();
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(result.current.items[0].textPreview).toBe("fresh");
+    expect(fetchPage.mock.calls).toEqual([
+      [{ query: "", kind: "all" }],
+      [{ query: "", kind: "all" }],
+    ]);
+  });
+
+  it("resumes loaded pages and retries an interrupted page after returning", async () => {
+    let resolve!: (value: WallpaperLibraryPage) => void;
+    fetchPage
+      .mockResolvedValueOnce(page("first", "cursor-1"))
+      .mockResolvedValueOnce(page("second", "cursor-2"))
+      .mockReturnValueOnce(
+        new Promise<WallpaperLibraryPage>((done) => {
+          resolve = done;
+        }),
+      )
+      .mockResolvedValueOnce(page("third"));
+    const { result, rerender } = renderHook(
+      ({ enabled }) => useWallpaperLibrary(enabled, "", "all"),
+      { initialProps: { enabled: true } },
+    );
+    await waitFor(() => expect(result.current.canLoadMore).toBe(true));
+    await act(async () => result.current.loadMore());
+
+    let pending!: Promise<void>;
+    act(() => {
+      pending = result.current.loadMore();
+    });
+    rerender({ enabled: false });
+    await act(async () => {
+      resolve(page("stale"));
+      await pending;
+    });
+    rerender({ enabled: true });
+
+    expect(result.current.loadingMore).toBe(false);
+    expect(result.current.items.map((item) => item.textPreview)).toEqual([
+      "first",
+      "second",
+    ]);
+    expect(fetchPage).toHaveBeenCalledTimes(3);
+    await act(async () => result.current.loadMore());
+    expect(fetchPage).toHaveBeenLastCalledWith(
+      { query: "", kind: "all" },
+      "cursor-2",
+    );
+    expect(result.current.items.map((item) => item.textPreview)).toEqual([
+      "first",
+      "second",
+      "third",
+    ]);
+  });
+
+  it("isolates filters, removes cached items, and clears history on close", async () => {
+    fetchPage
+      .mockResolvedValueOnce(page("first"))
+      .mockResolvedValueOnce(page("filtered"))
+      .mockResolvedValueOnce(page("reopened"));
+    const { result, rerender } = renderHook(
+      ({ query, open }) => useWallpaperLibrary(open, query, "all", open),
+      { initialProps: { query: "", open: true } },
+    );
+    await waitFor(() => expect(result.current.items).toHaveLength(1));
+    const removedId = result.current.items[0].id;
+
+    rerender({ query: "filtered", open: true });
+    await waitFor(() =>
+      expect(result.current.items[0]?.textPreview).toBe("filtered"),
+    );
+    act(() => result.current.remove(removedId));
+    rerender({ query: "", open: true });
+    expect(result.current.items).toHaveLength(0);
+    expect(fetchPage).toHaveBeenCalledTimes(2);
+
+    rerender({ query: "", open: false });
+    rerender({ query: "", open: true });
+    await waitFor(() =>
+      expect(result.current.items[0]?.textPreview).toBe("reopened"),
+    );
+    expect(fetchPage).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not renew snapshot age when appending", async () => {
+    vi.useFakeTimers();
+    fetchPage
+      .mockResolvedValueOnce(page("first", "cursor-1"))
+      .mockResolvedValueOnce(page("second"))
+      .mockResolvedValueOnce(page("fresh"));
+    const { result, rerender } = renderHook(
+      ({ enabled }) => useWallpaperLibrary(enabled, "", "all"),
+      { initialProps: { enabled: true } },
+    );
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(19 * 60_000);
+      await result.current.loadMore();
+    });
+    rerender({ enabled: false });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2 * 60_000);
+    });
+    rerender({ enabled: true });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(result.current.items[0].textPreview).toBe("fresh");
+    expect(fetchPage).toHaveBeenCalledTimes(3);
+  });
+
+  it("appends in host order and retries only the failed page", async () => {
+    fetchPage
+      .mockResolvedValueOnce(page("first", "cursor-1"))
+      .mockRejectedValueOnce(new Error("timeout"))
+      .mockResolvedValueOnce(page("older"));
+    const { result } = renderHook(() =>
+      useWallpaperLibrary(true, "", "all"),
+    );
+    await waitFor(() => expect(result.current.items).toHaveLength(1));
+
+    await act(async () => result.current.loadMore());
+    expect(result.current.error).toBe("timeout");
+    expect(result.current.items[0].textPreview).toBe("first");
+    expect(result.current.canLoadMore).toBe(true);
+    await act(async () => result.current.loadMore());
+
+    expect(result.current.items.map((item) => item.textPreview)).toEqual([
+      "first",
+      "older",
+    ]);
+    expect(fetchPage.mock.calls.slice(1)).toEqual([
+      [{ query: "", kind: "all" }, "cursor-1"],
+      [{ query: "", kind: "all" }, "cursor-1"],
+    ]);
+  });
+
+  it("queries the complete collection and ignores a previous late response", async () => {
+    let resolve!: (value: WallpaperLibraryPage) => void;
+    fetchPage
+      .mockReturnValueOnce(
+        new Promise<WallpaperLibraryPage>((done) => {
+          resolve = done;
+        }),
+      )
+      .mockResolvedValueOnce(page("found-old-file"));
+    const { result, rerender } = renderHook(
+      ({ query }) => useWallpaperLibrary(true, query, "all"),
+      { initialProps: { query: "" } },
+    );
+    await waitFor(() => expect(fetchPage).toHaveBeenCalledOnce());
+
+    rerender({ query: "old-file" });
+    await waitFor(() =>
+      expect(result.current.items[0]?.textPreview).toBe("found-old-file"),
+    );
+    await act(async () => resolve(page("stale")));
+
+    expect(result.current.items[0].textPreview).toBe("found-old-file");
+    expect(fetchPage).toHaveBeenLastCalledWith({
+      query: "old-file",
+      kind: "all",
+    });
+  });
+
+  it("invalidates an in-flight page on source switch", async () => {
+    let resolve!: (value: WallpaperLibraryPage) => void;
+    fetchPage
+      .mockResolvedValueOnce(page("first", "cursor-1"))
+      .mockReturnValueOnce(
+        new Promise<WallpaperLibraryPage>((done) => {
+          resolve = done;
+        }),
+      );
+    const { result, rerender } = renderHook(
+      ({ enabled }) => useWallpaperLibrary(enabled, "", "all"),
+      { initialProps: { enabled: true } },
+    );
+    await waitFor(() => expect(result.current.canLoadMore).toBe(true));
+
+    let pending!: Promise<void>;
+    act(() => {
+      pending = result.current.loadMore();
+    });
+    rerender({ enabled: false });
+    await act(async () => {
+      resolve(page("late"));
+      await pending;
+    });
+
+    expect(result.current.items.map((item) => item.textPreview)).toEqual([
+      "first",
+    ]);
+  });
+});

--- a/src/hooks/useWallpaperLibrary.ts
+++ b/src/hooks/useWallpaperLibrary.ts
@@ -1,0 +1,283 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { wallpaperLibraryPage, type WallpaperLibraryPage } from "@/lib/api";
+import {
+  libraryEntriesToGalleryItems,
+  parseWallpaperSourceError,
+  type WallpaperGalleryItem,
+  type WallpaperLibraryPurpose,
+  type WallpaperSourceErrorCode,
+} from "@/lib/wallpaperSource";
+
+type State = {
+  items: WallpaperGalleryItem[];
+  page: WallpaperLibraryPage | null;
+  busy: boolean;
+  loadingMore: boolean;
+  hasLoaded: boolean;
+  error: WallpaperSourceErrorCode | null;
+};
+
+type Entry = { key: string; created: number; value: State };
+
+const emptyState: State = {
+  items: [],
+  page: null,
+  busy: false,
+  loadingMore: false,
+  hasLoaded: false,
+  error: null,
+};
+
+// Expire before the Host's snapshot; appending must not renew its age.
+const CACHE_TTL = 20 * 60 * 1000;
+const MAX_CACHED_QUERIES = 8;
+const MAX_CACHED_ITEMS = 2_000;
+
+export function useWallpaperLibrary(
+  enabled: boolean,
+  query: string,
+  kind: "all" | "image" | "video",
+  open = true,
+  purpose: WallpaperLibraryPurpose = "all",
+) {
+  const [entry, setEntry] = useState<Entry | null>(null);
+  const entryRef = useRef<Entry | null>(null);
+  const replaceEntry = useCallback((next: Entry | null) => {
+    entryRef.current = next;
+    setEntry(next);
+  }, []);
+  const [revision, setRevision] = useState(0);
+  const cache = useRef(new Map<string, Entry>());
+  const generation = useRef(0);
+  const loading = useRef(false);
+  const normalizedQuery = query.trim();
+  const key = JSON.stringify([normalizedQuery, kind, purpose]);
+  const candidate = entry?.key === key ? entry : cache.current.get(key);
+  // Expiry fences future paging/restoration; it must not erase visible rows
+  // during an unrelated render while the user is inspecting the library.
+  const currentEntry = candidate;
+  const state = open ? currentEntry?.value ?? emptyState : emptyState;
+
+  const publish = useCallback(
+    (next: Entry) => {
+      cache.current.delete(next.key);
+      if (
+        next.value.hasLoaded &&
+        next.value.page &&
+        next.value.items.length <= MAX_CACHED_ITEMS
+      ) {
+        while (cache.current.size >= MAX_CACHED_QUERIES) {
+          const oldest = cache.current.keys().next().value;
+          if (oldest !== undefined) cache.current.delete(oldest);
+        }
+        cache.current.set(next.key, next);
+      }
+      replaceEntry(next);
+    },
+    [replaceEntry],
+  );
+
+  useEffect(() => {
+    const current = ++generation.current;
+    loading.current = false;
+    if (!open) {
+      cache.current.clear();
+      replaceEntry(null);
+      return;
+    }
+    if (!enabled) return;
+    const saved = cache.current.get(key);
+    if (saved && Date.now() - saved.created < CACHE_TTL) {
+      publish({
+        ...saved,
+        value: { ...saved.value, busy: false, loadingMore: false },
+      });
+      return;
+    }
+    cache.current.delete(key);
+    const created = Date.now();
+    replaceEntry({ key, created, value: { ...emptyState, busy: true } });
+    loading.current = true;
+    const timer = setTimeout(() => {
+      void wallpaperLibraryPage({
+        query: normalizedQuery,
+        kind,
+        ...(purpose !== "all" ? { purpose } : {}),
+      })
+        .then((page) => {
+          if (current !== generation.current) return;
+          publish({
+            key,
+            created,
+            value: {
+              items: libraryEntriesToGalleryItems(page.items, {
+                staticFirst: false,
+              }),
+              page,
+              busy: false,
+              loadingMore: false,
+              hasLoaded: true,
+              error: null,
+            },
+          });
+        })
+        .catch((error) => {
+          if (current !== generation.current) return;
+          publish({
+            key,
+            created,
+            value: {
+              ...emptyState,
+              hasLoaded: true,
+              error: parseWallpaperSourceError(error),
+            },
+          });
+        })
+        .finally(() => {
+          if (current === generation.current) loading.current = false;
+        });
+    }, normalizedQuery ? 180 : 0);
+    return () => {
+      clearTimeout(timer);
+      generation.current += 1;
+      loading.current = false;
+    };
+  }, [
+    enabled,
+    open,
+    normalizedQuery,
+    kind,
+    purpose,
+    key,
+    revision,
+    publish,
+    replaceEntry,
+  ]);
+
+  const refresh = useCallback(() => {
+    cache.current.clear();
+    generation.current += 1;
+    replaceEntry(null);
+    setRevision((value) => value + 1);
+  }, [replaceEntry]);
+
+  const loadMore = useCallback(async () => {
+    const cursor = currentEntry?.value.page?.nextCursor;
+    if (!enabled || !open || !cursor || !currentEntry || loading.current) return;
+    if (Date.now() - currentEntry.created >= CACHE_TTL) {
+      refresh();
+      return;
+    }
+    loading.current = true;
+    const current = generation.current;
+    const previous = currentEntry;
+    replaceEntry({
+      ...previous,
+      value: { ...previous.value, loadingMore: true, error: null },
+    });
+    try {
+      const page = await wallpaperLibraryPage(
+        {
+          query: normalizedQuery,
+          kind,
+          ...(purpose !== "all" ? { purpose } : {}),
+        },
+        cursor,
+      );
+      if (current !== generation.current) return;
+      // Favorite/delete actions remain available while paging. Merge into the
+      // current rows so a late page cannot undo a completed local mutation.
+      const latest = entryRef.current ?? previous;
+      publish({
+        ...latest,
+        value: {
+          ...latest.value,
+          items: [
+            ...latest.value.items,
+            ...libraryEntriesToGalleryItems(page.items, { staticFirst: false }),
+          ],
+          page,
+          error: null,
+          loadingMore: false,
+        },
+      });
+    } catch (error) {
+      if (current !== generation.current) return;
+      const latest = entryRef.current ?? previous;
+      publish({
+        ...latest,
+        value: {
+          ...latest.value,
+          loadingMore: false,
+          error: parseWallpaperSourceError(error),
+        },
+      });
+    } finally {
+      if (current === generation.current) loading.current = false;
+    }
+  }, [
+    enabled,
+    open,
+    currentEntry,
+    normalizedQuery,
+    kind,
+    purpose,
+    publish,
+    refresh,
+    replaceEntry,
+  ]);
+
+  const remove = useCallback(
+    (id: string) => {
+      const withoutItem = (previous: Entry): Entry => ({
+        ...previous,
+        value: {
+          ...previous.value,
+          items: previous.value.items.filter((item) => item.id !== id),
+        },
+      });
+      for (const [cachedKey, previous] of cache.current) {
+        cache.current.set(cachedKey, withoutItem(previous));
+      }
+      replaceEntry(entryRef.current ? withoutItem(entryRef.current) : null);
+    },
+    [replaceEntry],
+  );
+
+  const updateItem = useCallback(
+    (item: WallpaperGalleryItem) => {
+      const patchEntry = (previous: Entry): Entry => ({
+        ...previous,
+        value: {
+          ...previous.value,
+          items: previous.value.items.flatMap((row) => {
+            if (row.localPath !== item.localPath) return [row];
+            if (
+              JSON.parse(previous.key)[2] === "favorites" &&
+              !item.metadata?.favorite
+            ) {
+              return [];
+            }
+            return [{ ...row, metadata: item.metadata }];
+          }),
+        },
+      });
+      // A new favorite/download can affect views which have not loaded that row.
+      cache.current.clear();
+      replaceEntry(entryRef.current ? patchEntry(entryRef.current) : null);
+    },
+    [replaceEntry],
+  );
+
+  return {
+    ...state,
+    busy: enabled && state.busy,
+    loadingMore: enabled && state.loadingMore,
+    kindCounts: state.page?.kindCounts ?? { all: 0, image: 0, video: 0 },
+    canLoadMore: !!state.page?.nextCursor,
+    loadMore,
+    refresh,
+    remove,
+    updateItem,
+  };
+}

--- a/src/i18n/messages/de/settings-ui.ts
+++ b/src/i18n/messages/de/settings-ui.ts
@@ -1,5 +1,10 @@
 /** de messages — domain: settings-ui */
 export const deSettingsUi = {
+  "settings.wallpaperSource.library.collection": "Sammlung",
+  "settings.wallpaperSource.library.all": "Alle Medien",
+  "settings.wallpaperSource.library.favorites": "Favoriten",
+  "settings.wallpaperSource.library.generated": "Generiert",
+  "settings.wallpaperSource.library.cache": "Browser-Cache",
   "settings.wallpaperXSearchMode": "X-Suchroute",
   "settings.wallpaperXSearchModeDesc": "Legt fest, wie die Suche auf X ausgeführt wird. Die Responses-Vorschau verwendet die bestehende Grok-Build-Anmeldung am fest vorgegebenen offiziellen Kompatibilitätsendpunkt. Sie kann sich ändern und fällt, wenn sicher, auf die CLI zurück; bei Limits wird keine zweite Suche gestartet.",
   "settings.wallpaperXSearchMode.cli": "Grok Build CLI (stabil)",

--- a/src/i18n/messages/en/settings-ui.ts
+++ b/src/i18n/messages/en/settings-ui.ts
@@ -1,5 +1,10 @@
 /** English messages — domain: settings-ui */
 export const enSettingsUi = {
+  "settings.wallpaperSource.library.collection": "Collection",
+  "settings.wallpaperSource.library.all": "All media",
+  "settings.wallpaperSource.library.favorites": "Favorites",
+  "settings.wallpaperSource.library.generated": "Generated",
+  "settings.wallpaperSource.library.cache": "Browsing cache",
   "settings.wallpaperXSearchMode": "X search route",
   "settings.wallpaperXSearchModeDesc": "Choose how Search on X runs. Responses preview uses your existing Grok Build sign-in with the fixed official compatibility endpoint. It may change and falls back to the CLI when safe; rate limits never start a second search.",
   "settings.wallpaperXSearchMode.cli": "Grok Build CLI (stable)",

--- a/src/i18n/messages/es/settings-ui.ts
+++ b/src/i18n/messages/es/settings-ui.ts
@@ -1,5 +1,10 @@
 /** es messages — domain: settings-ui */
 export const esSettingsUi = {
+  "settings.wallpaperSource.library.collection": "Colección",
+  "settings.wallpaperSource.library.all": "Todos los medios",
+  "settings.wallpaperSource.library.favorites": "Favoritos",
+  "settings.wallpaperSource.library.generated": "Generados",
+  "settings.wallpaperSource.library.cache": "Caché de navegación",
   "settings.wallpaperXSearchMode": "Ruta de búsqueda en X",
   "settings.wallpaperXSearchModeDesc": "Elige cómo se ejecuta Buscar en X. La vista previa de Responses usa tu inicio de sesión actual de Grok Build con el endpoint oficial de compatibilidad fijado. Puede cambiar y vuelve a la CLI cuando es seguro; los límites no inician una segunda búsqueda.",
   "settings.wallpaperXSearchMode.cli": "Grok Build CLI (estable)",

--- a/src/i18n/messages/fil/settings-ui.ts
+++ b/src/i18n/messages/fil/settings-ui.ts
@@ -1,5 +1,10 @@
 /** fil messages — domain: settings-ui */
 export const filSettingsUi = {
+  "settings.wallpaperSource.library.collection": "Koleksiyon",
+  "settings.wallpaperSource.library.all": "Lahat ng media",
+  "settings.wallpaperSource.library.favorites": "Mga paborito",
+  "settings.wallpaperSource.library.generated": "Mga nilikha",
+  "settings.wallpaperSource.library.cache": "Cache ng pag-browse",
   "settings.wallpaperXSearchMode": "Ruta ng paghahanap sa X",
   "settings.wallpaperXSearchModeDesc": "Piliin kung paano tatakbo ang Search on X. Ginagamit ng Responses preview ang kasalukuyang Grok Build sign-in sa nakapirming opisyal na compatibility endpoint. Maaari itong magbago at babalik sa CLI kapag ligtas; hindi magsisimula ng ikalawang search kapag rate-limited.",
   "settings.wallpaperXSearchMode.cli": "Grok Build CLI (stable)",

--- a/src/i18n/messages/fr/settings-ui.ts
+++ b/src/i18n/messages/fr/settings-ui.ts
@@ -1,5 +1,10 @@
 /** fr messages — domain: settings-ui */
 export const frSettingsUi = {
+  "settings.wallpaperSource.library.collection": "Collection",
+  "settings.wallpaperSource.library.all": "Tous les médias",
+  "settings.wallpaperSource.library.favorites": "Favoris",
+  "settings.wallpaperSource.library.generated": "Créations",
+  "settings.wallpaperSource.library.cache": "Cache de navigation",
   "settings.wallpaperXSearchMode": "Route de recherche X",
   "settings.wallpaperXSearchModeDesc": "Choisissez comment la recherche sur X s’exécute. L’aperçu Responses utilise votre connexion Grok Build existante avec le point de compatibilité officiel fixe. Il peut évoluer et revient à la CLI lorsque c’est sûr ; une limitation ne lance jamais une seconde recherche.",
   "settings.wallpaperXSearchMode.cli": "Grok Build CLI (stable)",

--- a/src/i18n/messages/id/settings-ui.ts
+++ b/src/i18n/messages/id/settings-ui.ts
@@ -1,5 +1,10 @@
 /** id messages — domain: settings-ui */
 export const idSettingsUi = {
+  "settings.wallpaperSource.library.collection": "Koleksi",
+  "settings.wallpaperSource.library.all": "Semua media",
+  "settings.wallpaperSource.library.favorites": "Favorit",
+  "settings.wallpaperSource.library.generated": "Hasil pembuatan",
+  "settings.wallpaperSource.library.cache": "Cache penelusuran",
   "settings.wallpaperXSearchMode": "Rute pencarian X",
   "settings.wallpaperXSearchModeDesc": "Pilih cara Pencarian di X dijalankan. Pratinjau Responses memakai login Grok Build yang ada pada endpoint kompatibilitas resmi yang tetap. Fitur ini dapat berubah dan kembali ke CLI jika aman; pembatasan tidak memulai pencarian kedua.",
   "settings.wallpaperXSearchMode.cli": "Grok Build CLI (stabil)",

--- a/src/i18n/messages/it/settings-ui.ts
+++ b/src/i18n/messages/it/settings-ui.ts
@@ -1,5 +1,10 @@
 /** it messages — domain: settings-ui */
 export const itSettingsUi = {
+  "settings.wallpaperSource.library.collection": "Raccolta",
+  "settings.wallpaperSource.library.all": "Tutti i contenuti",
+  "settings.wallpaperSource.library.favorites": "Preferiti",
+  "settings.wallpaperSource.library.generated": "Generati",
+  "settings.wallpaperSource.library.cache": "Cache di navigazione",
   "settings.wallpaperXSearchMode": "Percorso di ricerca X",
   "settings.wallpaperXSearchModeDesc": "Scegli come eseguire la ricerca su X. L’anteprima Responses usa l’accesso Grok Build esistente con l’endpoint ufficiale di compatibilità fisso. Può cambiare e torna alla CLI quando è sicuro; i limiti non avviano una seconda ricerca.",
   "settings.wallpaperXSearchMode.cli": "Grok Build CLI (stabile)",

--- a/src/i18n/messages/ja/settings-ui.ts
+++ b/src/i18n/messages/ja/settings-ui.ts
@@ -1,5 +1,10 @@
 /** ja messages — domain: settings-ui */
 export const jaSettingsUi = {
+  "settings.wallpaperSource.library.collection": "コレクション",
+  "settings.wallpaperSource.library.all": "すべてのメディア",
+  "settings.wallpaperSource.library.favorites": "お気に入り",
+  "settings.wallpaperSource.library.generated": "生成作品",
+  "settings.wallpaperSource.library.cache": "閲覧キャッシュ",
   "settings.wallpaperXSearchMode": "X 検索ルート",
   "settings.wallpaperXSearchModeDesc": "X 検索の実行方法を選びます。Responses プレビューは、既存の Grok Build ログインを固定の公式互換エンドポイントで使用します。仕様は変更される可能性があり、安全な場合は CLI にフォールバックします。レート制限時に 2 回目の検索は行いません。",
   "settings.wallpaperXSearchMode.cli": "Grok Build CLI（安定版）",

--- a/src/i18n/messages/ko/settings-ui.ts
+++ b/src/i18n/messages/ko/settings-ui.ts
@@ -1,5 +1,10 @@
 /** ko messages — domain: settings-ui */
 export const koSettingsUi = {
+  "settings.wallpaperSource.library.collection": "컬렉션",
+  "settings.wallpaperSource.library.all": "모든 미디어",
+  "settings.wallpaperSource.library.favorites": "즐겨찾기",
+  "settings.wallpaperSource.library.generated": "생성 작품",
+  "settings.wallpaperSource.library.cache": "탐색 캐시",
   "settings.wallpaperXSearchMode": "X 검색 경로",
   "settings.wallpaperXSearchModeDesc": "X 검색 실행 방식을 선택합니다. Responses 미리보기는 기존 Grok Build 로그인을 고정된 공식 호환 엔드포인트에서 사용합니다. 동작이 바뀔 수 있으며 안전할 때 CLI로 대체합니다. 요청 제한 시 두 번째 검색은 시작하지 않습니다.",
   "settings.wallpaperXSearchMode.cli": "Grok Build CLI(안정)",

--- a/src/i18n/messages/pt-BR/settings-ui.ts
+++ b/src/i18n/messages/pt-BR/settings-ui.ts
@@ -1,5 +1,10 @@
 /** pt-BR messages — domain: settings-ui */
 export const ptBRSettingsUi = {
+  "settings.wallpaperSource.library.collection": "Coleção",
+  "settings.wallpaperSource.library.all": "Todas as mídias",
+  "settings.wallpaperSource.library.favorites": "Favoritos",
+  "settings.wallpaperSource.library.generated": "Criações",
+  "settings.wallpaperSource.library.cache": "Cache de navegação",
   "settings.wallpaperXSearchMode": "Rota de pesquisa no X",
   "settings.wallpaperXSearchModeDesc": "Escolha como a Pesquisa no X é executada. A prévia de Responses usa seu login atual do Grok Build no endpoint oficial de compatibilidade fixo. Ela pode mudar e recorre à CLI quando for seguro; limites não iniciam uma segunda pesquisa.",
   "settings.wallpaperXSearchMode.cli": "Grok Build CLI (estável)",

--- a/src/i18n/messages/ru/settings-ui.ts
+++ b/src/i18n/messages/ru/settings-ui.ts
@@ -1,5 +1,10 @@
 /** ru messages — domain: settings-ui */
 export const ruSettingsUi = {
+  "settings.wallpaperSource.library.collection": "Коллекция",
+  "settings.wallpaperSource.library.all": "Все медиа",
+  "settings.wallpaperSource.library.favorites": "Избранное",
+  "settings.wallpaperSource.library.generated": "Созданные",
+  "settings.wallpaperSource.library.cache": "Кэш просмотра",
   "settings.wallpaperXSearchMode": "Маршрут поиска в X",
   "settings.wallpaperXSearchModeDesc": "Выберите способ поиска в X. Предпросмотр Responses использует текущий вход Grok Build и фиксированный официальный endpoint совместимости. Интерфейс может измениться и при безопасной возможности откатывается к CLI; при лимите второй поиск не запускается.",
   "settings.wallpaperXSearchMode.cli": "Grok Build CLI (стабильный)",

--- a/src/i18n/messages/ta/settings-ui.ts
+++ b/src/i18n/messages/ta/settings-ui.ts
@@ -1,5 +1,10 @@
 /** ta messages — domain: settings-ui */
 export const taSettingsUi = {
+  "settings.wallpaperSource.library.collection": "தொகுப்பு",
+  "settings.wallpaperSource.library.all": "அனைத்து ஊடகங்களும்",
+  "settings.wallpaperSource.library.favorites": "விருப்பங்கள்",
+  "settings.wallpaperSource.library.generated": "உருவாக்கங்கள்",
+  "settings.wallpaperSource.library.cache": "உலாவல் தற்காலிகச் சேமிப்பு",
   "settings.wallpaperXSearchMode": "X தேடல் வழி",
   "settings.wallpaperXSearchModeDesc": "X தேடல் எவ்வாறு இயங்க வேண்டும் என்பதைத் தேர்ந்தெடுக்கவும். Responses முன்னோட்டம் உங்கள் தற்போதைய Grok Build உள்நுழைவை நிலையான அதிகாரப்பூர்வ இணக்க endpoint உடன் பயன்படுத்துகிறது. இது மாறக்கூடும்; பாதுகாப்பானபோது CLI-க்கு மாறும். வரம்பு ஏற்பட்டால் இரண்டாவது தேடல் தொடங்காது.",
   "settings.wallpaperXSearchMode.cli": "Grok Build CLI (நிலையானது)",

--- a/src/i18n/messages/uk/settings-ui.ts
+++ b/src/i18n/messages/uk/settings-ui.ts
@@ -1,5 +1,10 @@
 /** uk messages — domain: settings-ui */
 export const ukSettingsUi = {
+  "settings.wallpaperSource.library.collection": "Колекція",
+  "settings.wallpaperSource.library.all": "Усі медіа",
+  "settings.wallpaperSource.library.favorites": "Вибране",
+  "settings.wallpaperSource.library.generated": "Створені",
+  "settings.wallpaperSource.library.cache": "Кеш перегляду",
   "settings.wallpaperXSearchMode": "Маршрут пошуку в X",
   "settings.wallpaperXSearchModeDesc": "Виберіть спосіб пошуку в X. Попередній перегляд Responses використовує чинний вхід Grok Build і фіксований офіційний endpoint сумісності. Інтерфейс може змінитися й безпечно повертається до CLI; за обмеження запитів другий пошук не запускається.",
   "settings.wallpaperXSearchMode.cli": "Grok Build CLI (стабільний)",

--- a/src/i18n/messages/zh-TW/settings-ui.ts
+++ b/src/i18n/messages/zh-TW/settings-ui.ts
@@ -1,5 +1,10 @@
 /** Traditional Chinese messages — domain: settings-ui */
 export const zhTWSettingsUi = {
+  "settings.wallpaperSource.library.collection": "圖庫分類",
+  "settings.wallpaperSource.library.all": "全部媒體",
+  "settings.wallpaperSource.library.favorites": "收藏",
+  "settings.wallpaperSource.library.generated": "生成作品",
+  "settings.wallpaperSource.library.cache": "瀏覽快取",
   "settings.wallpaperXSearchMode": "X 搜尋管道",
   "settings.wallpaperXSearchModeDesc": "選擇「從 X 搜尋」的執行方式。Responses 預覽會使用現有 Grok Build 登入，並固定請求官方相容端點；介面可能變更，條件允許時會安全退回 CLI。遇到限流時不會再發起第二次搜尋。",
   "settings.wallpaperXSearchMode.cli": "Grok Build CLI（穩定）",

--- a/src/i18n/messages/zh/settings-ui.ts
+++ b/src/i18n/messages/zh/settings-ui.ts
@@ -1,5 +1,10 @@
 /** Simplified Chinese messages — domain: settings-ui */
 export const zhSettingsUi = {
+  "settings.wallpaperSource.library.collection": "图库分类",
+  "settings.wallpaperSource.library.all": "全部媒体",
+  "settings.wallpaperSource.library.favorites": "收藏",
+  "settings.wallpaperSource.library.generated": "生成作品",
+  "settings.wallpaperSource.library.cache": "浏览缓存",
   "settings.wallpaperXSearchMode": "X 搜索渠道",
   "settings.wallpaperXSearchModeDesc": "选择“从 X 搜索”的执行方式。Responses 预览会使用现有 Grok Build 登录，并固定请求官方兼容端点；接口可能变化，条件允许时会安全回退 CLI。遇到限流时不会再发起第二次搜索。",
   "settings.wallpaperXSearchMode.cli": "Grok Build CLI（稳定）",

--- a/src/lib/api/wallpaper.ts
+++ b/src/lib/api/wallpaper.ts
@@ -14,6 +14,7 @@ import {
 
 import type {
   WallpaperFetchResult,
+  WallpaperGalleryItem,
   WallpaperLibraryEntry,
   WallpaperSearchResult,
 } from "../wallpaperSource";
@@ -80,6 +81,85 @@ export async function wallpaperLibraryList(
   return invoke<WallpaperLibraryEntry[]>("wallpaper_library_list", {
     limit: limit ?? null,
   });
+}
+
+export type WallpaperLibraryQuery = {
+  query: string;
+  kind: "all" | "image" | "video";
+  purpose?: import("../wallpaperSource").WallpaperLibraryPurpose;
+};
+
+export type WallpaperLibraryPage = {
+  items: WallpaperLibraryEntry[];
+  nextCursor: string | null;
+  total: number;
+  kindCounts: { all: number; image: number; video: number };
+};
+
+export async function wallpaperLibraryPage(
+  query: WallpaperLibraryQuery,
+  cursor: string | null = null,
+): Promise<WallpaperLibraryPage> {
+  return invoke<WallpaperLibraryPage>("wallpaper_library_page", {
+    query,
+    cursor,
+    limit: 48,
+  });
+}
+
+type WallpaperLibraryRememberItem = Pick<
+  WallpaperGalleryItem,
+  | "source"
+  | "fullUrl"
+  | "sourceUrl"
+  | "sourceName"
+  | "authorName"
+  | "authorUrl"
+  | "username"
+  | "postUrl"
+  | "license"
+  | "licenseUrl"
+  | "textPreview"
+>;
+
+export async function wallpaperLibraryRemember(
+  path: string,
+  item: WallpaperLibraryRememberItem,
+  favorite?: boolean,
+): Promise<import("../wallpaperSource").WallpaperMediaRecord> {
+  return invoke("wallpaper_library_remember", {
+    path,
+    metadata: {
+      source: item.source,
+      mediaUrl: item.fullUrl,
+      sourceUrl: item.sourceUrl || item.postUrl || null,
+      sourceName: item.sourceName ?? null,
+      authorName: item.authorName || item.username || null,
+      authorUrl: item.authorUrl ?? null,
+      license: item.license ?? null,
+      licenseUrl: item.licenseUrl ?? null,
+      title: item.textPreview ?? null,
+    },
+    favorite: favorite ?? null,
+  });
+}
+
+export type WallpaperLibraryMatch = {
+  index: number;
+  path: string;
+  metadata: import("../wallpaperSource").WallpaperMediaRecord;
+};
+
+export async function wallpaperLibraryLookup(
+  requests: Array<{ source: string; mediaUrl: string }>,
+): Promise<WallpaperLibraryMatch[]> {
+  return invoke("wallpaper_library_lookup", { requests });
+}
+
+export async function wallpaperLibraryFindById(
+  id: string,
+): Promise<WallpaperLibraryEntry | null> {
+  return invoke("wallpaper_library_find_by_id", { id });
 }
 
 // ── Grok Imagine saved album (isolated consumer WebView) ───────────────────

--- a/src/lib/wallpaperSource.test.ts
+++ b/src/lib/wallpaperSource.test.ts
@@ -36,6 +36,9 @@ describe("wallpaperSource", () => {
     );
     expect(parseWallpaperSourceError("url_blocked")).toBe("url_blocked");
     expect(parseWallpaperSourceError("path_not_allowed")).toBe("url_blocked");
+    expect(parseWallpaperSourceError("catalog_write_failed: disk full")).toBe(
+      "catalog_write_failed",
+    );
     expect(parseWallpaperSourceError("timeout")).toBe("timeout");
     expect(parseWallpaperSourceError("imagine_failed")).toBe("imagine_failed");
     expect(parseWallpaperSourceError("wallpaper_imagine: boom")).toBe(
@@ -55,6 +58,9 @@ describe("wallpaperSource", () => {
     expect(
       errorCodeFromSearchResult({ items: [], errorCode: "timeout" }),
     ).toBe("timeout");
+    expect(
+      errorCodeFromSearchResult({ items: [], errorCode: "catalog_read_failed" }),
+    ).toBe("catalog_write_failed");
     expect(errorCodeFromSearchResult({ items: [], errorCode: null })).toBe("empty");
     expect(
       errorCodeFromSearchResult({
@@ -269,5 +275,51 @@ describe("wallpaperSource", () => {
     const one = libraryEntryToGalleryItem(entries[1]!);
     expect(one.localPath).toBe("/w/x/2026-08-01/a.jpg");
     expect(one.fullUrl).toBe("file:///w/x/2026-08-01/a.jpg");
+  });
+
+  it("uses catalog metadata when mapping a library entry", () => {
+    const item = libraryEntryToGalleryItem({
+      path: "/w/cache/example.png",
+      name: "example.png",
+      source: "library",
+      kind: "image",
+      bytes: 12,
+      modifiedMs: 123,
+      metadata: {
+        id: "media-1",
+        source: "pexels",
+        sourceUrl: "https://www.pexels.com/photo/1/",
+        sourceName: "Pexels",
+        authorName: "Photographer",
+        authorUrl: "https://www.pexels.com/@photographer/",
+        license: "Pexels License",
+        licenseUrl: "https://www.pexels.com/license/",
+        title: "Mountain lake",
+        width: 1920,
+        height: 1080,
+        prompt: "a calm mountain lake",
+        generation: null,
+        parentId: null,
+        favorite: true,
+        purpose: "cache",
+        bytes: 12,
+        modifiedMs: 123,
+      },
+    });
+
+    expect(item).toMatchObject({
+      source: "pexels",
+      textPreview: "Mountain lake",
+      prompt: "a calm mountain lake",
+      width: 1920,
+      height: 1080,
+      sourceUrl: "https://www.pexels.com/photo/1/",
+      sourceName: "Pexels",
+      authorName: "Photographer",
+      authorUrl: "https://www.pexels.com/@photographer/",
+      license: "Pexels License",
+      licenseUrl: "https://www.pexels.com/license/",
+      metadata: { id: "media-1", favorite: true },
+    });
   });
 });

--- a/src/lib/wallpaperSource.ts
+++ b/src/lib/wallpaperSource.ts
@@ -5,6 +5,7 @@
 export type WallpaperSourceKind = "x" | "imagine" | "library";
 
 export type WallpaperGalleryItem = {
+  metadata?: WallpaperMediaRecord | null;
   id: string;
   thumbUrl: string;
   fullUrl: string;
@@ -48,6 +49,7 @@ export type WallpaperFetchResult = {
 };
 
 export type WallpaperLibraryEntry = {
+  metadata?: WallpaperMediaRecord | null;
   path: string;
   name: string;
   source: string;
@@ -56,7 +58,41 @@ export type WallpaperLibraryEntry = {
   modifiedMs: number;
 };
 
+export type WallpaperMediaRecord = {
+  id: string;
+  source: string;
+  sourceUrl: string | null;
+  sourceName?: string | null;
+  authorName?: string | null;
+  authorUrl?: string | null;
+  license: string | null;
+  licenseUrl: string | null;
+  title: string | null;
+  width: number | null;
+  height: number | null;
+  prompt: string | null;
+  generation: {
+    operation: string;
+    aspectRatio: string | null;
+    resolution: string | null;
+    duration: number | null;
+    requestedModel: string | null;
+  } | null;
+  parentId: string | null;
+  favorite: boolean;
+  purpose: "cache" | "generated";
+  bytes: number;
+  modifiedMs: number;
+};
+
+export type WallpaperLibraryPurpose =
+  | "all"
+  | "favorites"
+  | "generated"
+  | "cache";
+
 export type WallpaperSourceErrorCode =
+  | "catalog_write_failed"
   | "pexels_key_required"
   | "pexels_key_invalid"
   | "service_unavailable"
@@ -82,6 +118,7 @@ export function parseWallpaperSourceError(err: unknown): WallpaperSourceErrorCod
           ? String((err as { message: unknown }).message)
           : "";
   const s = raw.toLowerCase();
+  if (s.includes("catalog_")) return "catalog_write_failed";
   if (s.includes("rate_limited")) return "rate_limited";
   if (s.includes("auth_required")) return "auth_required";
   if (s.includes("cli_missing")) return "cli_missing";
@@ -122,6 +159,7 @@ export function errorCodeFromSearchResult(
   if (result.items.length > 0) return null;
   const code = (result.errorCode || "").toLowerCase();
   if (!code) return "empty";
+  if (code.startsWith("catalog_")) return "catalog_write_failed";
   if (code === "auth_required") return "auth_required";
   if (code === "cli_missing") return "cli_missing";
   if (code === "search_failed") return "search_failed";
@@ -501,7 +539,8 @@ export function libraryEntryToGalleryItem(
     /\.(mp4|m4v|webm|mov)$/i.test(entry.name || abs)
       ? "video"
       : "image";
-  const source = (entry.source || "library").trim() || "library";
+  const source =
+    (entry.metadata?.source || entry.source || "library").trim() || "library";
   return {
     id: libraryEntryId(entry),
     thumbUrl: fileUrl,
@@ -509,13 +548,20 @@ export function libraryEntryToGalleryItem(
     kind,
     source,
     localPath: abs || null,
-    textPreview: entry.name || null,
+    textPreview: entry.metadata?.title || entry.name || null,
     username: null,
     postUrl: null,
-    prompt: null,
+    prompt: entry.metadata?.prompt ?? null,
     likes: null,
-    width: null,
-    height: null,
+    width: entry.metadata?.width ?? null,
+    height: entry.metadata?.height ?? null,
+    metadata: entry.metadata,
+    sourceUrl: entry.metadata?.sourceUrl,
+    sourceName: entry.metadata?.sourceName,
+    authorName: entry.metadata?.authorName,
+    authorUrl: entry.metadata?.authorUrl,
+    license: entry.metadata?.license,
+    licenseUrl: entry.metadata?.licenseUrl,
   };
 }
 

--- a/src/styles/workbench.part4.css
+++ b/src/styles/workbench.part4.css
@@ -692,6 +692,17 @@
   max-width: 280px;
 }
 
+.wallpaper-library-toolbar__collection {
+  flex: 0 1 160px;
+  min-width: 120px;
+  max-width: 100%;
+}
+
+.wallpaper-library-toolbar .wallpaper-source-filters__query {
+  flex: 1 1 160px;
+  max-width: none;
+}
+
 /* --- from #500 --- */
 
 .process-budget-panel__empty-hint {


### PR DESCRIPTION
## Summary

- 将“壁纸库”接入 `useWallpaperLibrary` 分页客户端，搜索与类型筛选覆盖完整本地目录，不再只过滤首批 96 项
- 增加“全部媒体 / 收藏 / 生成作品 / 浏览缓存”分类，并将 query、kind、purpose 交给 Host 统一筛选
- 使用稳定游标显式加载更多；下一页请求期间，已加载卡片仍可点击预览
- 删除媒体后同步清理 hook 缓存，避免切换筛选条件后重新出现
- 补齐 15 个 locale 文案和 Modal 集成测试

## 依赖与提交范围

- 依赖 #1105（`f8b6eada`）；#1105 又依赖 #1104
- 本 PR 的独立增量仅为 `db7d6469`
- 在依赖 PR 合并前，GitHub 对 `main` 的 diff 会暂时包含前置提交；前置 PR 合并后会自动收敛

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor / chore

## Verification

- `pnpm test`：610 files / 7,189 tests
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build:ui`
- `python scripts/check-code-quality-gates.py --mode final`
- `python scripts/publish-website-downloads.py --self-test`
- `pnpm deps:check`
- `pnpm audit:prod`
- 前置 Rust 变更已通过 fmt、clippy、Windows harness；#1104 / #1105 四平台 CI 全绿

## UI / Risk

- **UI hold：是**。请重点检查桌面与窄宽度下的分类选择器、类型 chip、搜索框和“加载更多”布局
- 浏览器 UI 壳无法调用 Tauri Host，真实图库数据路径由现有 hook / Host 集成测试覆盖
- 本 PR 不改远程搜索、Grok Saved 抓取、Imagine 生成或图生视频行为

## Checklist

- [x] I ran `pnpm typecheck` and `pnpm test`
- [x] I ran Rust checks for the dependent Host changes
- [x] User-facing strings are synchronized across all 15 locales
- [x] No `window.confirm` / `prompt` / `alert` for product dialogs
- [x] No standalone docs update is needed; this extends the existing wallpaper library surface
- [x] No secrets (`secrets.json`, tokens, `auth.json`) included