### PR TITLE
feat(wallpaper): 统一媒体预览并按需加载原图

### DIFF
--- a/docs/llm-wiki/media-delivery.md
+++ b/docs/llm-wiki/media-delivery.md
@@ -52,6 +52,26 @@ provider invalidates earlier asynchronous preparation; an older gallery must
 not reopen after close or replace a newer gallery. After first use, keep the
 lightbox mounted with `open=false` so its exit cleanup can complete.
 
+The viewer accepts mixed image and video galleries. Local video slides use the
+same loopback media endpoint as images; a gallery mounted during endpoint boot
+must rerender after `ensureMediaEndpoint()` settles so it does not keep a raw
+`file://` URL for the lifetime of the card. Image-only copy and zoom behavior
+must not be attached to video elements.
+
+Remote wallpaper cards open their already-validated thumbnail immediately and
+materialize the original only when that slide becomes current. Keep at most two
+original transfers active. If navigation outruns those slots, retain only the
+latest waiting slide; revisiting it may schedule it again after a slot opens.
+An original failure keeps the thumbnail visible, shows localized safe copy and
+retries only after an explicit user action.
+
+Closing the viewer, closing the source picker, changing source, starting a new
+search, refreshing Grok Saved, or observing a Grok Saved page/account revision
+invalidates queued and in-flight renderer results. A late original must neither
+reopen/replace the current gallery nor restore selection or local-path state
+from the previous source revision. Cancellation is still sent to the matching
+Host media bridge so renderer rejection is not the only boundary.
+
 ## Fallback
 
 `media://` custom protocol remains registered for cold-start races only. Steady-state UI should use HTTP URLs.

--- a/src/components/ImageLightbox.test.ts
+++ b/src/components/ImageLightbox.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import {
+  IMAGE_LIGHTBOX_PORTAL_Z_INDEX,
+  ImageLightbox,
+  toLightboxSlides,
+} from "./ImageLightbox";
+
+const labels = {
+  next: "Next",
+  prev: "Previous",
+  close: "Close",
+  zoomIn: "Zoom in",
+  zoomOut: "Zoom out",
+};
+
+describe("ImageLightbox", () => {
+  it("maps image and video slides to their proper renderer", () => {
+    const slides = toLightboxSlides([
+      {
+        kind: "image",
+        src: "https://example.test/wallpaper.jpg",
+        alt: "wallpaper",
+        width: 1920,
+        height: 1080,
+      },
+      {
+        kind: "video",
+        src: "http://127.0.0.1/media/clip",
+        mime: "video/mp4; charset=binary",
+      },
+      {
+        kind: "video",
+        src: "https://example.test/clip.webm?cache=1",
+      },
+    ]);
+
+    expect(slides[0]).toEqual(
+      expect.objectContaining({
+        type: "image",
+        src: "https://example.test/wallpaper.jpg",
+        alt: "wallpaper",
+        width: 1920,
+        height: 1080,
+      }),
+    );
+    expect(slides[1]).toEqual({
+      type: "video",
+      poster: undefined,
+      sources: [
+        { src: "http://127.0.0.1/media/clip", type: "video/mp4" },
+      ],
+    });
+    expect(slides[2]).toEqual({
+      type: "video",
+      poster: undefined,
+      sources: [
+        {
+          src: "https://example.test/clip.webm?cache=1",
+          type: "video/webm",
+        },
+      ],
+    });
+  });
+
+  it("hides the app origin and keeps the portal above application modals", () => {
+    const rendered = ImageLightbox({
+      open: true,
+      close: () => undefined,
+      index: 0,
+      slides: [
+        { kind: "image", src: "https://cdn.example.test/photo.jpg" },
+      ],
+      onView: () => undefined,
+      labels,
+    });
+    const props = rendered.props as {
+      carousel: { imageProps: { referrerPolicy?: string } };
+      styles: { root: Record<`--yarl__${string}`, string | number> };
+    };
+
+    expect(props.carousel.imageProps.referrerPolicy).toBe("no-referrer");
+    expect(props.styles.root["--yarl__portal_zindex"]).toBe(
+      IMAGE_LIGHTBOX_PORTAL_Z_INDEX,
+    );
+    expect(IMAGE_LIGHTBOX_PORTAL_Z_INDEX).toBeGreaterThan(12_000);
+  });
+});

--- a/src/components/ImageLightbox.tsx
+++ b/src/components/ImageLightbox.tsx
@@ -1,21 +1,57 @@
 /**
- * yet-another-react-lightbox — loaded only when a gallery opens.
+ * yet-another-react-lightbox, loaded only when a gallery opens.
  */
 
-import Lightbox from "yet-another-react-lightbox";
-import Zoom from "yet-another-react-lightbox/plugins/zoom";
+import Lightbox, { type Slide } from "yet-another-react-lightbox";
 import Counter from "yet-another-react-lightbox/plugins/counter";
+import Video from "yet-another-react-lightbox/plugins/video";
+import Zoom from "yet-another-react-lightbox/plugins/zoom";
+import { IconRefresh } from "./icons";
 import "yet-another-react-lightbox/styles.css";
 import "yet-another-react-lightbox/plugins/counter.css";
 
+export const IMAGE_LIGHTBOX_PORTAL_Z_INDEX = 14_000;
+
 export type ImageLightboxSlide = {
   src: string;
+  kind: "image" | "video";
+  mime?: string;
+  poster?: string;
   alt?: string;
   title?: string;
   width?: number;
   height?: number;
   srcSet?: Array<{ src: string; width: number; height: number }>;
+  originalStatus?: "loading" | "error";
+  originalError?: string;
 };
