### PR TITLE
fix(ci): 保留 Windows 测试所需系统工具

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,11 +103,17 @@ jobs:
 
           # --- scrub PATH (Temurin ships stale api-ms-win-*.dll forwarders) ---
           $dropped = [System.Collections.Generic.List[string]]::new()
+          $windowsRoot = [IO.Path]::GetFullPath($env:SystemRoot).TrimEnd('\')
           $kept = foreach ($d in ($env:Path -split $sep)) {
             if (-not $d) { continue }
             $shipsApiSet = $false
             if (Test-Path -LiteralPath $d -PathType Container -ErrorAction SilentlyContinue) {
-              $shipsApiSet = [bool](Get-ChildItem -LiteralPath $d -Filter 'api-ms-win-*.dll' -ErrorAction SilentlyContinue | Select-Object -First 1)
+              $fullPath = [IO.Path]::GetFullPath($d).TrimEnd('\')
+              $isWindowsDir = $fullPath.Equals($windowsRoot, [StringComparison]::OrdinalIgnoreCase) -or
+                $fullPath.StartsWith("$windowsRoot\", [StringComparison]::OrdinalIgnoreCase)
+              if (-not $isWindowsDir) {
+                $shipsApiSet = [bool](Get-ChildItem -LiteralPath $d -Filter 'api-ms-win-*.dll' -ErrorAction SilentlyContinue | Select-Object -First 1)
+              }
             }
             if ($shipsApiSet) {
               [void]$dropped.Add($d)


### PR DESCRIPTION
## Summary

Windows Rust 测试会清理 PATH 中携带旧 api-ms-win-*.dll 的目录，但系统目录在部分机器上也包含 API Set 文件。原逻辑会误删 SystemRoot 及其子目录，连带移除 pwsh、cmd、mt.exe 等系统工具路径。

本 PR 在清理前识别并保留 SystemRoot 目录树，同时继续过滤携带冲突 DLL 的第三方目录。相关历史背景见 #172。

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / chore

## Verification
- [x] pnpm typecheck
- [x] pnpm test（608 files / 7177 tests）
- [x] pnpm lint
- [x] pnpm build:ui
- [x] pnpm deps:check
- [x] pnpm audit:prod
- [x] 代码质量门禁与网站脚本自测
- [x] cargo fmt --all -- --check
- [x] cargo clippy --all-targets -- -D warnings
- [x] Windows manifest harness（1796 passed / 1 ignored）

## Checklist
- [x] User-facing strings go through src/i18n/messages.ts（本 PR 无 UI 文案）
- [x] No window.confirm / prompt / alert for product dialogs
- [x] Docs / docs/llm-wiki updated if behavior changed（仅 CI 行为，无产品文档变化）
- [x] No secrets (secrets.json, tokens, auth.json) included