### PR TITLE
fix(session): 修复带图片或附件的消息在流式接收时重复出现两条的问题

### DIFF
--- a/src/lib/session.projection.test.ts
+++ b/src/lib/session.projection.test.ts
@@ -913,6 +913,62 @@ describe("session projection", () => {
     expect(out.filter((m) => m.role === "user")).toHaveLength(1);
   });
 
+  it("applyRemoteUserMessage reconciles text + image when host dual-wrote @path", () => {
+    const shot = "/tmp/paste.png";
+    const body = "帮我看一下怎么操作，才能接入telegram";
+    const att = { path: shot, name: "paste.png", isDir: false };
+    const out = applyRemoteUserMessage(
+      [
+        {
+          id: "u-1710000000002",
+          role: "user",
+          content: body,
+          attachments: [att],
+        },
+        { id: "a-pending-2", role: "assistant", content: "", streaming: true },
+      ],
+      {
+        id: "host-user-2",
+        role: "user",
+        content: `${body}\n\n@${shot}`,
+        attachments: [att],
+      },
+      "host-stream-2",
+    );
+    expect(out.filter((m) => m.role === "user")).toHaveLength(1);
+    expect(out[0]!.id).toBe("host-user-2");
+    expect(out[0]!.content).toBe(body);
+    expect(out[0]!.attachments).toEqual([att]);
+    expect(out[1]!.id).toBe("a-pending-2");
+  });
+
+  it("applyRemoteUserMessage reconciles pure-image send when host dual-wrote @path", () => {
+    const shot = "/tmp/paste.png";
+    const att = { path: shot, name: "paste.png", isDir: false };
+    const out = applyRemoteUserMessage(
+      [
+        {
+          id: "u-1710000000003",
+          role: "user",
+          content: "",
+          attachments: [att],
+        },
+        { id: "a-pending-3", role: "assistant", content: "", streaming: true },
+      ],
+      {
+        id: "host-user-3",
+        role: "user",
+        content: `@${shot}`,
+        attachments: [att],
+      },
+      "host-stream-3",
+    );
+    expect(out.filter((m) => m.role === "user")).toHaveLength(1);
+    expect(out[0]!.id).toBe("host-user-3");
+    expect(out[0]!.content).toBe("");
+    expect(out[0]!.attachments).toEqual([att]);
+  });
+
   it("applyStreamChunk grows assistant text once per chunk", () => {
     let messages: ChatMessage[] = [];
     const chunks: StreamPayload[] = [

--- a/src/lib/session/rewind.ts
+++ b/src/lib/session/rewind.ts
@@ -284,6 +284,8 @@ export function forkSessionTitle(sourceTitle: string | undefined | null): string
 export function isClientOptimisticId(id: string): boolean {
   return (
     /^u-\d+$/.test(id) ||
+    id.startsWith("u-auto-") ||
+    id.startsWith("u-batch-") ||
     id.startsWith("a-pending-") ||
     /^a-\d+$/.test(id) ||
     /^t-\d+$/.test(id)
@@ -323,7 +325,7 @@ export function stripUserAttachmentRefs(message: ChatMessage): ChatMessage {
  * Match optimistic `u-${ts}` rows to the host UUID even when journal
  * dual-wrote `@/path` lines the composer never showed.
  */
-function userBubbleDedupeKey(message: ChatMessage): string {
+export function userBubbleDedupeKey(message: ChatMessage): string {
   const parsed = parseAttachmentsFromContent(message.content ?? "");
   const text = parsed.text.trim();
   const paths = new Set<string>();
@@ -336,7 +338,7 @@ function userBubbleDedupeKey(message: ChatMessage): string {
   return `${text}\n---\n${[...paths].sort().join("\n")}`;
 }
 
-const EMPTY_USER_KEY = "\n---\n";
+export const EMPTY_USER_KEY = "\n---\n";
 
 /**
  * Remove optimistic user/pending-assistant rows that host journal already

--- a/src/lib/session/stream.ts
+++ b/src/lib/session/stream.ts
@@ -6,7 +6,12 @@ import type {
   StreamPayload,
 } from "./types";
 import { isTurnPromptMessage } from "./types";
-import { stripUserAttachmentRefs } from "./rewind";
+import {
+  EMPTY_USER_KEY,
+  isClientOptimisticId,
+  stripUserAttachmentRefs,
+  userBubbleDedupeKey,
+} from "./rewind";
 import {
   appendContentToSegments,
   appendThoughtToSegments,
@@ -193,7 +198,8 @@ export function applyRemoteUserMessage(
     return ensureLiveAssistantAfterUser(messages, user.id, streamMessageId);
   }
 
-  const userText = (user.content || "").trim();
+  const cleanedUser = stripUserAttachmentRefs(user);
+  const userKey = userBubbleDedupeKey(user);
   let optimisticIdx = -1;
   for (let i = messages.length - 1; i >= 0; i--) {
     const m = messages[i];
@@ -201,9 +207,9 @@ export function applyRemoteUserMessage(
     const id = m.id || "";
     // Optimistic composer ids: `u-<ts>` / `u-auto-…` (see isClientOptimisticId).
     if (
-      userText &&
-      (m.content || "").trim() === userText &&
-      (/^u-\d+$/.test(id) || id.startsWith("u-auto-"))
+      userKey !== EMPTY_USER_KEY &&
+      userBubbleDedupeKey(m) === userKey &&
+      (isClientOptimisticId(id) || /^u-/.test(id))
     ) {
       optimisticIdx = i;
     }
@@ -215,15 +221,15 @@ export function applyRemoteUserMessage(
     next = messages.map((m, i) =>
       i === optimisticIdx
         ? {
-            ...user,
-            attachments: user.attachments?.length
-              ? user.attachments
+            ...cleanedUser,
+            attachments: cleanedUser.attachments?.length
+              ? cleanedUser.attachments
               : m.attachments,
           }
         : m,
     );
   } else {
-    next = [...messages, { ...user, role: "user" }];
+    next = [...messages, cleanedUser];
   }
   return ensureLiveAssistantAfterUser(next, user.id, streamMessageId);
 }


### PR DESCRIPTION
## Summary
修复当用户发送带有图片或文件附件的消息时，在流式响应过程中界面上重复出现两条一模一样的用户消息气泡的问题。

### 根因分析
1. 前端在发出消息时先创建本地乐观气泡（id 为 `u-<ts>`），其 `content` 仅包含用户正文纯文本，附件结构存储在 `attachments` 中。
2. 后端在 `turn.rs` 中为了兼容性通过 `append_journal_attachment_refs` 在存盘正文末尾双写了 `\n\n@/path/to/attachment`，并在发起会话时触发 `session://user_message` 事件广播该消息。
3. 前端 `stream.ts` 的 `applyRemoteUserMessage` 在收到该事件时，直接使用 `(m.content || "").trim() === userText` 进行全等比较。由于后端正文多出了追加的 `@/path` 尾缀，导致比较恒为 `false`，错误地将其识别为外部窗口/远端发来的新消息，从而在当前会话末尾又追加了一遍。
4. UI 渲染时由于会剥除 `@/path` 并展示附件卡片，导致用户在界面上看到两条一模一样的消息气泡。

### 修复方案
- `src/lib/session/rewind.ts`：导出已有的 `userBubbleDedupeKey` 和 `EMPTY_USER_KEY`；在 `isClientOptimisticId` 中增加对 `u-auto-` 和 `u-batch-` 乐观前缀的支持。
- `src/lib/session/stream.ts`：在 `applyRemoteUserMessage` 中改用 `userBubbleDedupeKey` 进行去重比对，利用已有的附件对齐与正文清洗逻辑；并在对齐与追加时统一经过 `stripUserAttachmentRefs` 清洗正文。
- `src/lib/session.projection.test.ts`：新增图文混排与纯图片场景下的乐观消息对齐测试用例。

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / chore

## Checklist
- [x] I ran `pnpm typecheck` and `pnpm test`
- [ ] I ran `cargo test` in `src-tauri` (or `cargo check` for docs-only)
- [ ] User-facing strings go through `src/i18n/messages.ts` (en + zh)
- [ ] No `window.confirm` / `prompt` / `alert` for product dialogs
- [ ] Docs / `docs/llm-wiki` updated if behavior changed
- [ ] No secrets (`secrets.json`, tokens, `auth.json`) included