### PR TITLE
fix(frontend): 修复外观热更新卡顿与主题菜单竞态

### DIFF
--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -10,7 +10,7 @@ import {
   type KeyboardEvent as ReactKeyboardEvent,
   type MouseEvent as ReactMouseEvent,
 } from "react";
-import { useThemeShell } from "@/providers/ThemeProvider";
+import { useThemeShell } from "@/providers/ThemeShellContext";
 import { usePetCompanion } from "@/hooks/usePetCompanion";
 import { useFloatingMenu } from "@/lib/floatingMenu";
 import { restoreSessionGate } from "@/lib/sessionGateRestore";

--- a/src/components/ReliabilityCenterModal.tsx
+++ b/src/components/ReliabilityCenterModal.tsx
@@ -31,8 +31,8 @@ import {
   type AuditLedgerEvent,
 } from "@/lib/auditLedger";
 import type { ProcessLimitEvent } from "@/lib/processBudget";
+import { assembleGoalOrchView } from "@/lib/goalOrchView";
 import {
-  assembleGoalOrchView,
   filterGoalOrchEvents,
   formatGoalOrchSummaryText,
   goalOrchPhaseLabelKey,

--- a/src/components/UserMenu.test.tsx
+++ b/src/components/UserMenu.test.tsx
@@ -73,7 +73,12 @@ it("opens the theme editor from the theme submenu footer group", async () => {
     </UserMenu>,
   );
 
-  fireEvent.mouseEnter(screen.getByRole("menuitem", { name: "Theme" }));
+  const themeItem = screen.getByRole("menuitem", { name: "Theme" });
+  fireEvent.mouseEnter(themeItem);
+  // A pointer enters the row before click. The click must not immediately
+  // close the submenu that pointer entry just opened.
+  fireEvent.click(themeItem);
+  expect(themeItem.getAttribute("aria-expanded")).toBe("true");
   const editor = await screen.findByRole("menuitem", { name: "Theme editor" });
   expect(document.querySelector(".user-menu__flyout-sep")).not.toBeNull();
   fireEvent.click(editor);

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -457,13 +457,7 @@ export function UserMenu({
               role="menuitem"
               aria-haspopup="menu"
               aria-expanded={themeSubOpen}
-              onClick={() => {
-                if (themeSubOpen) {
-                  setThemeSubOpen(false);
-                } else {
-                  openThemeSub();
-                }
-              }}
+              onClick={openThemeSub}
               onMouseEnter={openThemeSub}
               onMouseLeave={scheduleCloseThemeSub}
             >

--- a/src/components/settings/AppearanceChromeCard.tsx
+++ b/src/components/settings/AppearanceChromeCard.tsx
@@ -3,7 +3,7 @@
  */
 import { useEffect, useState } from "react";
 import { GlassModal } from "@/components/GlassModal";
-import { useThemeShell } from "@/providers/ThemeProvider";
+import { useThemeShell } from "@/providers/ThemeShellContext";
 import {
   THEME_DEFAULT_TEXT_COLOR,
   parseTextColor,

--- a/src/components/settings/AppearanceOpacityCard.tsx
+++ b/src/components/settings/AppearanceOpacityCard.tsx
@@ -4,7 +4,7 @@
  */
 import { IconHelp } from "@/components/icons";
 import { Tip } from "@/components/ui/tooltip";
-import { useThemeShell } from "@/providers/ThemeProvider";
+import { useThemeShell } from "@/providers/ThemeShellContext";
 import { useSettingsModel } from "@/providers/SettingsModelContext";
 
 function OpacitySlider(props: {

--- a/src/components/settings/SkinCatalogModal.tsx
+++ b/src/components/settings/SkinCatalogModal.tsx
@@ -8,7 +8,7 @@ import {
 } from "@/lib/skinCatalog";
 import { skinCatalogFetch, skinSourcesList } from "@/lib/api/skin";
 import { parseSkinPackError } from "@/lib/skinPack";
-import { useSkinShare } from "@/providers/SkinShareProvider";
+import { useSkinShare } from "@/providers/SkinShareContext";
 
 export function SkinCatalogModal({
   open,

--- a/src/components/settings/SkinPresetsCard.tsx
+++ b/src/components/settings/SkinPresetsCard.tsx
@@ -37,8 +37,8 @@ import {
   resolvePresetCardMedia,
   type PresetCardMedia,
 } from "@/lib/skinPresetCardMedia";
-import { useThemeShell } from "@/providers/ThemeProvider";
-import { useSkinShare } from "@/providers/SkinShareProvider";
+import { useThemeShell } from "@/providers/ThemeShellContext";
+import { useSkinShare } from "@/providers/SkinShareContext";
 import { useSettingsModel } from "@/providers/SettingsModelContext";
 import { GlassModal } from "@/components/GlassModal";
 import { Tip } from "@/components/ui/tooltip";

--- a/src/hooks/useAppearanceEditorModel.ts
+++ b/src/hooks/useAppearanceEditorModel.ts
@@ -141,7 +141,7 @@ import {
   SIDEBAR_SHOW_RELATIVE_TIME_CHANGE_EVENT,
 } from "@/lib/sidebarShowRelativeTimePref";
 import type { WallpaperSourceTab } from "@/components/WallpaperSourceModal";
-import { useThemeShell } from "@/providers/ThemeProvider";
+import { useThemeShell } from "@/providers/ThemeShellContext";
 import type { SettingsModel } from "@/providers/SettingsModelContext";
 import { notifyAppearanceChanged } from "@/lib/appearanceLiveSync";
 

--- a/src/lib/themeProviderHmr.guard.test.ts
+++ b/src/lib/themeProviderHmr.guard.test.ts
@@ -1,0 +1,83 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const sourceRoot = resolve(__dirname, "..");
+const themeProvider = readFileSync(
+  resolve(sourceRoot, "providers/ThemeProvider.tsx"),
+  "utf8",
+);
+const themeContext = readFileSync(
+  resolve(sourceRoot, "providers/ThemeShellContext.ts"),
+  "utf8",
+);
+const skinProvider = readFileSync(
+  resolve(sourceRoot, "providers/SkinShareProvider.tsx"),
+  "utf8",
+);
+const skinContext = readFileSync(
+  resolve(sourceRoot, "providers/SkinShareContext.ts"),
+  "utf8",
+);
+
+const themeConsumers = [
+  "app/AppWorkbench.tsx",
+  "hooks/useAppearanceEditorModel.ts",
+  "providers/SkinShareProvider.tsx",
+  "components/settings/AppearanceOpacityCard.tsx",
+  "components/settings/AppearanceChromeCard.tsx",
+  "components/settings/SkinPresetsCard.tsx",
+] as const;
+
+const skinConsumers = [
+  "components/settings/SkinCatalogModal.tsx",
+  "components/settings/SkinPresetsCard.tsx",
+] as const;
+
+describe("appearance provider Fast Refresh boundaries", () => {
+  it("keeps the theme context outside the component module", () => {
+    expect(themeProvider).toContain('from "@/providers/ThemeShellContext"');
+    expect(themeProvider).not.toContain("createContext(");
+    expect(themeProvider).not.toContain("export function useThemeShell");
+    expect(themeContext).toContain(
+      "export const ThemeShellContext = createContext",
+    );
+    expect(themeContext).toContain("export function useThemeShell");
+  });
+
+  it.each(themeConsumers)(
+    "imports the stable theme context from %s",
+    (relativePath) => {
+      const consumer = readFileSync(resolve(sourceRoot, relativePath), "utf8");
+      expect(consumer).toContain(
+        'import { useThemeShell } from "@/providers/ThemeShellContext";',
+      );
+      expect(consumer).not.toContain(
+        'import { useThemeShell } from "@/providers/ThemeProvider";',
+      );
+    },
+  );
+
+  it("keeps the skin-share context outside the component module", () => {
+    expect(skinProvider).toContain('from "@/providers/SkinShareContext"');
+    expect(skinProvider).not.toContain("createContext(");
+    expect(skinProvider).not.toContain("export function useSkinShare");
+    expect(skinContext).toContain(
+      "export const SkinShareContext = createContext",
+    );
+    expect(skinContext).toContain("export function useSkinShare");
+  });
+
+  it.each(skinConsumers)(
+    "imports the stable skin-share context from %s",
+    (relativePath) => {
+      const consumer = readFileSync(resolve(sourceRoot, relativePath), "utf8");
+      expect(consumer).toContain(
+        'import { useSkinShare } from "@/providers/SkinShareContext";',
+      );
+      expect(consumer).not.toContain(
+        'import { useSkinShare } from "@/providers/SkinShareProvider";',
+      );
+    },
+  );
+});

--- a/src/providers/SkinShareContext.ts
+++ b/src/providers/SkinShareContext.ts
@@ -1,0 +1,31 @@
+import { createContext, useContext } from "react";
+import type { SkinPackErrorCode } from "@/lib/skinPack";
+
+export type SkinShareNotice = {
+  kind: "err" | "warn";
+  code: SkinPackErrorCode | "unknown_skin" | "will_clear_wallpaper";
+};
+
+export type SkinShareValue = {
+  appearanceBusy: boolean;
+  notice: SkinShareNotice | null;
+  clearNotice: () => void;
+  openFilePreview: (path: string) => Promise<void>;
+  openPresetPreview: (id: string, undoMode?: boolean) => Promise<void>;
+  openCatalogPreview: (sourceId: string, packId: string) => Promise<void>;
+  refreshPending: () => Promise<void>;
+};
+
+export const SkinShareContext = createContext<SkinShareValue | null>(null);
+
+export function useSkinShare(): SkinShareValue {
+  const context = useContext(SkinShareContext);
+  if (!context) {
+    throw new Error("useSkinShare requires SkinShareProvider");
+  }
+  return context;
+}
+
+export function useSkinShareOptional(): SkinShareValue | null {
+  return useContext(SkinShareContext);
+}

--- a/src/providers/SkinShareProvider.tsx
+++ b/src/providers/SkinShareProvider.tsx
@@ -4,9 +4,7 @@
  */
 
 import {
-  createContext,
   useCallback,
-  useContext,
   useEffect,
   useMemo,
   useRef,
@@ -38,17 +36,16 @@ import {
 } from "@/lib/skinPresetStore";
 import {
   parseSkinPackError,
-  type SkinPackErrorCode,
   type SkinPackPreview,
 } from "@/lib/skinPack";
 import { OFFICIAL_SKIN_CATALOG_URL } from "@/lib/skinCatalog";
-import { useThemeShell } from "@/providers/ThemeProvider";
+import { useThemeShell } from "@/providers/ThemeShellContext";
+import {
+  SkinShareContext,
+  type SkinShareNotice,
+  type SkinShareValue,
+} from "@/providers/SkinShareContext";
 import { SkinImportPreviewModal } from "@/components/settings/SkinImportPreviewModal";
-
-export type SkinShareNotice = {
-  kind: "err" | "warn";
-  code: SkinPackErrorCode | "unknown_skin" | "will_clear_wallpaper";
-};
 
 type PreviewState = {
   preview: SkinPackPreview;
@@ -56,30 +53,6 @@ type PreviewState = {
   /** Existing library id when applying a saved preset (not undo). */
   libraryId?: string;
 };
-
-type SkinShareValue = {
-  appearanceBusy: boolean;
-  notice: SkinShareNotice | null;
-  clearNotice: () => void;
-  openFilePreview: (path: string) => Promise<void>;
-  openPresetPreview: (id: string, undoMode?: boolean) => Promise<void>;
-  openCatalogPreview: (sourceId: string, packId: string) => Promise<void>;
-  refreshPending: () => Promise<void>;
-};
-
-const Ctx = createContext<SkinShareValue | null>(null);
-
-export function useSkinShare(): SkinShareValue {
-  const v = useContext(Ctx);
-  if (!v) {
-    throw new Error("useSkinShare requires SkinShareProvider");
-  }
-  return v;
-}
-
-export function useSkinShareOptional(): SkinShareValue | null {
-  return useContext(Ctx);
-}
 
 export function SkinShareProvider({ children }: { children: ReactNode }) {
   const theme = useThemeShell();
@@ -297,7 +270,7 @@ export function SkinShareProvider({ children }: { children: ReactNode }) {
   );
 
   return (
-    <Ctx.Provider value={value}>
+    <SkinShareContext.Provider value={value}>
       {children}
       <SkinImportPreviewModal
         open={!!preview}
@@ -327,6 +300,6 @@ export function SkinShareProvider({ children }: { children: ReactNode }) {
             : undefined
         }
       />
-    </Ctx.Provider>
+    </SkinShareContext.Provider>
   );
 }

--- a/src/providers/ThemeProvider.tsx
+++ b/src/providers/ThemeProvider.tsx
@@ -1,11 +1,10 @@
 /**
  * Theme / skin / wallpaper ownership (extracted from App God Component).
  * localStorage keys and apply* behavior match the pre-split App.
+ * The shared context lives separately so Fast Refresh preserves its identity.
  */
 import {
-  createContext,
   useCallback,
-  useContext,
   useEffect,
   useMemo,
   useRef,
@@ -86,59 +85,10 @@ import {
   subscribeAppearanceChanged,
 } from "@/lib/appearanceLiveSync";
 import { isThemeEditorDocument } from "@/lib/themeEditorShell";
-
-export type ThemeShellValue = {
-  theme: Theme;
-  themePreference: ThemePreference;
-  setThemePreference: (v: ThemePreference) => void;
-  systemTheme: Theme;
-  setSystemTheme: (v: Theme) => void;
-  themeSchedule: ThemeScheduleConfig;
-  setThemeSchedule: (v: ThemeScheduleConfig) => void;
-  scheduleActive: boolean;
-  skin: ThemeSkinId;
-  setSkin: (v: ThemeSkinId) => void;
-  wallpaperRecord: WallpaperRecord | null;
-  setWallpaperRecord: React.Dispatch<React.SetStateAction<WallpaperRecord | null>>;
-  wallpaperUrl: string | null;
-  setWallpaperUrl: (v: string | null) => void;
-  wallpaperUrlRef: React.MutableRefObject<string | null>;
-  wallpaperScrim: number;
-  setWallpaperScrim: (v: number) => void;
-  wallpaperBlur: number;
-  setWallpaperBlur: (v: number) => void;
-  composerOpacity: number;
-  uiOpacity: number;
-  settingsOpacity: number;
-  textColor: string | null;
-  fontShadow: boolean;
-  applyThemeChoice: (next: ThemePreference) => void;
-  applyThemeScheduleChoice: (next: ThemeScheduleConfig) => void;
-  applySkinChoice: (
-    next: ThemeSkinId,
-    opts?: { applyPreferredTheme?: boolean },
-  ) => void;
-  applyWallpaperChoice: (
-    record: WallpaperRecord | null,
-    opts?: { onError?: (msg: string) => void },
-  ) => Promise<void>;
-  applyWallpaperAdjustChoice: (patch: {
-    focus: WallpaperFocus;
-    clip: WallpaperClip | null;
-    duration?: number;
-  }) => void;
-  applyWallpaperMediaSize: (size: { w: number; h: number }) => void;
-  applyWallpaperScrimChoice: (value: number) => void;
-  applyWallpaperBlurChoice: (value: number) => void;
-  applyComposerOpacityChoice: (value: number) => void;
-  applyUiOpacityChoice: (value: number) => void;
-  applySettingsOpacityChoice: (value: number) => void;
-  applyTextColorChoice: (value: string | null) => void;
-  applyFontShadowChoice: (value: boolean) => void;
-  resetAppearanceChromeChoice: () => void;
-};
-
-const ThemeShellContext = createContext<ThemeShellValue | null>(null);
+import {
+  ThemeShellContext,
+  type ThemeShellValue,
+} from "@/providers/ThemeShellContext";
 
 /** Persist theme preference into AppSettings (Host) for next cold-start paint. */
 async function persistThemeToHostSettings(
@@ -737,12 +687,4 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
       {children}
     </ThemeShellContext.Provider>
   );
-}
-
-export function useThemeShell(): ThemeShellValue {
-  const ctx = useContext(ThemeShellContext);
-  if (!ctx) {
-    throw new Error("useThemeShell must be used within ThemeProvider");
-  }
-  return ctx;
 }

--- a/src/providers/ThemeShellContext.ts
+++ b/src/providers/ThemeShellContext.ts
@@ -1,0 +1,76 @@
+import {
+  createContext,
+  useContext,
+  type Dispatch,
+  type MutableRefObject,
+  type SetStateAction,
+} from "react";
+import type { Theme, ThemePreference } from "@/lib/theme";
+import type { ThemeScheduleConfig } from "@/lib/themeSchedule";
+import type {
+  ThemeSkinId,
+  WallpaperClip,
+  WallpaperFocus,
+  WallpaperRecord,
+} from "@/lib/themeSkin";
+
+export type ThemeShellValue = {
+  theme: Theme;
+  themePreference: ThemePreference;
+  setThemePreference: (value: ThemePreference) => void;
+  systemTheme: Theme;
+  setSystemTheme: (value: Theme) => void;
+  themeSchedule: ThemeScheduleConfig;
+  setThemeSchedule: (value: ThemeScheduleConfig) => void;
+  scheduleActive: boolean;
+  skin: ThemeSkinId;
+  setSkin: (value: ThemeSkinId) => void;
+  wallpaperRecord: WallpaperRecord | null;
+  setWallpaperRecord: Dispatch<SetStateAction<WallpaperRecord | null>>;
+  wallpaperUrl: string | null;
+  setWallpaperUrl: (value: string | null) => void;
+  wallpaperUrlRef: MutableRefObject<string | null>;
+  wallpaperScrim: number;
+  setWallpaperScrim: (value: number) => void;
+  wallpaperBlur: number;
+  setWallpaperBlur: (value: number) => void;
+  composerOpacity: number;
+  uiOpacity: number;
+  settingsOpacity: number;
+  textColor: string | null;
+  fontShadow: boolean;
+  applyThemeChoice: (next: ThemePreference) => void;
+  applyThemeScheduleChoice: (next: ThemeScheduleConfig) => void;
+  applySkinChoice: (
+    next: ThemeSkinId,
+    options?: { applyPreferredTheme?: boolean },
+  ) => void;
+  applyWallpaperChoice: (
+    record: WallpaperRecord | null,
+    options?: { onError?: (message: string) => void },
+  ) => Promise<void>;
+  applyWallpaperAdjustChoice: (patch: {
+    focus: WallpaperFocus;
+    clip: WallpaperClip | null;
+    duration?: number;
+  }) => void;
+  applyWallpaperMediaSize: (size: { w: number; h: number }) => void;
+  applyWallpaperScrimChoice: (value: number) => void;
+  applyWallpaperBlurChoice: (value: number) => void;
+  applyComposerOpacityChoice: (value: number) => void;
+  applyUiOpacityChoice: (value: number) => void;
+  applySettingsOpacityChoice: (value: number) => void;
+  applyTextColorChoice: (value: string | null) => void;
+  applyFontShadowChoice: (value: boolean) => void;
+  resetAppearanceChromeChoice: () => void;
+};
+
+export const ThemeShellContext = createContext<ThemeShellValue | null>(null);
+
+export function useThemeShell(): ThemeShellValue {
+  const context = useContext(ThemeShellContext);
+  if (!context) {
+    throw new Error("useThemeShell must be used within ThemeProvider");
+  }
+  return context;
+}


### PR DESCRIPTION
> **UI hold**：此 PR 调整用户菜单中的主题子菜单交互，请维护者在本批次末统一审核；本 PR 不由 agent 合并。

## Summary

- 将 `ThemeShellContext` 与 `SkinShareContext` 从 Provider 组件模块拆出，确保开发态 Fast Refresh 保持稳定的 Context 身份，避免外观相关组件被异常重建。
- 修复鼠标先悬停主题入口、随后点击时子菜单被立即反向关闭的竞态；补充交互回归断言。
- 将 `assembleGoalOrchView` 改为从职责明确的模块直接导入，消除 `ReliabilityCenterModal` 构建时的循环 chunk 警告。
- 新增结构守卫，防止 Context 与 Provider 再次合并而使热更新边界退化。

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] Refactor / chore

## Validation

- [x] `pnpm typecheck`
- [x] `pnpm test`（622 files / 7291 tests）
- [x] `pnpm lint`
- [x] `python scripts/check-code-quality-gates.py --mode final`
- [x] `pnpm deps:check`
- [x] `pnpm audit:prod`
- [x] `python scripts/publish-website-downloads.py --self-test`
- [x] `pnpm build:ui`（目标循环 chunk 警告已消失）
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] Windows CI 等价测试流程（Common Controls v6 manifest）：1836 passed / 0 failed / 1 ignored
- [x] `git diff --check`、敏感信息与临时标记扫描

## Checklist

- [x] 用户可见文案未新增，无需 i18n 变更
- [x] 未引入 `window.confirm` / `prompt` / `alert`
- [x] 无需更新产品规则文档
- [x] 未包含密钥、token、`auth.json` 或本地配置

## Related issues

以主题编辑器卡死、Fast Refresh、主题子菜单和循环 chunk 等关键词检索了现有 Issues，未发现准确对应条目，因此不做错误关联。