### PR TITLE
perf(theme): stop 60s context rebuild forcing full workbench re-render

### DIFF
--- a/src/hooks/useAppearanceEditorModel.ts
+++ b/src/hooks/useAppearanceEditorModel.ts
@@ -184,6 +184,16 @@ export function useAppearanceEditorModel(opts: {
   const theme = useThemeShell();
   const resolvedLocale = resolveLocale(locale);
   const [catalogRev, setCatalogRev] = useState(0);
+
+  // Local 30s clock for the schedule honesty preview — previously consumed
+  // theme.scheduleClock from ThemeProvider, which forced every context
+  // consumer (including AppWorkbench) to re-render on every 60s tick.
+  const [scheduleClock, setScheduleClock] = useState(() => new Date());
+  useEffect(() => {
+    if (!theme.themeSchedule.enabled) return;
+    const id = window.setInterval(() => setScheduleClock(new Date()), 30_000);
+    return () => window.clearInterval(id);
+  }, [theme.themeSchedule.enabled]);
   useEffect(() => {
     let cancelled = false;
     void loadLocaleCatalog(resolvedLocale).then(() => {
@@ -482,9 +492,9 @@ export function useAppearanceEditorModel(opts: {
       deriveThemeScheduleHonesty({
         preference: theme.themePreference,
         schedule: theme.themeSchedule,
-        now: theme.scheduleClock,
+        now: scheduleClock,
       }),
-    [theme.themePreference, theme.themeSchedule, theme.scheduleClock],
+    [theme.themePreference, theme.themeSchedule, scheduleClock],
   );
 
   const sectionNav = useMemo(() => getNavDef("appearance"), []);

--- a/src/providers/ThemeProvider.tsx
+++ b/src/providers/ThemeProvider.tsx
@@ -95,8 +95,6 @@ export type ThemeShellValue = {
   setSystemTheme: (v: Theme) => void;
   themeSchedule: ThemeScheduleConfig;
   setThemeSchedule: (v: ThemeScheduleConfig) => void;
-  scheduleClock: Date;
-  setScheduleClock: (v: Date) => void;
   scheduleActive: boolean;
   skin: ThemeSkinId;
   setSkin: (v: ThemeSkinId) => void;
@@ -666,8 +664,6 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
       setSystemTheme,
       themeSchedule,
       setThemeSchedule,
-      scheduleClock,
-      setScheduleClock,
       scheduleActive,
       skin,
       setSkin,
@@ -705,7 +701,9 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
       themePreference,
       systemTheme,
       themeSchedule,
-      scheduleClock,
+      // scheduleClock intentionally excluded: the resolved `theme` above
+      // already reflects the schedule. Rebuilding the context value every
+      // 60s tick forced a full workbench re-render.
       scheduleActive,
       skin,
       wallpaperRecord,

--- a/src/styles/chat.part6.css
+++ b/src/styles/chat.part6.css
@@ -182,6 +182,8 @@
 .reliab-card__row {
   border-radius: 8px;
   padding: 6px 4px;
+  content-visibility: auto;
+  contain-intrinsic-size: auto 64px;
 }
 
 .reliab-card__row-main {

--- a/src/styles/settings.part2.css
+++ b/src/styles/settings.part2.css
@@ -147,6 +147,8 @@ html[data-theme="light"] .settings-config-edit__pre {
   padding: 12px 14px;
   border-bottom: 1px solid var(--border-subtle);
   cursor: default;
+  content-visibility: auto;
+  contain-intrinsic-size: auto 46px;
 }
 
 .settings-archived-row:hover {


### PR DESCRIPTION
## Summary

`ThemeProvider` 把 `scheduleClock`(主题调度激活时每 60s 更新一次的 Date)放进了 `ThemeShellValue` 上下文对象及其 useMemo 依赖。每次 tick 都重建上下文值 → 所有 `useThemeShell` 消费者（含 AppWorkbench）整树重渲染。

Fixes #1113
Stacked on #1056 + #1064 + #1073。

## Changes

- **`ThemeShellValue`**:从 context 移除 `scheduleClock` / `setScheduleClock` —— 已解析的 `theme` 本身已反映调度结果,clock 仅被外观编辑器的调度预览消费
- **`useAppearanceEditorModel`**:改用本地 30s tick 计算调度预览(与 SettingsPage 既有模式一致)
- **顺路**:`ReliabilityCenterModal` 审计行与 `ArchivedSection` 归档行加 `content-visibility: auto` + `contain-intrinsic-size`(行动态高度,CSS 级窗口化比固定行高 VirtualList 更合适)

## Test plan

- [x] `pnpm typecheck` ✓
- [x] `pnpm lint` ✓
- [x] `pnpm test` — 7177 全绿
- [x] `pnpm build:ui` ✓
- [ ] 维护者冒烟:开启主题调度(外观→跟随时间),观察工作台不再每 60s 全树重渲染;外观编辑器调度预览仍正确更新