+
+function videoMime(slide: ImageLightboxSlide): string {
+  const explicit = slide.mime?.split(";", 1)[0]?.trim().toLowerCase();
+  if (explicit?.startsWith("video/")) return explicit;
+  const path = slide.src.split(/[?#]/, 1)[0]?.toLowerCase() ?? "";
+  return path.endsWith(".webm") ? "video/webm" : "video/mp4";
+}
+
+export function toLightboxSlides(slides: ImageLightboxSlide[]): Slide[] {
+  return slides.map((slide) =>
+    slide.kind === "video"
+      ? {
+          type: "video",
+          poster: slide.poster,
+          sources: [{ src: slide.src, type: videoMime(slide) }],
+        }
+      : {
+          type: "image",
+          src: slide.src,
+          alt: slide.alt ?? slide.title,
+          title: slide.title,
+          width: slide.width,
+          height: slide.height,
+          ...(slide.srcSet?.length ? { srcSet: slide.srcSet } : {}),
+        },
+  );
+}
 
 export function ImageLightbox({
   open,
@@ -23,6 +59,7 @@ export function ImageLightbox({
   index,
   slides,
   onView,
+  onRetryOriginal,
   labels,
 }: {
   open: boolean;
@@ -30,31 +67,70 @@ export function ImageLightbox({
   index: number;
   slides: ImageLightboxSlide[];
   onView: (index: number) => void;
+  onRetryOriginal?: () => void;
   labels: {
     next: string;
     prev: string;
     close: string;
     zoomIn: string;
     zoomOut: string;
+    loadingOriginal?: string;
+    originalFailed?: string;
+    retry?: string;
   };
 }) {
+  const originalStatus = slides[index]?.originalStatus;
+
   return (
     <Lightbox
       open={open}
       close={close}
       index={index}
-      slides={slides.map((s) => ({
-        src: s.src,
-        alt: s.alt ?? s.title,
-        title: s.title,
-        width: s.width,
-        height: s.height,
-        ...(s.srcSet?.length ? { srcSet: s.srcSet } : {}),
-      }))}
-      on={{
-        view: ({ index: i }) => onView(i),
+      slides={toLightboxSlides(slides)}
+      toolbar={{
+        buttons: [
+          ...(originalStatus
+            ? [
+                <div
+                  key="original-status"
+                  className="image-original-status"
+                  role="status"
+                  aria-live="polite"
+                >
+                  <span>
+                    {originalStatus === "loading"
+                      ? labels.loadingOriginal
+                      : slides[index]?.originalError || labels.originalFailed}
+                  </span>
+                  {originalStatus === "error" && onRetryOriginal ? (
+                    <button
+                      type="button"
+                      className="yarl__button"
+                      title={labels.retry}
+                      aria-label={labels.retry}
+                      onClick={onRetryOriginal}
+                    >
+                      <IconRefresh size={22} />
+                    </button>
+                  ) : null}
+                </div>,
+              ]
+            : []),
+          "close",
+        ],
       }}
-      plugins={[Zoom, Counter]}
+      on={{
+        view: ({ index: nextIndex }) => onView(nextIndex),
+      }}
+      plugins={[Video, Zoom, Counter]}
+      video={{
+        autoPlay: true,
+        controls: true,
+        loop: true,
+        muted: true,
+        playsInline: true,
+        preload: "metadata",
+      }}
       zoom={{
         maxZoomPixelRatio: 4,
         scrollToZoom: true,
@@ -72,12 +148,16 @@ export function ImageLightbox({
             objectFit: "contain",
           },
           draggable: false,
+          referrerPolicy: "no-referrer",
         },
       }}
       controller={{
         closeOnBackdropClick: true,
       }}
       styles={{
+        root: {
+          "--yarl__portal_zindex": IMAGE_LIGHTBOX_PORTAL_Z_INDEX,
+        },
         container: { backgroundColor: "rgba(0, 0, 0, 0.92)" },
       }}
       labels={{

--- a/src/components/ImageViewer.test.tsx
+++ b/src/components/ImageViewer.test.tsx
@@ -1,16 +1,23 @@
 /** @vitest-environment jsdom */
-import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { ImageViewerProvider } from "./ImageViewer";
 import { useImageViewer, type ImageViewerApi } from "./ImageViewerContext";
 
-const resolveImages = vi.hoisted(() => vi.fn(async (paths: string[]) =>
-  paths.map((path) => ({ path, src: path })),
-));
+const resolveImage = vi.hoisted(() =>
+  vi.fn(async (src: string): Promise<string | null> => src),
+);
 const naturalSize = vi.hoisted(() => vi.fn(async () => ({ width: 640, height: 480 })));
+const renderedLightbox = vi.hoisted(() => vi.fn());
 vi.mock("@/lib/imageSrc", () => ({
-  resolveImageSrcs: resolveImages,
-  resolveImageSrc: vi.fn(async (src: string) => src),
+  resolveImageSrc: resolveImage,
 }));
 vi.mock("@/lib/copyImage", () => ({
   copyImageFromPath: vi.fn(async () => ({ ok: true })),
@@ -21,9 +28,30 @@ vi.mock("@/lib/imageLightboxFit", async (importOriginal) => ({
   loadImageNaturalSize: naturalSize,
 }));
 vi.mock("./ImageLightbox", () => ({
-  ImageLightbox: ({ open, slides }: { open: boolean; slides: { src: string }[] }) => (
-    <div data-testid="viewer" data-open={String(open)}>{slides[0]?.src}</div>
-  ),
+  ImageLightbox: (props: {
+    open: boolean;
+    slides: Array<{ src: string; originalStatus?: string }>;
+    index: number;
+    onView: (index: number) => void;
+    onRetryOriginal: () => void;
+  }) => {
+    renderedLightbox(props);
+    return (
+      <div data-testid="viewer" data-open={String(props.open)}>
+        {props.slides[props.index]?.src}
+        <button
+          type="button"
+          aria-label="next"
+          onClick={() => props.onView(props.index + 1)}
+        />
+        <button
+          type="button"
+          aria-label="retry"
+          onClick={props.onRetryOriginal}
+        />
+      </div>
+    );
+  },
 }));
 
 afterEach(() => {
@@ -43,8 +71,32 @@ function setup() {
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
-  const promise = new Promise<T>((finish) => { resolve = finish; });
-  return { promise, resolve };
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((finish, fail) => {
+    resolve = finish;
+    reject = fail;
+  });
+  return { promise, resolve, reject };
+}
+
+function deferredOriginals(count: number) {
+  return Array.from({ length: count }, (_, itemIndex) => {
+    const pending = deferred<{ src: string; kind: "image" }>();
+    const loadOriginal = vi.fn(() => pending.promise);
+    return {
+      slide: {
+        src: "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==",
+        loadOriginal,
+      },
+      loadOriginal,
+      finish: () =>
+        pending.resolve({
+          src: "original-" + itemIndex + ".jpg",
+          kind: "image",
+        }),
+      fail: () => pending.reject(new Error("download_failed")),
+    };
+  });
 }
 
 describe("ImageViewer lifecycle", () => {
@@ -60,12 +112,12 @@ describe("ImageViewer lifecycle", () => {
   });
 
   it("does not reopen when path resolution completes after close", async () => {
-    const pending = deferred<Awaited<ReturnType<typeof resolveImages>>>();
-    resolveImages.mockReturnValueOnce(pending.promise);
+    const pending = deferred<string | null>();
+    resolveImage.mockReturnValueOnce(pending.promise);
     const view = setup();
     act(() => view.api.open(["old.jpg"]));
     act(() => view.api.close());
-    await act(async () => pending.resolve([{ path: "old.jpg", src: "old.jpg" }]));
+    await act(async () => pending.resolve("old.jpg"));
     expect(screen.queryByTestId("viewer")).toBeNull();
   });
 
@@ -81,13 +133,13 @@ describe("ImageViewer lifecycle", () => {
   });
 
   it("keeps the newer gallery when an earlier open finishes last", async () => {
-    const pending = deferred<Awaited<ReturnType<typeof resolveImages>>>();
-    resolveImages.mockReturnValueOnce(pending.promise);
+    const pending = deferred<string | null>();
+    resolveImage.mockReturnValueOnce(pending.promise);
     const view = setup();
     act(() => view.api.open(["old.jpg"]));
     act(() => view.api.open(["new.jpg"]));
     await waitFor(() => expect(screen.getByTestId("viewer").textContent).toBe("new.jpg"));
-    await act(async () => pending.resolve([{ path: "old.jpg", src: "old.jpg" }]));
+    await act(async () => pending.resolve("old.jpg"));
     expect(screen.getByTestId("viewer").textContent).toBe("new.jpg");
   });
 
@@ -103,15 +155,187 @@ describe("ImageViewer lifecycle", () => {
   });
 
   it("does not affect a new provider when an unmounted request completes", async () => {
-    const pending = deferred<Awaited<ReturnType<typeof resolveImages>>>();
-    resolveImages.mockReturnValueOnce(pending.promise);
+    const pending = deferred<string | null>();
+    resolveImage.mockReturnValueOnce(pending.promise);
     const old = setup();
     act(() => old.api.open(["old.jpg"]));
     old.unmount();
     const next = setup();
     act(() => next.api.open(["new.jpg"]));
     await waitFor(() => expect(screen.getByTestId("viewer").textContent).toBe("new.jpg"));
-    await act(async () => pending.resolve([{ path: "old.jpg", src: "old.jpg" }]));
+    await act(async () => pending.resolve("old.jpg"));
     expect(screen.getByTestId("viewer").textContent).toBe("new.jpg");
+  });
+
+  it("opens a video slide without image decoding", async () => {
+    const view = setup();
+    act(() =>
+      view.api.open([
+        {
+          src: "clip.mp4",
+          kind: "video",
+          mime: "video/mp4",
+        },
+      ]),
+    );
+    await waitFor(() => expect(view.api.isOpen()).toBe(true));
+    const props = renderedLightbox.mock.calls.at(-1)?.[0] as {
+      slides: Array<{ kind: string; mime?: string }>;
+    };
+    expect(props.slides[0]).toMatchObject({
+      kind: "video",
+      mime: "video/mp4",
+    });
+    expect(naturalSize).not.toHaveBeenCalled();
+  });
+
+  it("limits original downloads and starts only the latest queued slide", async () => {
+    const originals = deferredOriginals(5);
+    const view = setup();
+    act(() => view.api.open(originals.map((entry) => entry.slide)));
+
+    await waitFor(() =>
+      expect(originals[0]?.loadOriginal).toHaveBeenCalledTimes(1),
+    );
+    for (let itemIndex = 1; itemIndex < originals.length; itemIndex += 1) {
+      fireEvent.click(screen.getByRole("button", { name: "next" }));
+    }
+    expect(
+      originals.map((entry) => entry.loadOriginal.mock.calls.length),
+    ).toEqual([1, 1, 0, 0, 0]);
+
+    await act(async () => originals[0]?.finish());
+    await waitFor(() =>
+      expect(originals[4]?.loadOriginal).toHaveBeenCalledTimes(1),
+    );
+    expect(originals[2]?.loadOriginal).not.toHaveBeenCalled();
+    expect(originals[3]?.loadOriginal).not.toHaveBeenCalled();
+
+    await act(async () => {
+      originals[1]?.finish();
+      originals[4]?.finish();
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId("viewer").textContent).toContain(
+        "original-4.jpg",
+      ),
+    );
+  });
+
+  it("discards a queued original when the viewer closes", async () => {
+    const originals = deferredOriginals(3);
+    const view = setup();
+    act(() => view.api.open(originals.map((entry) => entry.slide)));
+
+    await waitFor(() =>
+      expect(originals[0]?.loadOriginal).toHaveBeenCalledTimes(1),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "next" }));
+    fireEvent.click(screen.getByRole("button", { name: "next" }));
+    expect(originals[2]?.loadOriginal).not.toHaveBeenCalled();
+
+    act(() => view.api.close());
+    await act(async () => {
+      originals[0]?.finish();
+      originals[1]?.finish();
+    });
+    expect(originals[2]?.loadOriginal).not.toHaveBeenCalled();
+  });
+
+  it("ignores an original that settles after another gallery opens", async () => {
+    const pending = deferred<{ src: string; kind: "image" }>();
+    const loadOriginal = vi.fn(() => pending.promise);
+    const view = setup();
+    act(() => view.api.open([{ src: "thumbnail.jpg", loadOriginal }]));
+    await waitFor(() => expect(loadOriginal).toHaveBeenCalledTimes(1));
+
+    act(() => view.api.close());
+    act(() => view.api.open(["new-gallery.jpg"]));
+    await waitFor(() =>
+      expect(screen.getByTestId("viewer").textContent).toContain(
+        "new-gallery.jpg",
+      ),
+    );
+    await act(async () =>
+      pending.resolve({ src: "late-original.jpg", kind: "image" }),
+    );
+    expect(screen.getByTestId("viewer").textContent).toContain(
+      "new-gallery.jpg",
+    );
+    expect(screen.getByTestId("viewer").textContent).not.toContain(
+      "late-original.jpg",
+    );
+  });
+
+  it("keeps the requested index when lazy slides share a placeholder", async () => {
+    const firstOriginal = vi.fn(async () => ({
+      src: "first-original.jpg",
+      kind: "image" as const,
+    }));
+    const secondOriginal = vi.fn(async () => ({
+      src: "second-original.jpg",
+      kind: "image" as const,
+    }));
+    const placeholder =
+      "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==";
+    const view = setup();
+    act(() =>
+      view.api.open(
+        [
+          { src: placeholder, loadOriginal: firstOriginal },
+          { src: placeholder, loadOriginal: secondOriginal },
+        ],
+        1,
+      ),
+    );
+
+    await waitFor(() => expect(secondOriginal).toHaveBeenCalledTimes(1));
+    expect(firstOriginal).not.toHaveBeenCalled();
+    await waitFor(() =>
+      expect(screen.getByTestId("viewer").textContent).toContain(
+        "second-original.jpg",
+      ),
+    );
+  });
+
+  it("retains a thumbnail after failure and retries the original explicitly", async () => {
+    const loadOriginal = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("private upstream detail"))
+      .mockResolvedValueOnce({ src: "original.jpg", kind: "image" as const });
+    const view = setup();
+    act(() =>
+      view.api.open([
+        {
+          src: "thumbnail.jpg",
+          loadOriginal,
+          originalErrorMessage: () => "Friendly error",
+        },
+      ]),
+    );
+
+    await waitFor(() => {
+      const props = renderedLightbox.mock.calls.at(-1)?.[0] as {
+        slides: Array<{
+          src: string;
+          originalStatus?: string;
+          originalError?: string;
+        }>;
+      };
+      expect(props.slides[0]).toMatchObject({
+        src: "thumbnail.jpg",
+        originalStatus: "error",
+        originalError: "Friendly error",
+      });
+    });
+    fireEvent.click(screen.getByRole("button", { name: "retry" }));
+    await waitFor(() => {
+      const props = renderedLightbox.mock.calls.at(-1)?.[0] as {
+        slides: Array<{ src: string; originalStatus?: string }>;
+      };
+      expect(props.slides[0]).toMatchObject({ src: "original.jpg" });
+      expect(props.slides[0].originalStatus).toBeUndefined();
+    });
+    expect(loadOriginal).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/components/ImageViewer.tsx
+++ b/src/components/ImageViewer.tsx
@@ -1,11 +1,6 @@
 /**
- * Global image lightbox (yet-another-react-lightbox) + open/copy helpers.
- * Zoom, prev/next, counter; right-click on the active slide copies the image.
- *
- * Initial fit: always contain within the stage (upscale small images to fill,
- * downscale large ones). Logical slide width/height are inflated when the
- * natural bitmap is smaller than the stage so YARL's max-width cap and zoom
- * math do not leave a tiny thumbnail in the middle of the window.
+ * Global media lightbox + open/copy helpers.
+ * Images keep zoom/copy support; video slides use the lightbox video plugin.
  */
 
 import {
@@ -18,7 +13,7 @@ import {
   useState,
   type ReactNode,
 } from "react";
-import { resolveImageSrc, resolveImageSrcs } from "@/lib/imageSrc";
+import { createT, type Locale } from "@/i18n";
 import { copyImageFromPath, copyImageFromSrc } from "@/lib/copyImage";
 import {
   lightboxSlideDimensions,
@@ -26,27 +21,34 @@ import {
   lightboxYarlSlideSize,
   loadImageNaturalSize,
 } from "@/lib/imageLightboxFit";
-import { createT, type Locale } from "@/i18n";
-import { ImageViewerContext, type ImageSlideInput, type ImageViewerApi } from "./ImageViewerContext";
+import { resolveImageSrc } from "@/lib/imageSrc";
+import {
+  ImageViewerContext,
+  type ImageSlideInput,
+  type ImageViewerApi,
+} from "./ImageViewerContext";
 
 const ImageLightbox = lazy(async () => {
-  const m = await import("./ImageLightbox");
-  return { default: m.ImageLightbox };
+  const module = await import("./ImageLightbox");
+  return { default: module.ImageLightbox };
 });
 
 interface ResolvedSlide {
   src: string;
+  kind: "image" | "video";
+  mime?: string;
+  poster?: string;
   alt?: string;
   title?: string;
-  /** Original path/url for copy. */
+  onView?: ImageSlideInput["onView"];
+  loadOriginal?: ImageSlideInput["loadOriginal"];
+  originalErrorMessage?: ImageSlideInput["originalErrorMessage"];
+  originalStatus?: "loading" | "error";
+  originalError?: string;
+  /** Original path/URL for copy and stale-result identity checks. */
   origin: string;
-  /** Logical size for YARL fit + zoom (may exceed natural for small images). */
   width?: number;
   height?: number;
-  /**
-   * Same logical size as width/height — keeps Zoom imageRect ≥ stage fit so
-   * drag-pan works after zoom-in (see lightboxYarlSlideSize).
-   */
   srcSet?: Array<{ src: string; width: number; height: number }>;
 }
 
@@ -55,12 +57,27 @@ interface ImageViewerProviderProps {
   locale: Locale;
 }
 
-/** Stage size from the current window (SSR-safe fallback). */
 function currentStageRect() {
   if (typeof window === "undefined") {
     return lightboxSlideRect(1920, 1080);
   }
   return lightboxSlideRect(window.innerWidth, window.innerHeight);
+}
+
+async function withLogicalImageSize(
+  slide: ResolvedSlide,
+  stage: ReturnType<typeof currentStageRect>,
+  requireDecodedImage = false,
+): Promise<ResolvedSlide> {
+  if (slide.kind === "video") return slide;
+  const natural = await loadImageNaturalSize(slide.src);
+  if (!(natural.width > 0 && natural.height > 0)) {
+    if (requireDecodedImage) throw new Error("original_decode_failed");
+    return slide;
+  }
+  const logical = lightboxSlideDimensions(natural, stage);
+  const sizeFields = lightboxYarlSlideSize(slide.src, logical);
+  return sizeFields ? { ...slide, ...sizeFields } : slide;
 }
 
 export function ImageViewerProvider({
@@ -74,20 +91,30 @@ export function ImageViewerProvider({
   const isOpenRef = useRef(false);
   const slidesRef = useRef(slides);
   const generationRef = useRef(0);
+  const originalLoadsRef = useRef(new Set<string>());
+  const activeOriginalLoadsRef = useRef(0);
+  const pendingOriginalLoadRef = useRef<(() => void) | null>(null);
   slidesRef.current = slides;
 
   const close = useCallback(() => {
     generationRef.current += 1;
+    originalLoadsRef.current.clear();
+    pendingOriginalLoadRef.current = null;
     isOpenRef.current = false;
     setIsOpen(false);
   }, []);
 
   const viewerIsOpen = useCallback(() => isOpenRef.current, []);
 
-  useEffect(() => () => {
-    generationRef.current += 1;
-    isOpenRef.current = false;
-  }, []);
+  useEffect(
+    () => () => {
+      generationRef.current += 1;
+      originalLoadsRef.current.clear();
+      pendingOriginalLoadRef.current = null;
+      isOpenRef.current = false;
+    },
+    [],
+  );
 
   const openViewer = useCallback(
     (input: ImageSlideInput[] | string[], startIndex = 0) => {
@@ -96,44 +123,64 @@ export function ImageViewerProvider({
       );
       if (!normalized.length) return;
 
-      const generation = ++generationRef.current;
       void (async () => {
-        const paths = normalized.map((s) => s.src);
-        const resolved = await resolveImageSrcs(paths);
+        const generation = generationRef.current + 1;
+        generationRef.current = generation;
+        originalLoadsRef.current.clear();
+        pendingOriginalLoadRef.current = null;
+        const resolved = (
+          await Promise.all(
+            normalized.map(async (slide, inputIndex) => {
+              const src = await resolveImageSrc(slide.src);
+              return src
+                ? { path: slide.src, src, input: slide, inputIndex }
+                : null;
+            }),
+          )
+        ).filter((entry): entry is NonNullable<typeof entry> => entry !== null);
         if (!resolved.length) return;
 
-        const meta = new Map(normalized.map((s) => [s.src, s] as const));
-        const stage = currentStageRect();
-
-        // Resolve natural sizes so we can declare logical slide dims that
-        // allow small images to fill the stage at zoom=1.
-        const next: ResolvedSlide[] = await Promise.all(
-          resolved.map(async ({ path, src }) => {
-            const m = meta.get(path);
-            const natural = await loadImageNaturalSize(src);
-            const logical =
-              natural.width > 0 && natural.height > 0
-                ? lightboxSlideDimensions(natural, stage)
-                : { width: 0, height: 0 };
-            const sizeFields = lightboxYarlSlideSize(src, logical);
+        const next: ResolvedSlide[] = resolved.map(
+          ({ path, src, input: slide }) => {
+            const kind = slide.kind === "video" ? "video" : "image";
             return {
               src,
               origin: path,
-              alt: m?.alt ?? m?.title,
-              title: m?.title,
-              ...(sizeFields ?? {}),
+              kind,
+              ...(kind === "video"
+                ? { mime: slide.mime, poster: slide.poster }
+                : {}),
+              alt: slide.alt ?? slide.title,
+              title: slide.title,
+              onView: slide.onView,
+              loadOriginal: slide.loadOriginal,
+              originalErrorMessage: slide.originalErrorMessage,
             };
-          }),
+          },
         );
 
-        const want =
-          normalized[Math.min(startIndex, normalized.length - 1)]?.src;
-        let idx = next.findIndex((s) => s.origin === want);
-        if (idx < 0) idx = 0;
+        const requestedInputIndex = Math.min(
+          Math.max(Number.isFinite(startIndex) ? Math.trunc(startIndex) : 0, 0),
+          normalized.length - 1,
+        );
+        let nextIndex = resolved.findIndex(
+          (entry) => entry.inputIndex === requestedInputIndex,
+        );
+        if (nextIndex < 0) nextIndex = 0;
+
+        // Open lazy placeholders immediately. Eager images only wait for the
+        // selected slide's dimensions; siblings hydrate when viewed.
+        const selected = next[nextIndex];
+        if (selected && !selected.loadOriginal) {
+          next[nextIndex] = await withLogicalImageSize(
+            selected,
+            currentStageRect(),
+          );
+        }
 
         if (generationRef.current !== generation) return;
         setSlides(next);
-        setIndex(idx);
+        setIndex(nextIndex);
         isOpenRef.current = true;
         setIsOpen(true);
       })();
@@ -142,13 +189,162 @@ export function ImageViewerProvider({
   );
 
   const copyImage = useCallback(async (pathOrUrl: string) => {
-    // Prefer Host path write for absolute files; then URL/fetch path.
-    const r = await copyImageFromPath(pathOrUrl);
-    if (r.ok) return true;
+    const fromPath = await copyImageFromPath(pathOrUrl);
+    if (fromPath.ok) return true;
     const src = await resolveImageSrc(pathOrUrl);
     if (!src) return false;
     return (await copyImageFromSrc(src)).ok;
   }, []);
+
+  const hydrateSlideAt = useCallback(
+    function hydrateSlideAt(
+      targetIndex: number,
+      force = false,
+      retryOriginal = false,
+    ) {
+      if (!isOpenRef.current) return;
+      const slide = slidesRef.current[targetIndex];
+      if (!slide) return;
+
+      const generation = generationRef.current;
+      const expectedOrigin = slide.origin;
+      const expectedSrc = slide.src;
+
+      if (slide.loadOriginal) {
+        if (slide.originalStatus === "error" && !retryOriginal) return;
+        const loadKey = `${generation}:${targetIndex}:${expectedOrigin}`;
+        if (originalLoadsRef.current.has(loadKey)) return;
+
+        const updateSlide = (updated: ResolvedSlide) => {
+          if (generationRef.current !== generation) return;
+          const previous = slidesRef.current[targetIndex];
+          if (
+            previous?.origin !== expectedOrigin ||
+            previous.src !== expectedSrc
+          ) {
+            return;
+          }
+          const next = slidesRef.current.slice();
+          next[targetIndex] = updated;
+          slidesRef.current = next;
+          setSlides(next);
+        };
+
+        updateSlide({
+          ...slide,
+          originalStatus: "loading",
+          originalError: undefined,
+        });
+
+        // Keep at most two Host downloads active and retain only the latest
+        // navigation request waiting for a slot.
+        if (activeOriginalLoadsRef.current >= 2) {
+          pendingOriginalLoadRef.current = () => {
+            if (generationRef.current === generation) {
+              hydrateSlideAt(targetIndex, force, retryOriginal);
+            }
+          };
+          return;
+        }
+
+        originalLoadsRef.current.add(loadKey);
+        activeOriginalLoadsRef.current += 1;
+        void (async () => {
+          try {
+            const loaded = await slide.loadOriginal?.();
+            if (generationRef.current !== generation) return;
+            if (!loaded) throw new Error("original_unavailable");
+
+            const loadedSrc = await resolveImageSrc(loaded.src);
+            if (generationRef.current !== generation) return;
+            if (!loadedSrc) throw new Error("original_unavailable");
+
+            const upgraded: ResolvedSlide = {
+              ...slide,
+              src: loadedSrc,
+              origin: loaded.src,
+              kind: loaded.kind === "video" ? "video" : "image",
+              mime: loaded.mime,
+              poster: loaded.poster ?? slide.poster,
+              loadOriginal: undefined,
+              originalStatus: undefined,
+              originalError: undefined,
+              width: undefined,
+              height: undefined,
+              srcSet: undefined,
+            };
+            updateSlide(
+              await withLogicalImageSize(
+                upgraded,
+                currentStageRect(),
+                true,
+              ),
+            );
+          } catch (error) {
+            let originalError: string | undefined;
+            try {
+              originalError = slide.originalErrorMessage?.(error);
+            } catch {
+              originalError = undefined;
+            }
+            // Preserve the thumbnail. Retry only after an explicit action.
+            updateSlide({
+              ...slide,
+              originalStatus: "error",
+              originalError,
+            });
+          } finally {
+            originalLoadsRef.current.delete(loadKey);
+            activeOriginalLoadsRef.current -= 1;
+            const pending = pendingOriginalLoadRef.current;
+            pendingOriginalLoadRef.current = null;
+            pending?.();
+          }
+        })();
+        return;
+      }
+
+      if (slide.kind === "video" || (!force && slide.width && slide.height)) {
+        return;
+      }
+      void withLogicalImageSize(slide, currentStageRect()).then((updated) => {
+        if (generationRef.current !== generation) return;
+        setSlides((current) => {
+          if (
+            current[targetIndex]?.origin !== expectedOrigin ||
+            current[targetIndex]?.src !== expectedSrc
+          ) {
+            return current;
+          }
+          const previous = current[targetIndex];
+          if (
+            previous?.width === updated.width &&
+            previous.height === updated.height
+          ) {
+            return current;
+          }
+          const next = current.slice();
+          next[targetIndex] = updated;
+          return next;
+        });
+      });
+    },
+    [],
+  );
+
+  const handleView = useCallback(
+    (nextIndex: number) => {
+      pendingOriginalLoadRef.current = null;
+      setIndex(nextIndex);
+      slidesRef.current[nextIndex]?.onView?.();
+      hydrateSlideAt(nextIndex);
+    },
+    [hydrateSlideAt],
+  );
+
+  useEffect(() => {
+    if (isOpen) hydrateSlideAt(index);
+  }, [hydrateSlideAt, index, isOpen]);
 
   const api = useMemo<ImageViewerApi>(
     () => ({
@@ -157,28 +353,25 @@ export function ImageViewerProvider({
       isOpen: viewerIsOpen,
       copyImage,
     }),
-    [openViewer, close, viewerIsOpen, copyImage],
+    [close, copyImage, openViewer, viewerIsOpen],
   );
 
-  // Right-click inside lightbox → copy current image (keeps Zoom plugin intact).
   useEffect(() => {
     if (!isOpen) return;
-    const onCtx = (e: MouseEvent) => {
-      const target = e.target as HTMLElement | null;
+    const onContextMenu = (event: MouseEvent) => {
+      const target = event.target as HTMLElement | null;
       if (!target?.closest?.(".yarl__root")) return;
-      const img = target.closest("img") as HTMLImageElement | null;
-      if (!img) return;
-      const src = img.currentSrc || img.src;
+      const image = target.closest("img") as HTMLImageElement | null;
+      const src = image?.currentSrc || image?.src;
       if (!src) return;
-      e.preventDefault();
-      e.stopPropagation();
+      event.preventDefault();
+      event.stopPropagation();
       void copyImageFromSrc(src);
     };
-    document.addEventListener("contextmenu", onCtx, true);
-    return () => document.removeEventListener("contextmenu", onCtx, true);
+    document.addEventListener("contextmenu", onContextMenu, true);
+    return () => document.removeEventListener("contextmenu", onContextMenu, true);
   }, [isOpen]);
 
-  // Recompute logical dims on resize so small images still fill a larger stage.
   useEffect(() => {
     if (!isOpen) return;
     let cancelled = false;
@@ -186,43 +379,7 @@ export function ImageViewerProvider({
     const onResize = () => {
       if (timer) clearTimeout(timer);
       timer = setTimeout(() => {
-        const generation = generationRef.current;
-        const stage = currentStageRect();
-        const current = slidesRef.current;
-        if (!current.length) return;
-        void (async () => {
-          const updated = await Promise.all(
-            current.map(async (s) => {
-              const natural = await loadImageNaturalSize(s.src);
-              if (!(natural.width > 0 && natural.height > 0)) return s;
-              const logical = lightboxSlideDimensions(natural, stage);
-              const sizeFields = lightboxYarlSlideSize(s.src, logical);
-              if (
-                !sizeFields ||
-                (s.width === sizeFields.width &&
-                  s.height === sizeFields.height)
-              ) {
-                return s;
-              }
-              return { ...s, ...sizeFields };
-            }),
-          );
-          if (cancelled || generationRef.current !== generation) return;
-          setSlides((prev) => {
-            if (
-              prev.length !== updated.length ||
-              prev.some((p, i) => p.src !== updated[i]?.src)
-            ) {
-              return prev;
-            }
-            const changed = prev.some(
-              (p, i) =>
-                p.width !== updated[i]?.width ||
-                p.height !== updated[i]?.height,
-            );
-            return changed ? updated : prev;
-          });
-        })();
+        if (!cancelled) hydrateSlideAt(index, true);
       }, 120);
     };
     window.addEventListener("resize", onResize);
@@ -231,12 +388,11 @@ export function ImageViewerProvider({
       if (timer) clearTimeout(timer);
       window.removeEventListener("resize", onResize);
     };
-  }, [isOpen]);
+  }, [hydrateSlideAt, index, isOpen]);
 
   return (
     <ImageViewerContext.Provider value={api}>
       {children}
-      {/* Let the lightbox finish its exit cleanup after close. */}
       {slides.length > 0 ? (
         <Suspense fallback={null}>
           <ImageLightbox
@@ -244,13 +400,17 @@ export function ImageViewerProvider({
             close={close}
             index={index}
             slides={slides}
-            onView={setIndex}
+            onView={handleView}
+            onRetryOriginal={() => hydrateSlideAt(index, false, true)}
             labels={{
               next: tr("image.next"),
               prev: tr("image.prev"),
               close: tr("image.close"),
               zoomIn: tr("image.zoomIn"),
               zoomOut: tr("image.zoomOut"),
+              loadingOriginal: tr("image.loadingOriginal"),
+              originalFailed: tr("image.originalFailed"),
+              retry: tr("ui.errorBoundary.retry"),
             }}
           />
         </Suspense>

--- a/src/components/ImageViewerContext.ts
+++ b/src/components/ImageViewerContext.ts
@@ -1,11 +1,22 @@
-// Keep context identity outside the provider's Fast Refresh boundary.
 import { createContext, useContext } from "react";
 
-export interface ImageSlideInput {
+export interface ImageSlideSource {
   /** Local absolute path or already-viewable URL. */
   src: string;
+  kind?: "image" | "video";
+  mime?: string;
+  poster?: string;
+}
+
+export interface ImageSlideInput extends ImageSlideSource {
   alt?: string;
   title?: string;
+  /** Notify the owning gallery when this slide becomes current. */
+  onView?: () => void;
+  /** Upgrade a viewable placeholder to a local original on first navigation. */
+  loadOriginal?: () => Promise<ImageSlideSource | null>;
+  /** Return localized copy only; raw Host errors are never rendered. */
+  originalErrorMessage?: (error: unknown) => string;
 }
 
 export interface ImageViewerApi {
@@ -18,14 +29,18 @@ export interface ImageViewerApi {
   copyImage: (pathOrUrl: string) => Promise<boolean>;
 }
 
+/**
+ * Keep context identity outside the provider's Fast Refresh boundary so
+ * mounted providers and refreshed consumers retain the same context.
+ */
 export const ImageViewerContext = createContext<ImageViewerApi | null>(null);
 
 export function useImageViewer(): ImageViewerApi {
-  const ctx = useContext(ImageViewerContext);
-  if (!ctx) {
+  const context = useContext(ImageViewerContext);
+  if (!context) {
     throw new Error("useImageViewer must be used within ImageViewerProvider");
   }
-  return ctx;
+  return context;
 }
 
 const OPTIONAL_IMAGE_VIEWER: ImageViewerApi = {
@@ -37,6 +52,5 @@ const OPTIONAL_IMAGE_VIEWER: ImageViewerApi = {
 
 /** Safe hook when provider may be absent (returns stable no-ops). */
 export function useImageViewerOptional(): ImageViewerApi {
-  const ctx = useContext(ImageViewerContext);
-  return ctx ?? OPTIONAL_IMAGE_VIEWER;
+  return useContext(ImageViewerContext) ?? OPTIONAL_IMAGE_VIEWER;
 }

--- a/src/components/ThemeEditorApp.preview.test.tsx
+++ b/src/components/ThemeEditorApp.preview.test.tsx
@@ -1,0 +1,127 @@
+/** @vitest-environment jsdom */
+import type { ReactNode } from "react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import "@/test/jsdomStubs";
+
+vi.mock("@/providers/ThemeProvider", () => ({
+  ThemeProvider: ({ children }: { children: ReactNode }) => children,
+}));
+vi.mock("@/providers/SkinShareProvider", () => ({
+  SkinShareProvider: ({ children }: { children: ReactNode }) => children,
+}));
+vi.mock("@/hooks/useAppearanceEditorModel", () => ({
+  useAppearanceEditorModel: () => ({
+    model: { t: (key: string) => key },
+    toast: null,
+  }),
+}));
+vi.mock("@/lib/api/settings", () => ({
+  settingsGet: async () => ({ locale: "en" }),
+}));
+vi.mock("@/lib/wallpaperExportBake", () => ({
+  watchWallpaperViewportAspect: async () => () => {},
+}));
+vi.mock("@/lib/themeEditorShell", () => ({
+  readThemeEditorBootLocale: () => "en",
+  applyThemeEditorHtmlLang: vi.fn(),
+  OPEN_SETTINGS_FROM_EDITOR_EVENT: "open-settings",
+}));
+vi.mock("@/lib/imageSrc", () => ({
+  resolveImageSrc: async (src: string) => src,
+}));
+vi.mock("@/lib/imageLightboxFit", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/imageLightboxFit")>()),
+  loadImageNaturalSize: async () => ({ width: 640, height: 360 }),
+}));
+vi.mock("@/components/settings/AppearanceSection", async () => {
+  const { useImageViewerOptional } = await import(
+    "@/components/ImageViewerContext"
+  );
+  return {
+    AppearanceSection: () => {
+      const viewer = useImageViewerOptional();
+      return (
+        <>
+          <button
+            onClick={() =>
+              viewer.open([
+                {
+                  src: "https://media.example.test/video.mp4",
+                  kind: "video",
+                },
+              ])
+            }
+          >
+            Preview video
+          </button>
+          <button
+            onClick={() =>
+              viewer.open([
+                {
+                  src: "https://media.example.test/image.jpg",
+                  kind: "image",
+                },
+              ])
+            }
+          >
+            Preview image
+          </button>
+        </>
+      );
+    },
+  };
+});
+
+import { ThemeEditorApp } from "./ThemeEditorApp";
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("standalone theme editor media preview", () => {
+  it.each(["video", "image"] as const)(
+    "opens and closes a real %s lightbox",
+    async (kind) => {
+      vi.spyOn(HTMLMediaElement.prototype, "play").mockResolvedValue();
+      vi.spyOn(HTMLMediaElement.prototype, "pause").mockImplementation(
+        () => {},
+      );
+      render(<ThemeEditorApp />);
+
+      fireEvent.click(
+        screen.getByRole("button", { name: `Preview ${kind}` }),
+      );
+      await waitFor(() => {
+        expect(document.querySelector(".yarl__portal")).not.toBeNull();
+      });
+      if (kind === "video") {
+        const video = document.querySelector<HTMLVideoElement>(
+          ".yarl__portal video",
+        );
+        expect(video?.controls).toBe(true);
+        expect(video?.querySelector("source")?.src).toBe(
+          "https://media.example.test/video.mp4",
+        );
+      } else {
+        expect(
+          document.querySelector<HTMLImageElement>(
+            '.yarl__portal img[src="https://media.example.test/image.jpg"]',
+          ),
+        ).not.toBeNull();
+      }
+
+      fireEvent.click(screen.getByRole("button", { name: "Close" }));
+      await waitFor(() => {
+        expect(document.querySelector(".yarl__portal")).toBeNull();
+      });
+    },
+  );
+});

--- a/src/components/ThemeEditorApp.tsx
+++ b/src/components/ThemeEditorApp.tsx
@@ -4,6 +4,7 @@
  */
 import { useEffect, useState } from "react";
 import { AppearanceSection } from "@/components/settings/AppearanceSection";
+import { ImageViewerProvider } from "@/components/ImageViewer";
 import {
   WindowControls,
   tauriDragRegion,
@@ -154,9 +155,11 @@ function ThemeEditorBody() {
         <h1 className="theme-editor-shell__title sr-only">
           {model.t("user.themeEditor")}
         </h1>
-        <SettingsModelProvider value={model}>
-          <AppearanceSection />
-        </SettingsModelProvider>
+        <ImageViewerProvider locale={locale}>
+          <SettingsModelProvider value={model}>
+            <AppearanceSection />
+          </SettingsModelProvider>
+        </ImageViewerProvider>
       </div>
       {toast ? (
         <div className="app-toast" role="status">

--- a/src/components/WallpaperImagineControls.test.tsx
+++ b/src/components/WallpaperImagineControls.test.tsx
@@ -2,6 +2,7 @@
  * @vitest-environment jsdom
  */
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import "@/test/jsdomStubs";
 import {
@@ -270,7 +271,7 @@ describe("WallpaperImagineControls", () => {
     );
   });
 
-  it("turns the active generation action into cancel", () => {
+  it("keeps generation disabled while a separate cancel action is available", () => {
     const onCancelGeneration = vi.fn();
     render(
       <WallpaperImagineControls
@@ -288,6 +289,106 @@ describe("WallpaperImagineControls", () => {
       screen.getByRole("button", { name: "common.cancel" }),
     );
     expect(onCancelGeneration).toHaveBeenCalledTimes(1);
+    expect(
+      screen.getByRole<HTMLButtonElement>("button", {
+        name: "settings.wallpaperSource.generateVideo",
+      }).disabled,
+    ).toBe(true);
+  });
+
+  it.each(["image", "edit", "video"] as const)(
+    "does not turn a delayed cancel click into another %s generation",
+    async (mode) => {
+      const user = userEvent.setup();
+      const active = model({
+        mode,
+        prompt: "A quiet lake",
+        videoSourcePath: "/source.png",
+        videoSourceStatus: "ready",
+        generating: true,
+      });
+      const view = render(
+        <WallpaperImagineControls t={t} locked model={active} />,
+      );
+      const cancel = screen.getByRole<HTMLButtonElement>("button", {
+        name: "common.cancel",
+      });
+      await user.pointer({ target: cancel, keys: "[MouseLeft>]" });
+      view.rerender(
+        <WallpaperImagineControls
+          t={t}
+          locked={false}
+          model={{ ...active, generating: false }}
+        />,
+      );
+      await user.pointer({ target: cancel, keys: "[/MouseLeft]" });
+      expect(active.onGenerate).not.toHaveBeenCalled();
+      expect(active.onCancelGeneration).not.toHaveBeenCalled();
+
+      const generateName =
+        mode === "image"
+          ? "settings.wallpaperSource.generate"
+          : mode === "edit"
+            ? "settings.wallpaperSource.editImage"
+            : "settings.wallpaperSource.generateVideo";
+      await user.click(screen.getByRole("button", { name: generateName }));
+      expect(active.onGenerate).toHaveBeenCalledOnce();
+    },
+  );
+
+  it("does not generate when Space is released after a request finishes", async () => {
+    const user = userEvent.setup();
+    const active = model({ prompt: "A quiet lake", generating: true });
+    const view = render(
+      <WallpaperImagineControls t={t} locked model={active} />,
+    );
+    const cancel = screen.getByRole<HTMLButtonElement>("button", {
+      name: "common.cancel",
+    });
+    cancel.focus();
+    await user.keyboard("[Space>]");
+    view.rerender(
+      <WallpaperImagineControls
+        t={t}
+        locked={false}
+        model={{ ...active, generating: false }}
+      />,
+    );
+    await user.keyboard("[/Space]");
+    expect(active.onGenerate).not.toHaveBeenCalled();
+    expect(active.onCancelGeneration).not.toHaveBeenCalled();
+  });
+
+  it("blocks duplicate cancellation while both action targets stay mounted", async () => {
+    const user = userEvent.setup();
+    const active = model({ prompt: "A quiet lake", generating: true });
+    const view = render(
+      <WallpaperImagineControls t={t} locked model={active} />,
+    );
+    const cancel = screen.getByRole<HTMLButtonElement>("button", {
+      name: "common.cancel",
+    });
+
+    await user.click(cancel);
+    view.rerender(
+      <WallpaperImagineControls
+        t={t}
+        locked
+        model={{ ...active, cancelling: true }}
+      />,
+    );
+    await user.click(cancel);
+    await user.click(
+      screen.getByRole("button", {
+        name: "settings.wallpaperSource.generate",
+      }),
+    );
+
+    expect(active.onCancelGeneration).toHaveBeenCalledTimes(1);
+    expect(active.onGenerate).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: "common.cancel" })).toBe(
+      cancel,
+    );
   });
 
   it("allows cancelling image generation while other controls are locked", () => {

--- a/src/components/WallpaperImagineControls.tsx
+++ b/src/components/WallpaperImagineControls.tsx
@@ -80,9 +80,9 @@ export function WallpaperImagineControls({
   const preparingSource = videoSourceStatus === "preparing";
   const hardLocked = locked && !preparingSource && !generating;
   const sourceReady = videoSourceStatus === "ready" && !!videoSourcePath;
-  const cancellableGeneration = generating;
   const generateDisabled =
     hardLocked ||
+    generating ||
     (mode === "image" ? !prompt.trim() : !sourceReady) ||
     (mode === "edit" && !prompt.trim()) ||
     cancelling;
@@ -253,18 +253,12 @@ export function WallpaperImagineControls({
         ) : null}
         <button
           type="button"
-          className={cancellableGeneration ? "btn btn--ghost" : "btn btn--solid"}
-          disabled={generating ? cancelling : generateDisabled}
+          className="btn btn--solid"
+          disabled={generateDisabled}
           aria-busy={generating}
-          onClick={cancellableGeneration ? onCancelGeneration : onGenerate}
+          onClick={onGenerate}
         >
-          {generating ? (
-            cancelling ? (
-              t("settings.wallpaperSource.cancellingVideo")
-            ) : (
-              t("common.cancel")
-            )
-          ) : mode === "video" ? (
+          {mode === "video" ? (
             <>
               <IconPlay size={15} />
               <span>{t("settings.wallpaperSource.generateVideo")}</span>
@@ -274,6 +268,21 @@ export function WallpaperImagineControls({
           ) : (
             t("settings.wallpaperSource.generate")
           )}
+        </button>
+        {/* Keep both targets mounted so a delayed release cannot change intent. */}
+        <button
+          type="button"
+          className="btn btn--ghost"
+          disabled={!generating || cancelling}
+          aria-busy={cancelling}
+          title={
+            cancelling
+              ? t("settings.wallpaperSource.cancellingVideo")
+              : undefined
+          }
+          onClick={onCancelGeneration}
+        >
+          {t("common.cancel")}
         </button>
       </div>
     </div>

--- a/src/components/WallpaperMediaDetails.test.tsx
+++ b/src/components/WallpaperMediaDetails.test.tsx
@@ -228,7 +228,7 @@ describe("WallpaperMediaDetails", () => {
       screen.getByRole("button", { name: "Open full-size preview" }),
     );
     expect(viewer.open).toHaveBeenCalledWith([
-      { src: "/original.png", title: "Original title" },
+      { src: "/original.png", kind: "image", title: "Original title" },
     ]);
     fireEvent.keyDown(document, { key: "Escape" });
     expect(viewer.close).toHaveBeenCalledTimes(1);

--- a/src/components/WallpaperMediaDetails.tsx
+++ b/src/components/WallpaperMediaDetails.tsx
@@ -231,6 +231,7 @@ function MediaDetailsContent({
                 viewer.open([
                   {
                     src: item.localPath!,
+                    kind: item.kind === "video" ? "video" : "image",
                     title: item.textPreview || undefined,
                   },
                 ]);

--- a/src/components/WallpaperSourceFooter.tsx
+++ b/src/components/WallpaperSourceFooter.tsx
@@ -2,41 +2,39 @@ import type { WallpaperSourceModalProps } from "./WallpaperSourceModal";
 
 type Props = {
   t: WallpaperSourceModalProps["t"];
-  selected: boolean;
-  locked: boolean;
   applying: boolean;
+  applyDisabled: boolean;
   onClose: () => void;
-  applySelected: () => Promise<void>;
+  onApply: () => void;
 };
 
 export function WallpaperSourceFooter({
-  t, selected, locked, applying, onClose, applySelected,
+  t,
+  applying,
+  applyDisabled,
+  onClose,
+  onApply,
 }: Props) {
   return (
-        <>
-          <span className="wallpaper-source-footer-hint">
-            {selected
-              ? t("settings.wallpaperSource.previewThenApply")
-              : t("settings.wallpaperSource.clickToPreview")}
-          </span>
-          <button
-            type="button"
-            className="btn btn--ghost"
-            onClick={onClose}
-            disabled={applying}
-          >
-            {t("common.cancel")}
-          </button>
-          <button
-            type="button"
-            className="btn btn--solid"
-            disabled={!selected || locked}
-            onClick={() => void applySelected()}
-          >
-            {applying
-              ? t("settings.wallpaperSource.applying")
-              : t("settings.wallpaperSource.apply")}
-          </button>
-        </>
+    <>
+      <button
+        type="button"
+        className="btn btn--ghost"
+        onClick={onClose}
+        disabled={applying}
+      >
+        {t("common.close")}
+      </button>
+      <button
+        type="button"
+        className="btn btn--solid"
+        disabled={applyDisabled}
+        onClick={onApply}
+      >
+        {applying
+          ? t("settings.wallpaperSource.applying")
+          : t("settings.wallpaperSource.apply")}
+      </button>
+    </>
   );
 }

--- a/src/components/WallpaperSourceGallery.test.tsx
+++ b/src/components/WallpaperSourceGallery.test.tsx
@@ -1,8 +1,28 @@
 /** @vitest-environment jsdom */
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { WallpaperGalleryItem } from "@/lib/wallpaperSource";
 import { WallpaperSourceGallery } from "./WallpaperSourceGallery";
+
+const ensureMediaEndpoint = vi.hoisted(() => vi.fn(async () => null));
+const resolveImageSrcSync = vi.hoisted(() =>
+  vi.fn<(path: string) => string | null>(
+    (path) => `http://127.0.0.1/media/${encodeURIComponent(path)}`,
+  ),
+);
+
+vi.mock("@/lib/imageSrc", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/imageSrc")>()),
+  ensureMediaEndpoint,
+  resolveImageSrcSync,
+}));
 
 vi.mock("@/lib/api/wallpaper", () => ({
   wallpaperLibraryFindById: vi.fn(),
@@ -66,6 +86,67 @@ afterEach(() => {
 });
 
 describe("WallpaperSourceGallery media details", () => {
+  it("keeps the existing media fallback when endpoint boot fails", async () => {
+    ensureMediaEndpoint.mockRejectedValueOnce(new Error("endpoint unavailable"));
+    const path = "H:/wallpapers/imagine/fallback.mp4";
+    const videoItem: WallpaperGalleryItem = {
+      ...item,
+      id: "fallback-video",
+      kind: "video",
+      source: "imagine",
+      localPath: path,
+      fullUrl: `file://${path}`,
+      thumbUrl: "",
+    };
+    resolveImageSrcSync.mockReturnValueOnce(null);
+    const { container } = render(
+      <WallpaperSourceGallery
+        {...galleryProps([videoItem])}
+        tab="imagine"
+      />,
+    );
+
+    await waitFor(() => expect(ensureMediaEndpoint).toHaveBeenCalledOnce());
+    expect(container.querySelector("video")?.getAttribute("src")).toBe(
+      `file://${path}`,
+    );
+  });
+
+  it.each(["library", "imagine"] as const)(
+    "refreshes a local video in %s after the media endpoint becomes ready",
+    async (tab) => {
+      let finishEndpoint!: () => void;
+      ensureMediaEndpoint.mockReturnValueOnce(
+        new Promise((resolve) => {
+          finishEndpoint = () => resolve(null);
+        }),
+      );
+      resolveImageSrcSync.mockReturnValueOnce(null);
+      const path = "H:/wallpapers/imagine/result.mp4";
+      const videoItem: WallpaperGalleryItem = {
+        ...item,
+        id: "generated-video",
+        kind: "video",
+        source: "imagine",
+        localPath: path,
+        fullUrl: `file://${path}`,
+        thumbUrl: "",
+      };
+      const { container } = render(
+        <WallpaperSourceGallery
+          {...galleryProps([videoItem])}
+          tab={tab}
+        />,
+      );
+      const video = container.querySelector("video");
+      expect(video?.getAttribute("src")).toBe(`file://${path}`);
+      await act(async () => finishEndpoint());
+      expect(video?.getAttribute("src")).toBe(
+        `http://127.0.0.1/media/${encodeURIComponent(path)}`,
+      );
+    },
+  );
+
   it("opens details with an item-specific label and forwards prompt reuse", () => {
     const onReusePrompt = vi.fn();
     render(

--- a/src/components/WallpaperSourceGallery.tsx
+++ b/src/components/WallpaperSourceGallery.tsx
@@ -9,7 +9,7 @@ import type { WallpaperSourceModalProps, WallpaperSourceTab } from "./WallpaperS
 import type { WallpaperGalleryItem } from "@/lib/wallpaperSource";
 import type { WallpaperGalleryEmptyPresentation } from "@/lib/wallpaperGalleryPro";
 import { resolveWallpaperXCitation } from "@/lib/xEvidenceCitation";
-import { resolveImageSrcSync } from "@/lib/imageSrc";
+import { ensureMediaEndpoint, resolveImageSrcSync } from "@/lib/imageSrc";
 import { WallpaperProviderThumbnail } from "./WallpaperProviderThumbnail";
 import { GrokAlbumThumbnail } from "./GrokAlbumThumbnail";
 import { WallpaperMediaDetails } from "./WallpaperMediaDetails";
@@ -95,6 +95,7 @@ export function WallpaperSourceGallery({
 }: Props) {
   const isImagineLayout = tab === "imagine";
   const isLibraryTab = tab === "library";
+  const [, refreshMediaSources] = useState(0);
   const [details, setDetails] = useState<{ tab: string; id: string } | null>(
     null,
   );
@@ -112,6 +113,21 @@ export function WallpaperSourceGallery({
     );
   }, [tab, visibleItems]);
 
+  useEffect(() => {
+    let mounted = true;
+    void ensureMediaEndpoint()
+      .then(() => {
+        if (mounted) refreshMediaSources((value) => value + 1);
+      })
+      .catch(() => {
+        // Keep the existing source fallback; endpoint boot may be retried by
+        // the normal media resolver on the next user action.
+      });
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
   return (
     <>
       {/*
@@ -121,7 +137,10 @@ export function WallpaperSourceGallery({
       */}
       <div
         ref={scrollRef}
-        className="wallpaper-masonry-scroll"
+        className={
+          "wallpaper-masonry-scroll" +
+          (isImagineLayout ? " wallpaper-masonry-scroll--imagine" : "")
+        }
         role="list"
         aria-label={t("settings.wallpaperSource.gallery")}
         aria-busy={busy || previewingId !== null}

--- a/src/components/WallpaperSourceModal.grokAlbum.test.tsx
+++ b/src/components/WallpaperSourceModal.grokAlbum.test.tsx
@@ -1,5 +1,12 @@
 /** @vitest-environment jsdom */
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import "@/test/jsdomStubs";
 
@@ -11,6 +18,7 @@ const mocks = vi.hoisted(() => ({
   })),
   cancelMedia: vi.fn(),
   viewerOpen: vi.fn(),
+  viewerClose: vi.fn(),
   loadMore: vi.fn(async () => undefined),
 }));
 
@@ -111,7 +119,11 @@ vi.mock("@/components/GrokAlbumThumbnail", () => ({
 }));
 
 vi.mock("@/components/ImageViewerContext", () => ({
-  useImageViewerOptional: () => ({ open: mocks.viewerOpen }),
+  useImageViewerOptional: () => ({
+    open: mocks.viewerOpen,
+    close: mocks.viewerClose,
+    isOpen: () => false,
+  }),
 }));
 
 vi.mock("@/components/GlassModal", () => ({
@@ -187,18 +199,107 @@ describe("WallpaperSourceModal Grok Saved integration", () => {
     expect(firstCard?.hasAttribute("disabled")).toBe(false);
     fireEvent.click(firstCard!);
 
-    await waitFor(() => expect(mocks.fetchMedia).toHaveBeenCalledOnce());
+    await waitFor(() => expect(mocks.viewerOpen).toHaveBeenCalledOnce());
+    expect(mocks.fetchMedia).not.toHaveBeenCalled();
+    const slide = mocks.viewerOpen.mock.calls[0]?.[0]?.[0] as {
+      kind: string;
+      loadOriginal?: () => Promise<{
+        src: string;
+        kind?: string;
+        mime?: string;
+      } | null>;
+    };
+    expect(slide.kind).toBe("image");
+    expect(slide.loadOriginal).toBeTypeOf("function");
+
+    let original:
+      | { src: string; kind?: string; mime?: string }
+      | null
+      | undefined;
+    await act(async () => {
+      original = await slide.loadOriginal?.();
+    });
+    expect(mocks.fetchMedia).toHaveBeenCalledOnce();
     expect(mocks.fetchMedia).toHaveBeenCalledWith(
       "https://assets.grok.com/generated/one.jpg",
     );
-    await waitFor(() => expect(mocks.viewerOpen).toHaveBeenCalledOnce());
-    expect(mocks.viewerOpen.mock.calls[0]?.[0]).toEqual([
-      expect.objectContaining({ src: "C:/wallpapers/grok-album/selected.jpg" }),
-    ]);
+    expect(original).toMatchObject({
+      src: "C:/wallpapers/grok-album/selected.jpg",
+      kind: "image",
+      mime: "image/jpeg",
+    });
 
     fireEvent.click(screen.getByRole("button", { name: "modal-close" }));
     expect(mocks.cancelMedia).toHaveBeenCalled();
     expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("closes the viewer and rejects a late original after the album revision changes", async () => {
+    let finishFetch!: (result: {
+      path: string;
+      name: string;
+      mime: string;
+    }) => void;
+    mocks.fetchMedia.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finishFetch = resolve;
+        }),
+    );
+    const view = renderAlbum();
+    const firstCard = screen.getAllByRole("button", {
+      name: "settings.wallpaperSource.openPreview",
+    })[0];
+    fireEvent.click(firstCard!);
+    await waitFor(() => expect(mocks.viewerOpen).toHaveBeenCalledOnce());
+    const slide = mocks.viewerOpen.mock.calls[0]?.[0]?.[0] as {
+      loadOriginal: () => Promise<{ src: string } | null>;
+    };
+    let pendingOriginal!: Promise<{ src: string } | null>;
+    await act(async () => {
+      pendingOriginal = slide.loadOriginal();
+      await Promise.resolve();
+    });
+    expect(mocks.fetchMedia).toHaveBeenCalledOnce();
+
+    albumState = {
+      ...albumState,
+      historyRevision: 1,
+      items: [
+        {
+          ...defaultAlbumItems[0],
+          id: "saved-new-page",
+          fullUrl: "https://assets.grok.com/generated/new-page.jpg",
+        },
+      ],
+    };
+    view.rerender(
+      <WallpaperSourceModal
+        open
+        initialTab="grok_album"
+        t={((key: string) => key) as never}
+        onClose={vi.fn()}
+        onPickFile={vi.fn()}
+      />,
+    );
+    await waitFor(() => expect(mocks.viewerClose).toHaveBeenCalled());
+    expect(mocks.cancelMedia).toHaveBeenCalled();
+
+    let original: { src: string } | null = { src: "unexpected" };
+    await act(async () => {
+      finishFetch({
+        path: "C:/wallpapers/grok-album/stale.jpg",
+        name: "stale.jpg",
+        mime: "image/jpeg",
+      });
+      original = await pendingOriginal;
+    });
+    expect(original).toBeNull();
+    expect(
+      screen.getAllByRole("button", {
+        name: "settings.wallpaperSource.openPreview",
+      }),
+    ).toHaveLength(1);
   });
 
   it("restores filters and scroll after loading, then clears them for a new album revision", async () => {

--- a/src/components/WallpaperSourceModal.providers.test.tsx
+++ b/src/components/WallpaperSourceModal.providers.test.tsx
@@ -1,5 +1,13 @@
 /** @vitest-environment jsdom */
-import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import { afterEach, beforeEach, expect, it, vi } from "vitest";
 import "@/test/jsdomStubs";
 import type { WallpaperRemoteSearchResult } from "@/lib/wallpaperRemoteSearch";
@@ -251,14 +259,34 @@ it("searches and previews Web results through the remote media pipeline", async 
   );
   await waitFor(() => expect(cards()).toHaveLength(1));
   fireEvent.click(cards()[0]);
-  await waitFor(() =>
-    expect(mocks.remoteFetch).toHaveBeenCalledWith(
+  await waitFor(() => expect(mocks.preview).toHaveBeenCalledTimes(1));
+  expect(mocks.remoteFetch).not.toHaveBeenCalled();
+  const slide = mocks.preview.mock.calls[0]?.[0]?.[0] as {
+    loadOriginal?: () => Promise<{
+      src: string;
+      kind?: string;
+      mime?: string;
+    } | null>;
+  };
+  expect(slide.loadOriginal).toBeTypeOf("function");
+
+  let original:
+    | { src: string; kind?: string; mime?: string }
+    | null
+    | undefined;
+  await act(async () => {
+    original = await slide.loadOriginal?.();
+  });
+  expect(mocks.remoteFetch).toHaveBeenCalledWith(
       "web",
       "https://images.example.com/web-first.jpg",
       expect.any(String),
-    ),
   );
-  expect(mocks.preview).toHaveBeenCalledTimes(1);
+  expect(original).toMatchObject({
+    src: "C:/cache/sky.jpg",
+    kind: "image",
+    mime: "image/jpeg",
+  });
 });
 it("favorites a provider result without downloading it again to unfavorite", async () => {
   await initial(["favorite"]);
@@ -323,16 +351,30 @@ it("keeps the card after a catalog failure and clears the error on favorite retr
   expect(mocks.preview).not.toHaveBeenCalled();
 });
 
-it("keeps a preview card retryable when saving its provenance fails", async () => {
+it("keeps a lazy preview retryable when saving its provenance fails", async () => {
   mocks.libraryRemember.mockRejectedValueOnce(new Error("catalog_write_failed"));
   await initial(["preview-save"]);
 
   fireEvent.click(cards()[0]);
-  await screen.findByText("settings.wallpaperSource.library.saveFailed");
-  expect(cards()).toHaveLength(1);
-  expect(mocks.preview).not.toHaveBeenCalled();
-  fireEvent.click(cards()[0]);
   await waitFor(() => expect(mocks.preview).toHaveBeenCalledTimes(1));
+  const slide = mocks.preview.mock.calls[0]?.[0]?.[0] as {
+    loadOriginal?: () => Promise<{ src: string } | null>;
+  };
+  expect(slide.loadOriginal).toBeTypeOf("function");
+  await act(async () => {
+    await expect(slide.loadOriginal!()).rejects.toThrow("catalog_write_failed");
+  });
+  expect(cards()).toHaveLength(1);
+  expect(
+    screen.queryByText("settings.wallpaperSource.library.saveFailed"),
+  ).toBeNull();
+
+  let original: { src: string } | null | undefined;
+  await act(async () => {
+    original = await slide.loadOriginal?.();
+  });
+  expect(original).toMatchObject({ src: "C:/cache/sky.jpg" });
+  expect(mocks.remoteFetch).toHaveBeenCalledTimes(2);
 });
 
 it("disables preview only for the card whose favorite is being saved", async () => {

--- a/src/components/WallpaperSourceModal.tsx
+++ b/src/components/WallpaperSourceModal.tsx
@@ -21,6 +21,7 @@ import {
 import { useWallpaperProviderController } from "@/hooks/useWallpaperProviderController";
 import { useWallpaperGrokAlbum } from "@/hooks/useWallpaperGrokAlbum";
 import { useWallpaperImagineController } from "@/hooks/useWallpaperImagineController";
+import { useWallpaperItemPreview } from "@/hooks/useWallpaperItemPreview";
 import { useWallpaperLibrary } from "@/hooks/useWallpaperLibrary";
 import { useWallpaperCatalogMetadata } from "@/hooks/useWallpaperCatalogMetadata";
 import { useWallpaperMediaActions } from "@/hooks/useWallpaperMediaActions";
@@ -70,8 +71,11 @@ import {
 import { WallpaperPrepareError } from "@/lib/themeSkin";
 import { wallpaperRemoteProgressMessageKey } from "@/lib/wallpaperRemoteSearch";
 import { resolveGrokAlbumEmptyPresentation } from "@/lib/grokAlbum";
-import { cancelGrokAlbumMediaRequests } from "@/lib/grokAlbumMedia";
-import { ensureLocalWallpaperMedia } from "@/lib/wallpaperSourceMedia";
+import {
+  cancelGrokAlbumMediaRequests,
+  cancelRemoteWallpaperMediaRequests,
+  ensureLocalWallpaperMedia,
+} from "@/lib/wallpaperSourceMedia";
 import { isWallpaperImageItem } from "@/lib/wallpaperImagine";
 import type { MessageKey } from "@/i18n";
 
@@ -184,6 +188,7 @@ export function WallpaperSourceModal({
   } = useWallpaperXSearch();
   const [applying, setApplying] = useState(false);
   const [previewingId, setPreviewingId] = useState<string | null>(null);
+  const sourceGenerationRef = useRef(0);
   const [error, setError] = useState<string | null>(null);
   const [errorCode, setErrorCode] = useState<WallpaperSourceErrorCode | null>(
     null,
@@ -241,19 +246,30 @@ export function WallpaperSourceModal({
     applying ||
     previewingId !== null;
   const close = useCallback(() => {
+    sourceGenerationRef.current += 1;
+    viewer.close?.();
     void cancelX();
     void provider.cancel();
     cancelGrokAlbumMediaRequests();
+    void cancelRemoteWallpaperMediaRequests().catch(() => {});
     imagineController.cancelAll();
     onClose();
-  }, [cancelX, imagineController.cancelAll, provider.cancel, onClose]);
+  }, [
+    cancelX,
+    imagineController.cancelAll,
+    onClose,
+    provider.cancel,
+    viewer,
+  ]);
   useEffect(() => {
     if (!open || tab !== "x") void cancelX();
   }, [open, tab, cancelX]);
   useEffect(() => {
+    sourceGenerationRef.current += 1;
     sourceHistory.clear();
     pendingHistoryRestore.current = null;
     pendingScrollRestore.current = null;
+    setApplying(false);
     if (!open) return;
     setTab(initialTab);
     setError(null);
@@ -269,6 +285,13 @@ export function WallpaperSourceModal({
     setItems([]);
     setContinuation(null);
   }, [open, initialTab, sourceHistory.clear]);
+
+  useEffect(
+    () => () => {
+      sourceGenerationRef.current += 1;
+    },
+    [],
+  );
 
   useEffect(() => {
     if (pendingHistoryRestore.current !== tab) return;
@@ -328,6 +351,15 @@ export function WallpaperSourceModal({
     ) {
       return;
     }
+    sourceGenerationRef.current += 1;
+    viewer.close?.();
+    cancelGrokAlbumMediaRequests();
+    setApplying(false);
+    setPreviewingId(null);
+    setStatusHint(null);
+    // A revision can represent a different page or account. Do not carry a
+    // materialized path from the previous authenticated album into it.
+    setItems(grokAlbum.items);
     setGalleryFilter("");
     setKindFilter("all");
     setSelectedId(null);
@@ -339,12 +371,14 @@ export function WallpaperSourceModal({
       pendingScrollRestore.current = null;
     }
   }, [
+    grokAlbum.items,
     grokAlbum.historyRevision,
     grokAlbum.status,
     open,
     sourceHistory.clear,
     sourceHistory.scrollRef,
     tab,
+    viewer.close,
   ]);
 
   const galleryItems =
@@ -505,8 +539,11 @@ export function WallpaperSourceModal({
         top: saved?.scrollTop ?? 0,
       };
 
+      sourceGenerationRef.current += 1;
+      viewer.close?.();
       void provider.cancel();
-      if (tab === "grok_album") cancelGrokAlbumMediaRequests();
+      cancelGrokAlbumMediaRequests();
+      void cancelRemoteWallpaperMediaRequests().catch(() => {});
       if (tab === "imagine") imagineController.cancelAll();
 
       setTab(nextTab);
@@ -544,12 +581,30 @@ export function WallpaperSourceModal({
       sourceHistory.scrollRef,
       statusHint,
       tab,
+      viewer,
     ],
   );
 
   const selected = useMemo(
     () => visibleItems.find((i) => i.id === selectedId) ?? null,
     [visibleItems, selectedId],
+  );
+
+  const runProviderSearch = useCallback(() => {
+    sourceGenerationRef.current += 1;
+    viewer.close?.();
+    void cancelRemoteWallpaperMediaRequests().catch(() => {});
+    return provider.search();
+  }, [provider.search, viewer]);
+
+  const refreshGrokAlbum = useCallback(
+    (sync: boolean) => {
+      sourceGenerationRef.current += 1;
+      viewer.close?.();
+      cancelGrokAlbumMediaRequests();
+      return sync ? grokAlbum.sync() : grokAlbum.refresh();
+    },
+    [grokAlbum.refresh, grokAlbum.sync, viewer],
   );
 
   const runXSearch = useCallback(async () => {
@@ -568,6 +623,10 @@ export function WallpaperSourceModal({
       setCiteSummary(null);
       return;
     }
+    sourceGenerationRef.current += 1;
+    viewer.close?.();
+    cancelGrokAlbumMediaRequests();
+    void cancelRemoteWallpaperMediaRequests().catch(() => {});
     setError(null);
     setErrorCode(null);
     setCiteSummary(null);
@@ -641,7 +700,7 @@ export function WallpaperSourceModal({
       setErrorCode(code);
       setError(errorMessage(t, code));
     }
-  }, [query, sort, t, searchX, xBusy, routeSaving]);
+  }, [query, sort, t, searchX, viewer, xBusy, routeSaving]);
 
   const dropItem = useCallback((id: string) => {
     setItems((prev) => prev.filter((it) => it.id !== id));
@@ -701,100 +760,20 @@ export function WallpaperSourceModal({
     [busy, applying, previewingId, t, dropItem, library.remove],
   );
 
-  /**
-   * Click card: load original into library if needed, open ImageViewer, mark selected.
-   * User then confirms with footer "Set as background".
-   */
-  const openItemPreview = useCallback(
-    async (item: WallpaperGalleryItem) => {
-      if (interactionLocked || mediaActions.busyIds.has(item.id)) {
-        return;
-      }
-      if (!isDesktopHost()) {
-        setErrorCode("generic");
-        setError(t("settings.wallpaperSource.err.desktopOnly"));
-        return;
-      }
-      setSelectedId(item.id);
-      setPreviewingId(item.id);
-      setError(null);
-      setErrorCode(null);
-      setStatusHint(t("settings.wallpaperSource.loadingOriginal"));
-      try {
-        // Ensure current item is local (download orig for remote X media)
-        const local = await ensureLocalWallpaperMedia(item);
-        setItems((prev) =>
-          prev.map((it) =>
-            it.id === item.id
-              ? {
-                  ...it,
-                  localPath: local.path,
-                  fullUrl: it.fullUrl.startsWith("http")
-                    ? it.fullUrl
-                    : `file://${local.path}`,
-                  metadata: local.metadata ?? it.metadata,
-                }
-              : it,
-          ),
-        );
-
-        // Only open downloadable / already-local siblings in the lightbox
-        // (visible set only — never invent off-filter CDN cards).
-        const viable = visibleItems.filter((it) => {
-          if (it.id === item.id || it.localPath) return true;
-          // Saved URLs carry browser-session signatures. Never hand another
-          // one to the main renderer; each selected original must cross the
-          // isolated Host bridge first.
-          if (item.source === "grok_album") return false;
-          return it.fullUrl.startsWith("http");
-        });
-        const slides = viable.map((it) => {
-          const path =
-            it.id === item.id
-              ? local.path
-              : it.localPath ||
-                (it.fullUrl.startsWith("file://")
-                  ? decodeURIComponent(it.fullUrl.replace(/^file:\/\//, ""))
-                  : it.fullUrl);
-          return {
-            src: path,
-            title:
-              it.textPreview ||
-              it.prompt ||
-              (it.username ? `@${it.username}` : undefined),
-            alt: it.prompt || it.textPreview || undefined,
-          };
-        });
-        const idx = Math.max(
-          0,
-          viable.findIndex((it) => it.id === item.id),
-        );
-        viewer.open(slides, idx);
-      } catch (e) {
-        const code = parseWallpaperSourceError(e);
-        // A failed catalog write does not make a downloaded image invalid.
-        // Keep its card so the user can retry without repeating the search.
-        if (code !== "catalog_write_failed") dropItem(item.id);
-        setErrorCode(code);
-        setError(
-          code === "catalog_write_failed"
-            ? t("settings.wallpaperSource.library.saveFailed")
-            : errorMessage(t, code),
-        );
-      } finally {
-        setPreviewingId(null);
-        setStatusHint(null);
-      }
-    },
-    [
-      interactionLocked,
-      visibleItems,
-      t,
-      viewer,
-      dropItem,
-      mediaActions.busyIds,
-    ],
-  );
+  const openItemPreview = useWallpaperItemPreview({
+    interactionLocked,
+    busyIds: mediaActions.busyIds,
+    visibleItems,
+    sourceGenerationRef,
+    viewer,
+    t,
+    setItems,
+    setSelectedId,
+    setPreviewingId,
+    setError,
+    setErrorCode,
+    setStatusHint,
+  });
 
   const openExternalSource = useCallback((url: string) => {
     void api.openExternalUrl(url).catch(() => {
@@ -837,12 +816,14 @@ export function WallpaperSourceModal({
       setError(t("settings.wallpaperSource.err.desktopOnly"));
       return;
     }
+    const sourceGeneration = sourceGenerationRef.current;
     setApplying(true);
     setError(null);
     setErrorCode(null);
     setStatusHint(t("settings.wallpaperSource.applying"));
     try {
       const local = await ensureLocalWallpaperMedia(selected);
+      if (sourceGeneration !== sourceGenerationRef.current) return;
       // Local evidence ring for X picks only (path + status url meta; no cloud).
       if ((selected.source || "x") === "x") {
         const pick = wallpaperXEvidenceFromGalleryItem(selected, local.path);
@@ -852,9 +833,12 @@ export function WallpaperSourceModal({
         name: local.name,
         mime: local.mime,
       });
+      if (sourceGeneration !== sourceGenerationRef.current) return;
       await onPickFile(file);
+      if (sourceGeneration !== sourceGenerationRef.current) return;
       onClose();
     } catch (e) {
+      if (sourceGeneration !== sourceGenerationRef.current) return;
       // prepareWallpaperFromFile errors use settings.wallpaper.err.* keys
       if (e instanceof WallpaperPrepareError) {
         const key = `settings.wallpaper.err.${e.code}` as MessageKey;
@@ -867,8 +851,10 @@ export function WallpaperSourceModal({
       setErrorCode(code);
       setError(errorMessage(t, code));
     } finally {
-      setApplying(false);
-      setStatusHint(null);
+      if (sourceGeneration === sourceGenerationRef.current) {
+        setApplying(false);
+        setStatusHint(null);
+      }
     }
   }, [selected, t, onPickFile, onClose, mediaActions.busyIds]);
 
@@ -900,6 +886,14 @@ export function WallpaperSourceModal({
     }
   }, [continuation, xBusy, applying, routeSaving, searchMore, t]);
 
+  const closeModalLayer = useCallback(() => {
+    if (viewer.isOpen?.()) {
+      viewer.close?.();
+      return;
+    }
+    close();
+  }, [close, viewer]);
+
   const authNeeded = errorCode === "auth_required";
   const locked = busy || applying || previewingId !== null;
   const showGalleryFilters =
@@ -919,7 +913,7 @@ export function WallpaperSourceModal({
     <>
       <GlassModal
         open={open}
-        onClose={close}
+        onClose={closeModalLayer}
         title={t("settings.wallpaperSource.title")}
         size="lg"
         className="wallpaper-source-modal"
@@ -929,14 +923,14 @@ export function WallpaperSourceModal({
         footer={
           <WallpaperSourceFooter
             t={t}
-            selected={selected !== null}
-            locked={
+            applying={applying}
+            applyDisabled={
+              selected === null ||
               interactionLocked ||
               (selected !== null && mediaActions.busyIds.has(selected.id))
             }
-            applying={applying}
             onClose={close}
-            applySelected={applySelected}
+            onApply={() => void applySelected()}
           />
         }
       >
@@ -963,9 +957,12 @@ export function WallpaperSourceModal({
               invalidKey={errorCode === "pexels_key_invalid"}
               t={t}
               setQuery={setQuery}
-              search={provider.search}
+              search={runProviderSearch}
               cancel={provider.cancel}
               onSaved={() => {
+                sourceGenerationRef.current += 1;
+                viewer.close?.();
+                void cancelRemoteWallpaperMediaRequests().catch(() => {});
                 sourceHistory.clear("pexels");
                 void provider.clear();
                 setItems([]);
@@ -991,10 +988,10 @@ export function WallpaperSourceModal({
                 void grokAlbum.open(t("settings.wallpaperGrokAlbum"));
               }}
               onSync={() => {
-                void grokAlbum.sync();
+                void refreshGrokAlbum(true);
               }}
               onRefresh={() => {
-                void grokAlbum.refresh();
+                void refreshGrokAlbum(false);
               }}
             />
           ) : (

--- a/src/components/WallpaperSourceModal.viewer.integration.test.tsx
+++ b/src/components/WallpaperSourceModal.viewer.integration.test.tsx
@@ -1,0 +1,279 @@
+/**
+ * @vitest-environment jsdom
+ */
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import "@/test/jsdomStubs";
+
+vi.mock("@/lib/imageLightboxFit", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/imageLightboxFit")>(
+    "@/lib/imageLightboxFit",
+  );
+  return {
+    ...actual,
+    loadImageNaturalSize: vi.fn(async () => ({ width: 1920, height: 1080 })),
+  };
+});
+
+const fetchAlbumMedia = vi.hoisted(() =>
+  vi.fn(async () => ({
+    path: "H:\\wallpapers\\integration-video.mp4",
+    name: "integration-video.mp4",
+    mime: "video/mp4",
+    bytes: 1024,
+  })),
+);
+const xSearchState = vi.hoisted(() => ({
+  search: vi.fn(),
+  loadMore: vi.fn(),
+  cancel: vi.fn(async () => true),
+}));
+const providerState = vi.hoisted(() => ({
+  busy: false,
+  loadingMore: false,
+  stage: null as string | null,
+  canLoadMore: true,
+}));
+const webItems = vi.hoisted(() => [
+  {
+    id: "web-integration-image",
+    thumbUrl: "https://images.example.test/wallpaper.jpg",
+    fullUrl: "https://images.example.test/wallpaper.jpg",
+    kind: "image" as const,
+    source: "web" as const,
+    width: 1920,
+    height: 1080,
+    sourceUrl: "https://photos.example.test/wallpaper",
+    sourceName: "photos.example.test",
+  },
+]);
+const albumState = vi.hoisted(() => {
+  const albumUrl =
+    "https://assets.grok.com/users/test/generated/fake/integration-video.mp4";
+  return {
+    items: [
+      {
+        id: "album-integration-video",
+        thumbUrl: albumUrl,
+        fullUrl: albumUrl,
+        kind: "video" as const,
+        source: "grok_album" as const,
+        width: 1280,
+        height: 720,
+      },
+    ],
+    open: vi.fn(),
+    sync: vi.fn(),
+    refresh: vi.fn(),
+    loadMore: vi.fn(),
+  };
+});
+
+vi.mock("@/hooks/useWallpaperXSearch", () => ({
+  useWallpaperXSearch: () => ({
+    busy: false,
+    loadingMore: false,
+    requestId: null,
+    stage: null,
+    progressiveItems: [],
+    search: xSearchState.search,
+    loadMore: xSearchState.loadMore,
+    cancel: xSearchState.cancel,
+  }),
+}));
+
+vi.mock("@/hooks/useWallpaperGrokAlbum", () => ({
+  useWallpaperGrokAlbum: () => ({
+    historyRevision: 0,
+    items: albumState.items,
+    status: "ready",
+    cachedCount: 1,
+    visibleCount: 1,
+    busy: false,
+    syncing: false,
+    loadingMore: false,
+    hasSynced: true,
+    errorCode: null,
+    canLoadMore: false,
+    open: albumState.open,
+    sync: albumState.sync,
+    refresh: albumState.refresh,
+    loadMore: albumState.loadMore,
+  }),
+}));
+
+vi.mock("@/hooks/useWallpaperProviderController", () => ({
+  useWallpaperProviderController: (options: {
+    setItems: (items: typeof webItems) => void;
+    setHasSearched: (value: boolean) => void;
+  }) => ({
+    ...providerState,
+    search: async () => {
+      options.setItems(webItems);
+      options.setHasSearched(true);
+    },
+    loadMore: vi.fn(),
+    cancel: vi.fn(async () => false),
+    clear: vi.fn(async () => false),
+    capture: vi.fn(() => null),
+    restore: vi.fn(),
+  }),
+}));
+
+vi.mock("@/lib/api", () => ({
+  isDesktopHost: () => true,
+  isTauri: () => false,
+  settingsGet: vi.fn(async () => ({ wallpaperXSearchMode: "cli" })),
+  settingsSet: vi.fn(async () => ({})),
+  wallpaperFetchMedia: vi.fn(),
+  wallpaperLibraryRemember: vi.fn(async () => ({ source: "grok_album" })),
+  wallpaperLibraryLookup: vi.fn(async () => []),
+  wallpaperRemoteFetchMedia: vi.fn(async () => ({
+    path: "H:\\wallpapers\\web-integration.jpg",
+    name: "web-integration.jpg",
+    mime: "image/jpeg",
+    bytes: 1024,
+  })),
+  wallpaperRemoteThumbnail: vi.fn(async () => ({
+    dataUrl: "data:image/jpeg;base64,YWJj",
+    width: 32,
+    height: 18,
+  })),
+  wallpaperRemoteCancelMediaRequests: vi.fn(async () => 0),
+  wallpaperRemoteCancelAllMediaRequests: vi.fn(async () => 0),
+  wallpaperGrokAlbumFetchMedia: fetchAlbumMedia,
+  wallpaperGrokAlbumThumbnail: vi.fn(async () => ({
+    dataUrl: "data:image/jpeg;base64,YWJj",
+    width: 32,
+    height: 18,
+  })),
+  wallpaperGrokAlbumCancelRequests: vi.fn(async () => 0),
+  wallpaperGrokAlbumCancelAllRequests: vi.fn(async () => 0),
+  wallpaperImagine: vi.fn(),
+  wallpaperLibraryList: vi.fn(),
+  wallpaperLibraryPage: vi.fn(async () => ({
+    items: [],
+    nextCursor: null,
+    total: 0,
+    kindCounts: { all: 0, image: 0, video: 0 },
+  })),
+  wallpaperLibraryDelete: vi.fn(),
+  openExternalUrl: vi.fn(),
+}));
+
+vi.mock("@/components/Select", () => ({
+  Select: ({ value }: { value: string }) => <span>{value}</span>,
+}));
+
+import { ImageViewerProvider } from "./ImageViewer";
+import { WallpaperSourceModal } from "./WallpaperSourceModal";
+import { setMediaEndpoint } from "@/lib/imageSrc";
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  vi.clearAllMocks();
+  setMediaEndpoint(null);
+  providerState.busy = false;
+  providerState.loadingMore = false;
+  providerState.stage = null;
+  providerState.canLoadMore = true;
+});
+
+describe("WallpaperSourceModal image viewer integration", () => {
+  it("retries a failed original in the real preview without dropping its card", async () => {
+    setMediaEndpoint({
+      baseUrl: "http://127.0.0.1:19200",
+      token: "test-only",
+    });
+    vi.spyOn(HTMLMediaElement.prototype, "play").mockResolvedValue();
+    vi.spyOn(HTMLMediaElement.prototype, "pause").mockImplementation(() => {});
+    fetchAlbumMedia.mockRejectedValueOnce(
+      new Error("download_failed: private diagnostic"),
+    );
+
+    render(
+      <ImageViewerProvider locale="en">
+        <WallpaperSourceModal
+          open
+          initialTab="grok_album"
+          t={(key) =>
+            key === "settings.wallpaperSource.err.download_failed"
+              ? "Download failed"
+              : key
+          }
+          onClose={vi.fn()}
+          onPickFile={vi.fn()}
+        />
+      </ImageViewerProvider>,
+    );
+
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: "settings.wallpaperSource.openPreview",
+      }),
+    );
+    const retry = await screen.findByRole("button", { name: "Retry" });
+    const portal = document.querySelector<HTMLElement>(".yarl__portal");
+    expect(portal).not.toBeNull();
+    expect(within(portal!).getByRole("status").textContent).toContain(
+      "Download failed",
+    );
+    expect(document.body.textContent).not.toContain("private diagnostic");
+    expect(document.querySelector(".wallpaper-masonry__preview")).not.toBeNull();
+
+    fireEvent.click(retry);
+    await waitFor(() => expect(portal?.querySelector("video")).not.toBeNull());
+    expect(fetchAlbumMedia).toHaveBeenCalledTimes(2);
+    expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+  });
+
+  it("opens the real preview while a provider page is loading", async () => {
+    const props = {
+      open: true,
+      initialTab: "web" as const,
+      t: ((key: string) => key) as never,
+      onClose: vi.fn(),
+      onPickFile: vi.fn(),
+    };
+    const view = render(
+      <ImageViewerProvider locale="en">
+        <WallpaperSourceModal {...props} />
+      </ImageViewerProvider>,
+    );
+
+    fireEvent.change(
+      screen.getByRole("searchbox", {
+        name: "settings.wallpaperSource.search",
+      }),
+      { target: { value: "night skyline" } },
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: "settings.wallpaperSource.search" }),
+    );
+    const card = await screen.findByRole("button", {
+      name: "settings.wallpaperSource.openPreview",
+    });
+
+    providerState.busy = true;
+    providerState.loadingMore = true;
+    view.rerender(
+      <ImageViewerProvider locale="en">
+        <WallpaperSourceModal {...props} />
+      </ImageViewerProvider>,
+    );
+
+    expect((card as HTMLButtonElement).disabled).toBe(false);
+    fireEvent.click(card);
+    await waitFor(() =>
+      expect(document.querySelector(".yarl__portal")).not.toBeNull(),
+    );
+  });
+});

--- a/src/hooks/useWallpaperItemPreview.ts
+++ b/src/hooks/useWallpaperItemPreview.ts
@@ -1,0 +1,299 @@
+import {
+  useCallback,
+  type Dispatch,
+  type RefObject,
+  type SetStateAction,
+} from "react";
+import type {
+  ImageSlideInput,
+  ImageViewerApi,
+} from "@/components/ImageViewerContext";
+import type { MessageKey } from "@/i18n";
+import { isDesktopHost } from "@/lib/api";
+import { peekGrokAlbumThumbnail } from "@/lib/grokAlbumThumbnail";
+import { peekRemoteWallpaperThumbnail } from "@/lib/remoteWallpaperThumbnail";
+import { isWallpaperRemoteSource } from "@/lib/wallpaperRemoteSearch";
+import {
+  parseWallpaperSourceError,
+  type WallpaperGalleryItem,
+  type WallpaperSourceErrorCode,
+} from "@/lib/wallpaperSource";
+import {
+  EMPTY_WALLPAPER_IMAGE_PLACEHOLDER,
+  ensureLocalWallpaperMedia,
+} from "@/lib/wallpaperSourceMedia";
+import { wallpaperSourceErrorMessage } from "@/lib/wallpaperSourcePresentation";
+
+type Translate = (
+  key: MessageKey,
+  vars?: Record<string, string | number | undefined | null>,
+) => string;
+
+type PreviewOptions = {
+  interactionLocked: boolean;
+  busyIds: ReadonlySet<string>;
+  visibleItems: WallpaperGalleryItem[];
+  sourceGenerationRef: RefObject<number>;
+  viewer: ImageViewerApi;
+  t: Translate;
+  setItems: Dispatch<SetStateAction<WallpaperGalleryItem[]>>;
+  setSelectedId: Dispatch<SetStateAction<string | null>>;
+  setPreviewingId: Dispatch<SetStateAction<string | null>>;
+  setError: Dispatch<SetStateAction<string | null>>;
+  setErrorCode: Dispatch<SetStateAction<WallpaperSourceErrorCode | null>>;
+  setStatusHint: Dispatch<SetStateAction<string | null>>;
+};
+
+function slideTitle(item: WallpaperGalleryItem): string | undefined {
+  return (
+    item.textPreview ||
+    item.prompt ||
+    (item.username ? `@${item.username}` : undefined)
+  );
+}
+
+function decodedFilePath(url: string): string {
+  return decodeURIComponent(url.replace(/^file:\/\//, ""));
+}
+
+export function useWallpaperItemPreview({
+  interactionLocked,
+  busyIds,
+  visibleItems,
+  sourceGenerationRef,
+  viewer,
+  t,
+  setItems,
+  setSelectedId,
+  setPreviewingId,
+  setError,
+  setErrorCode,
+  setStatusHint,
+}: PreviewOptions) {
+  return useCallback(
+    async (item: WallpaperGalleryItem) => {
+      if (interactionLocked || busyIds.has(item.id)) return;
+      if (!isDesktopHost()) {
+        setErrorCode("generic");
+        setError(t("settings.wallpaperSource.err.desktopOnly"));
+        return;
+      }
+
+      const sourceGeneration = sourceGenerationRef.current;
+      setSelectedId(item.id);
+      setPreviewingId(item.id);
+      setError(null);
+      setErrorCode(null);
+
+      const lazyAlbumPreview = item.source === "grok_album";
+      const lazyRemotePreview = isWallpaperRemoteSource(item.source);
+      const eagerLocalPreview = !lazyAlbumPreview && !lazyRemotePreview;
+      if (eagerLocalPreview) {
+        setStatusHint(t("settings.wallpaperSource.loadingOriginal"));
+      }
+
+      try {
+        const local = eagerLocalPreview
+          ? await ensureLocalWallpaperMedia(item)
+          : null;
+        if (sourceGeneration !== sourceGenerationRef.current) return;
+
+        if (local) {
+          setItems((previous) =>
+            previous.map((candidate) =>
+              candidate.id === item.id
+                ? {
+                    ...candidate,
+                    localPath: local.path,
+                    metadata: local.metadata ?? candidate.metadata,
+                    fullUrl: candidate.fullUrl.startsWith("http")
+                      ? candidate.fullUrl
+                      : `file://${local.path}`,
+                  }
+                : candidate,
+            ),
+          );
+        }
+
+        const viable = visibleItems.filter(
+          (candidate) =>
+            candidate.id === item.id ||
+            !!candidate.localPath ||
+            candidate.fullUrl.startsWith("http"),
+        );
+        const slides: ImageSlideInput[] = viable.map((candidate) => {
+          const lazyAlbumOriginal =
+            candidate.source === "grok_album" &&
+            !candidate.localPath &&
+            candidate.fullUrl.startsWith("http");
+          if (lazyAlbumOriginal) {
+            const thumbnail =
+              peekGrokAlbumThumbnail(
+                candidate.thumbUrl || candidate.fullUrl,
+              ) || EMPTY_WALLPAPER_IMAGE_PLACEHOLDER;
+            return {
+              src: thumbnail,
+              kind: "image",
+              title: slideTitle(candidate),
+              alt: candidate.prompt || candidate.textPreview || undefined,
+              onView: () => {
+                if (sourceGeneration === sourceGenerationRef.current) {
+                  setSelectedId(candidate.id);
+                }
+              },
+              originalErrorMessage: (error) =>
+                wallpaperSourceErrorMessage(
+                  t,
+                  parseWallpaperSourceError(error),
+                ),
+              loadOriginal: async () => {
+                if (sourceGeneration !== sourceGenerationRef.current) {
+                  return null;
+                }
+                try {
+                  const loaded = await ensureLocalWallpaperMedia(candidate);
+                  if (sourceGeneration !== sourceGenerationRef.current) {
+                    return null;
+                  }
+                  setItems((previous) =>
+                    previous.map((current) =>
+                      current.id === candidate.id
+                        ? {
+                            ...current,
+                            localPath: loaded.path,
+                            metadata: loaded.metadata ?? current.metadata,
+                            fullUrl: current.fullUrl.startsWith("http")
+                              ? current.fullUrl
+                              : `file://${loaded.path}`,
+                          }
+                        : current,
+                    ),
+                  );
+                  return {
+                    src: loaded.path,
+                    kind: candidate.kind === "video" ? "video" : "image",
+                    mime: loaded.mime,
+                    poster:
+                      candidate.kind === "video" ? thumbnail : undefined,
+                  };
+                } catch (error) {
+                  if (sourceGeneration !== sourceGenerationRef.current) {
+                    return null;
+                  }
+                  throw error;
+                }
+              },
+            };
+          }
+
+          const lazyRemoteOriginal =
+            isWallpaperRemoteSource(candidate.source) &&
+            !candidate.localPath &&
+            candidate.fullUrl.startsWith("http");
+          if (lazyRemoteOriginal) {
+            return {
+              src:
+                peekRemoteWallpaperThumbnail(candidate) ||
+                candidate.thumbUrl ||
+                candidate.fullUrl,
+              kind: "image",
+              title: slideTitle(candidate),
+              alt: candidate.prompt || candidate.textPreview || undefined,
+              onView: () => {
+                if (sourceGeneration === sourceGenerationRef.current) {
+                  setSelectedId(candidate.id);
+                }
+              },
+              originalErrorMessage: (error) =>
+                wallpaperSourceErrorMessage(
+                  t,
+                  parseWallpaperSourceError(error),
+                ),
+              loadOriginal: async () => {
+                if (sourceGeneration !== sourceGenerationRef.current) {
+                  return null;
+                }
+                try {
+                  const loaded = await ensureLocalWallpaperMedia(candidate);
+                  if (sourceGeneration !== sourceGenerationRef.current) {
+                    return null;
+                  }
+                  setItems((previous) =>
+                    previous.map((current) =>
+                      current.id === candidate.id
+                        ? {
+                            ...current,
+                            localPath: loaded.path,
+                            metadata: loaded.metadata ?? current.metadata,
+                          }
+                        : current,
+                    ),
+                  );
+                  return {
+                    src: loaded.path,
+                    kind: "image" as const,
+                    mime: loaded.mime,
+                  };
+                } catch (error) {
+                  if (sourceGeneration !== sourceGenerationRef.current) {
+                    return null;
+                  }
+                  throw error;
+                }
+              },
+            };
+          }
+
+          const path =
+            candidate.id === item.id && local
+              ? local.path
+              : candidate.localPath ||
+                (candidate.fullUrl.startsWith("file://")
+                  ? decodedFilePath(candidate.fullUrl)
+                  : candidate.fullUrl);
+          return {
+            src: path,
+            kind: candidate.kind === "video" ? "video" : "image",
+            mime: candidate.id === item.id ? local?.mime : undefined,
+            title: slideTitle(candidate),
+            alt: candidate.prompt || candidate.textPreview || undefined,
+            onView: () => {
+              if (sourceGeneration === sourceGenerationRef.current) {
+                setSelectedId(candidate.id);
+              }
+            },
+          };
+        });
+        const index = Math.max(
+          0,
+          viable.findIndex((candidate) => candidate.id === item.id),
+        );
+        viewer.open(slides, index);
+      } catch (error) {
+        if (sourceGeneration !== sourceGenerationRef.current) return;
+        const code = parseWallpaperSourceError(error);
+        setErrorCode(code);
+        setError(wallpaperSourceErrorMessage(t, code));
+      } finally {
+        if (sourceGeneration === sourceGenerationRef.current) {
+          setPreviewingId(null);
+          setStatusHint(null);
+        }
+      }
+    },
+    [
+      busyIds,
+      interactionLocked,
+      setError,
+      setErrorCode,
+      setItems,
+      setPreviewingId,
+      setSelectedId,
+      setStatusHint,
+      sourceGenerationRef,
+      t,
+      viewer,
+      visibleItems,
+    ],
+  );
+}

--- a/src/i18n/messages/de/core.ts
+++ b/src/i18n/messages/de/core.ts
@@ -1,6 +1,8 @@
 /** de messages — domain: core */
 export const deCore = {
   "app.name": "Grok",
+  "image.loadingOriginal": "Original wird geladen…",
+  "image.originalFailed": "Original konnte nicht geladen werden. Die Vorschau bleibt verfügbar.",
   "app.tagline": "MIT · Inoffiziell · Schwesterprojekt grok-go",
   "app.versionFooter": "Grok v0.2.33 · MIT · Inoffiziell · Schwesterprojekt grok-go",
   "window.minimize": "Minimieren",

--- a/src/i18n/messages/en/core.ts
+++ b/src/i18n/messages/en/core.ts
@@ -1,6 +1,8 @@
 /** English messages — domain: core */
 export const enCore = {
   "app.name": "Grok",
+  "image.loadingOriginal": "Loading original...",
+  "image.originalFailed": "Could not load the original. The preview is still available.",
   "app.tagline": "MIT · Unofficial · Sister project grok-go",
   "app.versionFooter": "Grok v0.2.33 · MIT · Unofficial · Sister project grok-go",
   "window.minimize": "Minimize",

--- a/src/i18n/messages/es/core.ts
+++ b/src/i18n/messages/es/core.ts
@@ -1,6 +1,8 @@
 /** es messages — domain: core */
 export const esCore = {
   "app.name": "Grok",
+  "image.loadingOriginal": "Cargando original…",
+  "image.originalFailed": "No se pudo cargar el original. La vista previa sigue disponible.",
   "app.tagline": "MIT · No oficial · Proyecto hermano grok-go",
   "app.versionFooter": "Grok v0.2.33 · MIT · No oficial · Proyecto hermano grok-go",
   "window.minimize": "Minimizar",

--- a/src/i18n/messages/fil/core.ts
+++ b/src/i18n/messages/fil/core.ts
@@ -1,6 +1,8 @@
 /** fil messages — domain: core */
 export const filCore = {
   "app.name": "Grok",
+  "image.loadingOriginal": "Nilo-load ang orihinal…",
+  "image.originalFailed": "Hindi ma-load ang orihinal. Makikita pa rin ang preview.",
   "app.tagline": "MIT · Hindi opisyal · Sister project grok-go",
   "app.versionFooter": "Grok v0.2.33 · MIT · Hindi opisyal · Sister project grok-go",
   "window.minimize": "I-minimize",

--- a/src/i18n/messages/fr/core.ts
+++ b/src/i18n/messages/fr/core.ts
@@ -1,6 +1,8 @@
 /** fr messages — domain: core */
 export const frCore = {
   "app.name": "Grok",
+  "image.loadingOriginal": "Chargement de l’original…",
+  "image.originalFailed": "Impossible de charger l’original. L’aperçu reste disponible.",
   "app.tagline": "MIT · Non officiel · Projet sœur grok-go",
   "app.versionFooter": "Grok v0.2.33 · MIT · Non officiel · Projet sœur grok-go",
   "window.minimize": "Réduire",

--- a/src/i18n/messages/id/core.ts
+++ b/src/i18n/messages/id/core.ts
@@ -1,6 +1,8 @@
 /** id messages — domain: core */
 export const idCore = {
   "app.name": "Grok",
+  "image.loadingOriginal": "Memuat berkas asli…",
+  "image.originalFailed": "Berkas asli tidak dapat dimuat. Pratinjau tetap tersedia.",
   "app.tagline": "MIT · Tidak resmi · Proyek saudara grok-go",
   "app.versionFooter": "Grok v0.2.33 · MIT · Tidak resmi · Proyek saudara grok-go",
   "window.minimize": "Perkecil",

--- a/src/i18n/messages/it/core.ts
+++ b/src/i18n/messages/it/core.ts
@@ -1,6 +1,8 @@
 /** it messages — domain: core */
 export const itCore = {
   "app.name": "Grok",
+  "image.loadingOriginal": "Caricamento dell’originale…",
+  "image.originalFailed": "Impossibile caricare l’originale. L’anteprima è ancora disponibile.",
   "app.tagline": "MIT · Non ufficiale · Progetto gemello grok-go",
   "app.versionFooter": "Grok v0.2.33 · MIT · Non ufficiale · Progetto gemello grok-go",
   "window.minimize": "Riduci a icona",

--- a/src/i18n/messages/ja/core.ts
+++ b/src/i18n/messages/ja/core.ts
@@ -1,6 +1,8 @@
 /** ja messages — domain: core */
 export const jaCore = {
   "app.name": "Grok",
+  "image.loadingOriginal": "元のファイルを読み込み中…",
+  "image.originalFailed": "元のファイルを読み込めませんでした。プレビューは引き続き表示できます。",
   "app.tagline": "MIT · 非公式 · 姉妹プロジェクト grok-go",
   "app.versionFooter": "Grok v0.2.33 · MIT · 非公式 · 姉妹プロジェクト grok-go",
   "window.minimize": "最小化",

--- a/src/i18n/messages/ko/core.ts
+++ b/src/i18n/messages/ko/core.ts
@@ -1,6 +1,8 @@
 /** ko messages — domain: core */
 export const koCore = {
   "app.name": "Grok",
+  "image.loadingOriginal": "원본을 불러오는 중…",
+  "image.originalFailed": "원본을 불러오지 못했습니다. 미리보기는 계속 볼 수 있습니다.",
   "app.tagline": "MIT · 비공식 · 자매 프로젝트 grok-go",
   "app.versionFooter": "Grok v0.2.33 · MIT · 비공식 · 자매 프로젝트 grok-go",
   "window.minimize": "최소화",

--- a/src/i18n/messages/pt-BR/core.ts
+++ b/src/i18n/messages/pt-BR/core.ts
@@ -1,6 +1,8 @@
 /** pt-BR messages — domain: core */
 export const ptBRCore = {
   "app.name": "Grok",
+  "image.loadingOriginal": "Carregando original…",
+  "image.originalFailed": "Não foi possível carregar o original. A prévia continua disponível.",
   "app.tagline": "MIT · Não oficial · Projeto irmão grok-go",
   "app.versionFooter": "Grok v0.2.33 · MIT · Não oficial · Projeto irmão grok-go",
   "window.minimize": "Minimizar",

--- a/src/i18n/messages/ru/core.ts
+++ b/src/i18n/messages/ru/core.ts
@@ -1,6 +1,8 @@
 /** ru messages — domain: core */
 export const ruCore = {
   "app.name": "Grok",
+  "image.loadingOriginal": "Загрузка оригинала…",
+  "image.originalFailed": "Не удалось загрузить оригинал. Предпросмотр по-прежнему доступен.",
   "app.tagline": "MIT · Неофициально · Сестринский проект grok-go",
   "app.versionFooter": "Grok v0.2.33 · MIT · Неофициально · Сестринский проект grok-go",
   "window.minimize": "Свернуть",

--- a/src/i18n/messages/ta/core.ts
+++ b/src/i18n/messages/ta/core.ts
@@ -1,6 +1,8 @@
 /** ta messages — domain: core */
 export const taCore = {
   "app.name": "Grok",
+  "image.loadingOriginal": "அசல் கோப்பு ஏற்றப்படுகிறது…",
+  "image.originalFailed": "அசல் கோப்பை ஏற்ற முடியவில்லை. முன்னோட்டம் தொடர்ந்து கிடைக்கும்.",
   "app.tagline": "MIT · அதிகாரப்பூர்வமற்றது · சகோதரத் திட்டம் grok-go",
   "app.versionFooter": "Grok v0.2.33 · MIT · அதிகாரப்பூர்வமற்றது · சகோதரத் திட்டம் grok-go",
   "window.minimize": "சிறிதாக்கு",

--- a/src/i18n/messages/uk/core.ts
+++ b/src/i18n/messages/uk/core.ts
@@ -1,6 +1,8 @@
 /** uk messages — domain: core */
 export const ukCore = {
   "app.name": "Grok",
+  "image.loadingOriginal": "Завантаження оригіналу…",
+  "image.originalFailed": "Не вдалося завантажити оригінал. Попередній перегляд залишається доступним.",
   "app.tagline": "MIT · Неофіційний · Сестринський проєкт grok-go",
   "app.versionFooter": "Grok v0.2.33 · MIT · Неофіційний · Сестринський проєкт grok-go",
   "window.minimize": "Згорнути",

--- a/src/i18n/messages/zh-TW/core.ts
+++ b/src/i18n/messages/zh-TW/core.ts
@@ -1,6 +1,8 @@
 /** Traditional Chinese messages — domain: core */
 export const zhTWCore = {
   "app.name": "Grok",
+  "image.loadingOriginal": "正在載入原始檔案…",
+  "image.originalFailed": "原始檔案載入失敗，仍可查看預覽。",
   "app.tagline": "MIT · 非 xAI 官方 · 姊妹專案 grok-go",
   "app.versionFooter": "Grok v0.2.33 · MIT · 非 xAI 官方 · 姊妹專案 grok-go",
   "window.minimize": "最小化",

--- a/src/i18n/messages/zh/core.ts
+++ b/src/i18n/messages/zh/core.ts
@@ -1,6 +1,8 @@
 /** Simplified Chinese messages — domain: core */
 export const zhCore = {
   "app.name": "Grok",
+  "image.loadingOriginal": "正在加载原文件…",
+  "image.originalFailed": "原文件加载失败，仍可查看预览。",
   "app.tagline": "MIT · 非 xAI 官方 · 姐妹项目 grok-go",
   "app.versionFooter": "Grok v0.2.33 · MIT · 非 xAI 官方 · 姐妹项目 grok-go",
   "window.minimize": "最小化",

--- a/src/lib/wallpaperSourceMedia.ts
+++ b/src/lib/wallpaperSourceMedia.ts
@@ -15,6 +15,9 @@ import {
 } from "@/lib/wallpaperRemoteSearch";
 import { clearRemoteWallpaperThumbnailCache } from "@/lib/remoteWallpaperThumbnail";
 
+export const EMPTY_WALLPAPER_IMAGE_PLACEHOLDER =
+  "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==";
+
 export { cancelGrokAlbumMediaRequests };
 
 export async function cancelRemoteWallpaperMediaRequests(): Promise<void> {

--- a/src/styles/settings.part4.css
+++ b/src/styles/settings.part4.css
@@ -187,6 +187,7 @@
   width: 100%;
   resize: vertical;
   min-height: calc(var(--ws-control-h) * 3);
+  max-height: min(160px, 24vh);
   padding: 8px 12px;
   line-height: 1.4;
 }
@@ -323,15 +324,6 @@
   gap: 8px;
 }
 
-.wallpaper-source-footer-hint {
-  flex: 1 1 140px;
-  min-width: 0;
-  margin-right: auto;
-  font-size: 12px;
-  color: var(--text-tertiary);
-  line-height: 1.3;
-}
-
 .wallpaper-source-status {
   margin: 0;
   font-size: 12.5px;
@@ -370,11 +362,12 @@
  */
 .wallpaper-masonry-scroll {
   flex: 1 1 auto;
-  min-height: 180px;
+  min-height: 0;
   /* Prefer remaining modal body height over a short fixed cap */
   max-height: none;
   overflow-x: hidden;
   overflow-y: auto;
+  scrollbar-gutter: stable;
   overscroll-behavior: contain;
   -webkit-overflow-scrolling: touch;
   padding: 2px;
@@ -400,10 +393,27 @@
   overflow: visible;
 }
 
-/* Imagine: one full-width column */
+/* Keep generated portrait and landscape media within the available scroller. */
 .wallpaper-masonry--full {
   column-count: 1;
   column-gap: 0;
+}
+
+.wallpaper-masonry-scroll--imagine {
+  container-type: size;
+}
+
+.wallpaper-masonry--full .wallpaper-masonry__media-shell {
+  height: clamp(160px, calc(100cqh - 64px), 360px);
+}
+
+.wallpaper-masonry--full .wallpaper-masonry__preview,
+.wallpaper-masonry--full .wallpaper-masonry__img,
+.wallpaper-masonry--full .wallpaper-masonry__thumb-placeholder {
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+  object-fit: contain;
 }
 
 .wallpaper-masonry__empty {
@@ -1227,6 +1237,7 @@ button.settings-wallpaper__preview:hover:not(:disabled) {
 
 .wallpaper-masonry--full .wallpaper-masonry__card-wrap {
   display: block;
+  max-width: 560px;
   margin-bottom: 12px;
 }
 

--- a/src/styles/sidebar.part1.css
+++ b/src/styles/sidebar.part1.css
@@ -68,6 +68,32 @@ button:disabled {
   user-select: none;
 }
 
+.image-original-status {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  max-width: min(400px, calc(100vw - 224px));
+  color: #fff;
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.image-original-status > span {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.image-original-status > button {
+  flex: 0 0 40px;
+  width: 40px;
+  height: 40px;
+}
+
+.image-original-status > button:focus-visible {
+  outline: 2px solid #fff;
+  outline-offset: -4px;
+}
+
 /* Zoomed past fit: drag to pan (YARL adds this class when zoom > 1). */
 .yarl__slide_wrapper_interactive {
   cursor: grab;


### PR DESCRIPTION
> **UI hold**：本 PR 会改变设置 → 外观中的媒体预览、Imagine 操作区和独立主题编辑器可见界面；请由维护者审核后再决定是否合并。

## Summary

- 图片与视频统一使用全屏 Viewer；独立主题编辑器也提供完整预览上下文。
- Web、Openverse、Pexels 与 Grok Saved 先打开已验证缩略图，当前幻灯片再按需获取原图。
- 原图最多两路并发；快速导航只保留最新等待项，失败时保留缩略图、显示安全本地化文案并允许手动重试。
- 关闭 Viewer / 来源弹窗、切换来源、开始新搜索、刷新相册或 Grok Saved 页面/账户 revision 变化后，拒绝迟到结果并取消对应媒体请求。
- 本地视频在媒体端点就绪后刷新 URL；生成与取消保持两个稳定按钮，底部操作与 Imagine 单图布局同步收口。
- 补充 15 种语言文案、Viewer 生命周期文档和真实组件集成回归测试。

## Type of change

- [x] Bug fix
- [x] New feature
- [x] Documentation
- [x] Refactor / chore

## User-visible surfaces

- 设置 → 外观 → 壁纸来源：卡片可在分页加载期间继续点选，预览先显示缩略图再加载原图；失败可重试。
- 设置 → 外观 → Imagine：生成与取消不再复用同一 DOM 目标，单图和窄窗口布局更稳定。
- 独立主题编辑器：图片和视频都能打开全屏 Viewer。

## Verification

- [x] pnpm typecheck
- [x] pnpm test — 624 files / 7302 tests passed
- [x] pnpm lint
- [x] py -3 scripts/check-code-quality-gates.py --mode final
- [x] py -3 scripts/publish-website-downloads.py --self-test
- [x] pnpm deps:check
- [x] pnpm audit:prod — no known vulnerabilities
- [x] pnpm build:ui
- [x] cargo fmt --all -- --check
- [x] cargo clippy --all-targets -- -D warnings
- [x] Windows CI-equivalent test harness — 1836 passed / 1 ignored
- [x] git diff --check

普通 cargo test 在本机直接启动 harness 时仍会遇到仓库已知的 Windows 0xc0000139；按仓库 CI 同样的 PATH 清理 + Common Controls v6 manifest 流程运行后，全部 Rust 断言通过。本 PR 没有 Rust 源码改动。

## Checklist

- [x] User-facing strings go through src/i18n/（15 locales key parity）
- [x] No window.confirm / prompt / alert for product dialogs
- [x] docs/llm-wiki updated for the Viewer lifecycle contract
- [x] No secrets, auth files, local paths or temporary debug code included
- [x] No matching open Issue found; no issue is auto-closed

## Risk notes

- 共享 Viewer 是跨页面组件，已覆盖关闭/换源/快速导航/失败重试/视频渲染和独立编辑器集成。
- build:ui 仍会报告 main 已存在的 goalOrch 循环 chunk 警告；本 PR 未修改该模块，后续用独立稳定性 PR 处理。