### PR TITLE
feat(session): show a recent-chat list while holding Ctrl+Tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ See `docs/llm-wiki/release.md`.
 - 插件授权密钥不再出现在进程命令行中。
 
 ### Added
+- Ctrl+Tab shows a recent-chat list while you hold Ctrl. Release Ctrl to open the highlighted chat (#1125).
 - Chat markdown renders Mermaid diagrams from fenced code blocks.
 - Wallpaper X can use Responses search with a clear fallback to CLI (#1088).
 - Wallpaper X Responses search shows validated images in batches as paths finish (#1089).
@@ -71,9 +72,9 @@ See `docs/llm-wiki/release.md`.
 - Openverse and Pexels prefetch the next page after a successful search (#1097).
 - Wallpaper sources add a separate Web image search with safe preview download (#1099).
 - Wallpaper sources can browse your Grok Saved album after a secure sign-in check (#1103).
-- Ctrl+Tab jumps back to the last chat you used. Hold Ctrl and tap Tab to cycle further; Ctrl+Shift+Tab goes the other way.
 
 **中文 · 新增**
+- 按住 Ctrl+Tab 会弹出最近对话列表。松开 Ctrl 打开高亮的那一条（#1125）。
 - 聊天 Markdown 会渲染 fenced Mermaid 流程图。
 - 壁纸 X 可用 Responses 搜索，失败时清楚回退到 CLI（#1088）。
 - 壁纸 X 的 Responses 搜索会按完成批次逐步显示已校验图片（#1089）。
@@ -83,7 +84,6 @@ See `docs/llm-wiki/release.md`.
 - Openverse / Pexels 在成功搜索后会预取下一页（#1097）。
 - 壁纸来源新增独立的 Web 图片搜索，并安全下载预览（#1099）。
 - 壁纸来源可在安全登录校验后浏览 Grok Saved 相册（#1103）。
-- Ctrl+Tab 切回上一个用过的对话。按住 Ctrl 再点 Tab 继续循环；Ctrl+Shift+Tab 反向。
 
 ### Changed
 - Finished Worked-for rails fold after the turn. Failed tools stay as one-line excerpts.

--- a/src/app/WorkbenchChromeOverlays.tsx
+++ b/src/app/WorkbenchChromeOverlays.tsx
@@ -8,6 +8,7 @@
 import { lazy, Suspense } from "react";
 import { ArchiveAgeConfirmModal } from "@/components/workbench-modals/ArchiveAgeConfirmModal";
 import { PromptHistoryClearModal } from "@/components/workbench-modals/PromptHistoryClearModal";
+import { SessionMruSwitcher } from "@/components/SessionMruSwitcher";
 import { ShortcutsHelpModal } from "@/components/workbench-modals/ShortcutsHelpModal";
 import { WorktreeCreateModal } from "@/components/workbench-modals/WorktreeCreateModal";
 import { WorktreeGcModal } from "@/components/workbench-modals/WorktreeGcModal";
@@ -105,6 +106,7 @@ export function WorkbenchChromeOverlays(p: WorkbenchChromeOverlaysProps) {
   const wt = p.worktreeChrome;
   return (
     <>
+      <SessionMruSwitcher locale={p.locale} />
       {p.showDoctor ? (
         <Suspense fallback={null}>
           <DoctorModal

--- a/src/components/SessionMruSwitcher.test.tsx
+++ b/src/components/SessionMruSwitcher.test.tsx
@@ -1,0 +1,45 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import "@/test/jsdomStubs";
+import { cleanup, render, screen } from "@testing-library/react";
+import { SessionMruSwitcher } from "./SessionMruSwitcher";
+import { setSessionMruPanelState } from "@/lib/sessionMruPanelStore";
+
+afterEach(() => {
+  cleanup();
+  setSessionMruPanelState(null);
+});
+
+describe("SessionMruSwitcher", () => {
+  it("renders nothing when idle", () => {
+    render(<SessionMruSwitcher locale="en" />);
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+  });
+
+  it("lists chats and marks the highlighted row", () => {
+    setSessionMruPanelState({
+      index: 1,
+      rows: [
+        { id: "b", title: "Beta", projectName: "App" },
+        { id: "a", title: "Alpha", projectName: "" },
+      ],
+    });
+    render(<SessionMruSwitcher locale="en" />);
+    expect(
+      screen.getByRole("listbox", { name: "Recently used chats" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Release Ctrl to open")).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: /Beta/ })).toHaveAttribute(
+      "aria-selected",
+      "false",
+    );
+    expect(screen.getByRole("option", { name: /Alpha/ })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(screen.getByText("App")).toBeInTheDocument();
+  });
+});

--- a/src/components/SessionMruSwitcher.tsx
+++ b/src/components/SessionMruSwitcher.tsx
@@ -1,0 +1,89 @@
+/**
+ * Temporary Ctrl+Tab chat switcher. Shows while Ctrl is held; gone on release.
+ */
+import { useEffect, useRef, useSyncExternalStore } from "react";
+import { createPortal } from "react-dom";
+import { createT, type Locale } from "@/i18n";
+import {
+  getSessionMruPanelState,
+  pickSessionMruPanelIndex,
+  subscribeSessionMruPanel,
+} from "@/lib/sessionMruPanelStore";
+
+export function SessionMruSwitcher({ locale }: { locale: Locale }) {
+  const state = useSyncExternalStore(
+    subscribeSessionMruPanel,
+    getSessionMruPanelState,
+    getSessionMruPanelState,
+  );
+  const activeRef = useRef<HTMLButtonElement | null>(null);
+  const tr = createT(locale);
+
+  useEffect(() => {
+    activeRef.current?.scrollIntoView?.({ block: "nearest" });
+  }, [state?.index, state?.rows.length]);
+
+  if (!state || typeof document === "undefined") return null;
+
+  return createPortal(
+    <div
+      className="overlay session-mru-overlay"
+      role="presentation"
+    >
+      <div
+        className="search-panel session-mru-panel"
+        role="listbox"
+        aria-label={tr("shortcuts.recentSessionMruPanel")}
+        aria-activedescendant={
+          state.rows[state.index]
+            ? `session-mru-${state.rows[state.index]!.id}`
+            : undefined
+        }
+        onMouseDown={(e) => e.preventDefault()}
+      >
+        <div className="search-panel__head">
+          <div className="search-panel__body">
+            <div className="search-panel__title">
+              {tr("shortcuts.recentSessionMruPanel")}
+            </div>
+            <div className="session-mru-panel__hint">
+              {tr("shortcuts.recentSessionMruPanelHint")}
+            </div>
+          </div>
+        </div>
+        <div className="search-panel__results">
+          {state.rows.map((row, index) => {
+            const active = index === state.index;
+            const title = row.title || tr("tray.untitled");
+            return (
+              <button
+                key={row.id}
+                type="button"
+                id={`session-mru-${row.id}`}
+                ref={active ? activeRef : undefined}
+                className={
+                  active
+                    ? "search-panel__row is-active"
+                    : "search-panel__row"
+                }
+                role="option"
+                aria-selected={active}
+                onClick={() => pickSessionMruPanelIndex(index)}
+              >
+                <span className="search-panel__body">
+                  <span className="search-panel__title">{title}</span>
+                  {row.projectName ? (
+                    <span className="search-panel__snippet">
+                      {row.projectName}
+                    </span>
+                  ) : null}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/src/hooks/useSessionMruNav.test.ts
+++ b/src/hooks/useSessionMruNav.test.ts
@@ -4,15 +4,21 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { cleanup, renderHook } from "@testing-library/react";
 import { SESSION_MRU_STORAGE_KEY } from "@/lib/sessionMru";
+import {
+  getSessionMruPanelState,
+  setSessionMruPanelState,
+} from "@/lib/sessionMruPanelStore";
 import { useSessionMruNav } from "./useSessionMruNav";
 
 afterEach(() => {
   cleanup();
   localStorage.clear();
+  setSessionMruPanelState(null);
 });
 
 beforeEach(() => {
   localStorage.clear();
+  setSessionMruPanelState(null);
 });
 
 function tab(
@@ -28,8 +34,10 @@ function tab(
   });
 }
 
+const getRow = (id: string) => ({ title: id, projectName: "" });
+
 describe("useSessionMruNav", () => {
-  it("ping-pongs Ctrl+Tab between the current chat and the previous one", () => {
+  it("shows the panel on Ctrl+Tab and opens the previous chat on release", () => {
     localStorage.setItem(
       SESSION_MRU_STORAGE_KEY,
       JSON.stringify(["b", "a"]),
@@ -40,6 +48,7 @@ describe("useSessionMruNav", () => {
       useSessionMruNav({
         getCurrentId: () => current,
         getLiveIds: () => ["a", "b"],
+        getRow,
         openById: (id) => {
           opened.push(id);
           current = id;
@@ -47,13 +56,21 @@ describe("useSessionMruNav", () => {
       }),
     );
     window.dispatchEvent(tab());
-    expect(opened).toEqual(["a"]);
+    expect(opened).toEqual([]);
+    expect(getSessionMruPanelState()?.index).toBe(1);
+    expect(getSessionMruPanelState()?.rows.map((r) => r.id)).toEqual([
+      "b",
+      "a",
+    ]);
     window.dispatchEvent(new KeyboardEvent("keyup", { key: "Control" }));
+    expect(opened).toEqual(["a"]);
+    expect(getSessionMruPanelState()).toBeNull();
     window.dispatchEvent(tab());
+    window.dispatchEvent(new KeyboardEvent("keyup", { key: "Control" }));
     expect(opened).toEqual(["a", "b"]);
   });
 
-  it("walks three chats while Ctrl is held, then commits the landing chat", () => {
+  it("walks three chats in the panel while Ctrl is held, then opens the landing chat", () => {
     localStorage.setItem(
       SESSION_MRU_STORAGE_KEY,
       JSON.stringify(["c", "b", "a"]),
@@ -64,6 +81,7 @@ describe("useSessionMruNav", () => {
       useSessionMruNav({
         getCurrentId: () => current,
         getLiveIds: () => ["a", "b", "c"],
+        getRow,
         openById: (id) => {
           opened.push(id);
           current = id;
@@ -72,12 +90,39 @@ describe("useSessionMruNav", () => {
     );
     window.dispatchEvent(tab());
     window.dispatchEvent(tab());
-    expect(opened).toEqual(["b", "a"]);
+    expect(opened).toEqual([]);
+    expect(getSessionMruPanelState()?.rows[getSessionMruPanelState()!.index]?.id).toBe(
+      "a",
+    );
     window.dispatchEvent(new KeyboardEvent("keyup", { key: "Control" }));
+    expect(opened).toEqual(["a"]);
     result.current.noteOpened("a");
     expect(JSON.parse(localStorage.getItem(SESSION_MRU_STORAGE_KEY) ?? "[]")).toEqual(
       ["a", "c", "b"],
     );
+  });
+
+  it("cancels the panel on Escape without opening", () => {
+    localStorage.setItem(
+      SESSION_MRU_STORAGE_KEY,
+      JSON.stringify(["b", "a"]),
+    );
+    const openById = vi.fn();
+    renderHook(() =>
+      useSessionMruNav({
+        getCurrentId: () => "b",
+        getLiveIds: () => ["a", "b"],
+        getRow,
+        openById,
+      }),
+    );
+    window.dispatchEvent(tab());
+    expect(getSessionMruPanelState()).not.toBeNull();
+    window.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+    );
+    expect(getSessionMruPanelState()).toBeNull();
+    expect(openById).not.toHaveBeenCalled();
   });
 
   it("ignores Cmd+Tab", () => {
@@ -86,10 +131,12 @@ describe("useSessionMruNav", () => {
       useSessionMruNav({
         getCurrentId: () => "b",
         getLiveIds: () => ["a", "b"],
+        getRow,
         openById,
       }),
     );
     window.dispatchEvent(tab({ metaKey: true, ctrlKey: false }));
     expect(openById).not.toHaveBeenCalled();
+    expect(getSessionMruPanelState()).toBeNull();
   });
 });

--- a/src/hooks/useSessionMruNav.ts
+++ b/src/hooks/useSessionMruNav.ts
@@ -2,13 +2,15 @@
  * Global Ctrl+Tab / Ctrl+Shift+Tab: switch recently used chats.
  *
  * Same chord on macOS, Windows, and Linux (Cmd+Tab is the OS app switcher).
- * Hold Ctrl and tap Tab to walk a frozen MRU snapshot; release Ctrl to commit.
+ * Hold Ctrl and tap Tab to walk a frozen snapshot in a temporary panel;
+ * releasing Ctrl opens the highlighted chat and hides the panel.
  */
 
 import { useCallback, useEffect, useRef } from "react";
 import { isShortcutRecordingActive } from "@/lib/shortcutRemap";
 import {
   beginSessionMruCycle,
+  buildSessionMruPanelState,
   isSessionMruModifierKey,
   loadSessionMru,
   matchSessionMruChord,
@@ -19,10 +21,20 @@ import {
   type SessionMruCycle,
   type SessionMruDir,
 } from "@/lib/sessionMru";
+import {
+  registerSessionMruPanelPick,
+  setSessionMruPanelState,
+} from "@/lib/sessionMruPanelStore";
+
+export type SessionMruRowLookup = {
+  title: string;
+  projectName: string;
+};
 
 export function useSessionMruNav(opts: {
   getCurrentId: () => string | null | undefined;
   getLiveIds: () => readonly string[];
+  getRow: (id: string) => SessionMruRowLookup | null;
   openById: (id: string) => void;
   isEnabled?: () => boolean;
 }): { noteOpened: (id: string) => void } {
@@ -37,12 +49,26 @@ export function useSessionMruNav(opts: {
     saveSessionMru(next);
   };
 
+  const publish = (cycle: SessionMruCycle | null) => {
+    setSessionMruPanelState(
+      buildSessionMruPanelState(cycle, optsRef.current.getRow),
+    );
+  };
+
+  const hidePanel = () => {
+    cycleRef.current = null;
+    publish(null);
+  };
+
   const commitCycle = () => {
     const cycle = cycleRef.current;
     if (!cycle) return;
-    cycleRef.current = null;
+    hidePanel();
     const target = sessionMruCycleTarget(cycle);
-    if (target) persist(touchSessionMru(listRef.current, target));
+    if (!target) return;
+    persist(touchSessionMru(listRef.current, target));
+    const current = (optsRef.current.getCurrentId() ?? "").trim();
+    if (target !== current) optsRef.current.openById(target);
   };
 
   const noteOpened = useCallback((id: string) => {
@@ -51,7 +77,7 @@ export function useSessionMruNav(opts: {
     const cycle = cycleRef.current;
     if (cycle) {
       if (sessionMruCycleTarget(cycle) === tid) return;
-      cycleRef.current = null;
+      hidePanel();
     }
     persist(touchSessionMru(listRef.current, tid));
   }, []);
@@ -73,16 +99,32 @@ export function useSessionMruNav(opts: {
       cycle = stepSessionMruCycle(cycle, dir);
     }
     if (!cycle) return;
-    const target = sessionMruCycleTarget(cycle);
-    if (!target) return;
     cycleRef.current = cycle;
-    if (target !== (o.getCurrentId() ?? "").trim()) {
-      o.openById(target);
-    }
+    publish(cycle);
+  };
+
+  const pickIndex = (index: number) => {
+    const cycle = cycleRef.current;
+    if (!cycle) return;
+    if (index < 0 || index >= cycle.snapshot.length) return;
+    const next = { snapshot: cycle.snapshot, index };
+    cycleRef.current = next;
+    publish(next);
   };
 
   useEffect(() => {
+    registerSessionMruPanelPick(pickIndex);
+    return () => registerSessionMruPanelPick(null);
+  }, []);
+
+  useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
+      if (cycleRef.current && e.key === "Escape" && !e.isComposing) {
+        e.preventDefault();
+        e.stopPropagation();
+        hidePanel();
+        return;
+      }
       const dir = matchSessionMruChord({
         key: e.key,
         code: e.code,

--- a/src/hooks/useSessionNavigation.ts
+++ b/src/hooks/useSessionNavigation.ts
@@ -245,6 +245,19 @@ export function useSessionNavigation(opts: {
   const { noteOpened } = useSessionMruNav({
     getCurrentId: () => viewingSessionIdRef.current,
     getLiveIds: () => hostRef.current.catalog.listLiveIds(),
+    getRow: (id) => {
+      try {
+        const row = hostRef.current.catalog.findRow(id);
+        if (!row) return null;
+        const proj = hostRef.current.catalog.resolveProject(row);
+        return {
+          title: (row.title || "").trim(),
+          projectName: (proj?.name || "").trim(),
+        };
+      } catch {
+        return null;
+      }
+    },
     openById: (id) => {
       const row = hostRef.current.catalog.findRow(id);
       if (row) void mruOpenRef.current(row);

--- a/src/i18n/messages/de/core.ts
+++ b/src/i18n/messages/de/core.ts
@@ -124,6 +124,8 @@ export const deCore = {
   "shortcuts.closeSideTab": "Seitentab schließen (Fenster, wenn keiner offen)",
   "shortcuts.sidebarSessionNav": "Nächster / vorheriger Chat in der Seitenleiste (Fokus in der Liste)",
   "shortcuts.recentSessionMru": "Nächster / vorheriger kürzlich verwendeter Chat",
+  "shortcuts.recentSessionMruPanel": "Kürzlich verwendete Chats",
+  "shortcuts.recentSessionMruPanelHint": "Strg loslassen zum Öffnen",
   "shortcuts.doctor": "Doctor",
   "shortcuts.liveVoice": "Live Voice starten",
   "shortcuts.off": "Aus",

--- a/src/i18n/messages/en/core.ts
+++ b/src/i18n/messages/en/core.ts
@@ -125,6 +125,8 @@ export const enCore = {
   "shortcuts.closeSideTab": "Close side tab (window when none open)",
   "shortcuts.sidebarSessionNav": "Next / previous chat in sidebar (focus in list)",
   "shortcuts.recentSessionMru": "Next / previous recently used chat",
+  "shortcuts.recentSessionMruPanel": "Recently used chats",
+  "shortcuts.recentSessionMruPanelHint": "Release Ctrl to open",
   "shortcuts.doctor": "Doctor",
   "shortcuts.liveVoice": "Start Live Voice",
   "shortcuts.off": "Off",

--- a/src/i18n/messages/es/core.ts
+++ b/src/i18n/messages/es/core.ts
@@ -124,6 +124,8 @@ export const esCore = {
   "shortcuts.closeSideTab": "Cerrar pestaña lateral (la ventana si no hay ninguna abierta)",
   "shortcuts.sidebarSessionNav": "Chat siguiente / anterior en la barra lateral (foco en la lista)",
   "shortcuts.recentSessionMru": "Chat reciente siguiente / anterior",
+  "shortcuts.recentSessionMruPanel": "Chats recientes",
+  "shortcuts.recentSessionMruPanelHint": "Suelta Ctrl para abrir",
   "shortcuts.doctor": "Doctor",
   "shortcuts.liveVoice": "Iniciar Live Voice",
   "shortcuts.off": "Desactivado",

--- a/src/i18n/messages/fil/core.ts
+++ b/src/i18n/messages/fil/core.ts
@@ -124,6 +124,8 @@ export const filCore = {
   "shortcuts.closeSideTab": "Isara ang side tab (window kapag walang bukas)",
   "shortcuts.sidebarSessionNav": "Susunod / nakaraang chat sa sidebar (focus sa listahan)",
   "shortcuts.recentSessionMru": "Susunod / nakaraang kamakailang chat",
+  "shortcuts.recentSessionMruPanel": "Mga kamakailang chat",
+  "shortcuts.recentSessionMruPanelHint": "Bitawan ang Ctrl para buksan",
   "shortcuts.doctor": "Doctor",
   "shortcuts.liveVoice": "Simulan ang Live Voice",
   "shortcuts.off": "Naka-off",

--- a/src/i18n/messages/fr/core.ts
+++ b/src/i18n/messages/fr/core.ts
@@ -124,6 +124,8 @@ export const frCore = {
   "shortcuts.closeSideTab": "Fermer l’onglet latéral (fenêtre si aucun ouvert)",
   "shortcuts.sidebarSessionNav": "Conversation suivante / précédente dans la barre latérale (focus dans la liste)",
   "shortcuts.recentSessionMru": "Conversation récente suivante / précédente",
+  "shortcuts.recentSessionMruPanel": "Conversations récentes",
+  "shortcuts.recentSessionMruPanelHint": "Relâchez Ctrl pour ouvrir",
   "shortcuts.doctor": "Doctor",
   "shortcuts.liveVoice": "Démarrer Live Voice",
   "shortcuts.off": "Désactivé",

--- a/src/i18n/messages/id/core.ts
+++ b/src/i18n/messages/id/core.ts
@@ -124,6 +124,8 @@ export const idCore = {
   "shortcuts.closeSideTab": "Tutup tab sisi (jendela jika tidak ada yang terbuka)",
   "shortcuts.sidebarSessionNav": "Obrolan berikutnya / sebelumnya di bilah sisi (fokus di daftar)",
   "shortcuts.recentSessionMru": "Obrolan terbaru berikutnya / sebelumnya",
+  "shortcuts.recentSessionMruPanel": "Obrolan terbaru",
+  "shortcuts.recentSessionMruPanelHint": "Lepas Ctrl untuk membuka",
   "shortcuts.doctor": "Doctor",
   "shortcuts.liveVoice": "Mulai Live Voice",
   "shortcuts.off": "Mati",

--- a/src/i18n/messages/it/core.ts
+++ b/src/i18n/messages/it/core.ts
@@ -124,6 +124,8 @@ export const itCore = {
   "shortcuts.closeSideTab": "Chiudi scheda laterale (finestra se nessuna è aperta)",
   "shortcuts.sidebarSessionNav": "Chat successiva / precedente nella barra laterale (focus nell’elenco)",
   "shortcuts.recentSessionMru": "Chat recente successiva / precedente",
+  "shortcuts.recentSessionMruPanel": "Chat recenti",
+  "shortcuts.recentSessionMruPanelHint": "Rilascia Ctrl per aprire",
   "shortcuts.doctor": "Doctor",
   "shortcuts.liveVoice": "Avvia Live Voice",
   "shortcuts.off": "Disattivato",

--- a/src/i18n/messages/ja/core.ts
+++ b/src/i18n/messages/ja/core.ts
@@ -124,6 +124,8 @@ export const jaCore = {
   "shortcuts.closeSideTab": "サイドタブを閉じる（開いていないときはウィンドウ）",
   "shortcuts.sidebarSessionNav": "サイドバーで次 / 前のチャット（リストにフォーカス時）",
   "shortcuts.recentSessionMru": "最近使ったチャットの次 / 前",
+  "shortcuts.recentSessionMruPanel": "最近使ったチャット",
+  "shortcuts.recentSessionMruPanelHint": "Ctrl を離すと開きます",
   "shortcuts.doctor": "ドクター",
   "shortcuts.liveVoice": "Live Voice を開始",
   "shortcuts.off": "オフ",

--- a/src/i18n/messages/ko/core.ts
+++ b/src/i18n/messages/ko/core.ts
@@ -124,6 +124,8 @@ export const koCore = {
   "shortcuts.closeSideTab": "사이드 탭 닫기 (열린 탭이 없으면 창)",
   "shortcuts.sidebarSessionNav": "사이드바에서 다음 / 이전 대화 (목록에 포커스)",
   "shortcuts.recentSessionMru": "최근 사용한 대화 다음 / 이전",
+  "shortcuts.recentSessionMruPanel": "최근 사용한 대화",
+  "shortcuts.recentSessionMruPanelHint": "Ctrl을 놓으면 열립니다",
   "shortcuts.doctor": "닥터",
   "shortcuts.liveVoice": "라이브 음성 시작",
   "shortcuts.off": "끄기",

--- a/src/i18n/messages/pt-BR/core.ts
+++ b/src/i18n/messages/pt-BR/core.ts
@@ -124,6 +124,8 @@ export const ptBRCore = {
   "shortcuts.closeSideTab": "Fechar aba lateral (janela quando nenhuma estiver aberta)",
   "shortcuts.sidebarSessionNav": "Próximo / anterior chat na barra lateral (foco na lista)",
   "shortcuts.recentSessionMru": "Chat recente seguinte / anterior",
+  "shortcuts.recentSessionMruPanel": "Chats recentes",
+  "shortcuts.recentSessionMruPanelHint": "Solte Ctrl para abrir",
   "shortcuts.doctor": "Doctor",
   "shortcuts.liveVoice": "Iniciar Live Voice",
   "shortcuts.off": "Desligado",

--- a/src/i18n/messages/ru/core.ts
+++ b/src/i18n/messages/ru/core.ts
@@ -124,6 +124,8 @@ export const ruCore = {
   "shortcuts.closeSideTab": "Закрыть боковую вкладку (окно, если вкладок нет)",
   "shortcuts.sidebarSessionNav": "Следующий / предыдущий чат на боковой панели (фокус в списке)",
   "shortcuts.recentSessionMru": "Следующий / предыдущий недавно использованный чат",
+  "shortcuts.recentSessionMruPanel": "Недавние чаты",
+  "shortcuts.recentSessionMruPanelHint": "Отпустите Ctrl, чтобы открыть",
   "shortcuts.doctor": "Диагностика",
   "shortcuts.liveVoice": "Начать Live Voice",
   "shortcuts.off": "Выкл.",

--- a/src/i18n/messages/ta/core.ts
+++ b/src/i18n/messages/ta/core.ts
@@ -124,6 +124,8 @@ export const taCore = {
   "shortcuts.closeSideTab": "பக்க தாவலை மூடு (சாளரம் எதுவும் திறக்கப்படாத போது)",
   "shortcuts.sidebarSessionNav": "பக்கப்பட்டியில் அடுத்த / முந்தைய உரையாடல் (பட்டியலில் கவனம்)",
   "shortcuts.recentSessionMru": "சமீபத்தில் பயன்படுத்திய அடுத்த / முந்தைய உரையாடல்",
+  "shortcuts.recentSessionMruPanel": "சமீபத்திய உரையாடல்கள்",
+  "shortcuts.recentSessionMruPanelHint": "திறக்க Ctrl-ஐ விடுங்கள்",
   "shortcuts.doctor": "Doctor",
   "shortcuts.liveVoice": "நேரடிக் குரலைத் தொடங்கவும்",
   "shortcuts.off": "அணைப்பு",

--- a/src/i18n/messages/uk/core.ts
+++ b/src/i18n/messages/uk/core.ts
@@ -124,6 +124,8 @@ export const ukCore = {
   "shortcuts.closeSideTab": "Закрити бічну вкладку (вікно, якщо вкладок немає)",
   "shortcuts.sidebarSessionNav": "Наступний / попередній чат на бічній панелі (фокус у списку)",
   "shortcuts.recentSessionMru": "Наступний / попередній нещодавно використаний чат",
+  "shortcuts.recentSessionMruPanel": "Нещодавні чати",
+  "shortcuts.recentSessionMruPanelHint": "Відпустіть Ctrl, щоб відкрити",
   "shortcuts.doctor": "Діагностика",
   "shortcuts.liveVoice": "Запустити Live Voice",
   "shortcuts.off": "Вимкнено",

--- a/src/i18n/messages/zh-TW/core.ts
+++ b/src/i18n/messages/zh-TW/core.ts
@@ -124,6 +124,8 @@ export const zhTWCore = {
   "shortcuts.closeSideTab": "關閉側邊分頁（無分頁時關閉視窗）",
   "shortcuts.sidebarSessionNav": "側欄上下切換對話（焦點在列表內）",
   "shortcuts.recentSessionMru": "最近用過的對話（上一個 / 下一個）",
+  "shortcuts.recentSessionMruPanel": "最近用過的對話",
+  "shortcuts.recentSessionMruPanelHint": "放開 Ctrl 開啟",
   "shortcuts.doctor": "體檢",
   "shortcuts.liveVoice": "開始即時語音",
   "shortcuts.off": "關閉",

--- a/src/i18n/messages/zh/core.ts
+++ b/src/i18n/messages/zh/core.ts
@@ -124,6 +124,8 @@ export const zhCore = {
   "shortcuts.closeSideTab": "关闭侧边标签（无标签时关闭窗口）",
   "shortcuts.sidebarSessionNav": "侧栏上下切换会话（焦点在列表内）",
   "shortcuts.recentSessionMru": "最近用过的对话（上一个 / 下一个）",
+  "shortcuts.recentSessionMruPanel": "最近用过的对话",
+  "shortcuts.recentSessionMruPanelHint": "松开 Ctrl 打开",
   "shortcuts.doctor": "体检",
   "shortcuts.liveVoice": "开始实时语音",
   "shortcuts.off": "关闭",

--- a/src/lib/sessionMru.test.ts
+++ b/src/lib/sessionMru.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   beginSessionMruCycle,
+  buildSessionMruPanelState,
   filterSessionMru,
   isSessionMruModifierKey,
   loadSessionMru,
@@ -97,6 +98,23 @@ describe("beginSessionMruCycle", () => {
     expect(beginSessionMruCycle(["a"], ["a"], "a", "next")).toBeNull();
     expect(beginSessionMruCycle([], ["a"], "a", "next")).toBeNull();
     expect(beginSessionMruCycle(["gone"], ["a"], "a", "next")).toBeNull();
+  });
+
+  it("builds switcher rows from the frozen cycle", () => {
+    const cycle = beginSessionMruCycle(["b", "a"], ["a", "b"], "b", "next");
+    expect(
+      buildSessionMruPanelState(cycle, (id) => ({
+        title: id === "a" ? " Alpha " : "Beta",
+        projectName: id === "a" ? " proj " : "",
+      })),
+    ).toEqual({
+      index: 1,
+      rows: [
+        { id: "b", title: "Beta", projectName: "" },
+        { id: "a", title: "Alpha", projectName: "proj" },
+      ],
+    });
+    expect(buildSessionMruPanelState(null, () => null)).toBeNull();
   });
 
   it("wraps prev from the current chat to the oldest recent", () => {

--- a/src/lib/sessionMru.ts
+++ b/src/lib/sessionMru.ts
@@ -155,6 +155,42 @@ export function sessionMruCycleTarget(
   return cycle.snapshot[cycle.index] ?? null;
 }
 
+export type SessionMruPanelRow = {
+  id: string;
+  title: string;
+  projectName: string;
+};
+
+export type SessionMruPanelState = {
+  rows: SessionMruPanelRow[];
+  index: number;
+} | null;
+
+/** Snapshot + labels for the Ctrl-held switcher panel. */
+export function buildSessionMruPanelState(
+  cycle: SessionMruCycle | null,
+  getRow: (id: string) => { title: string; projectName: string } | null,
+): SessionMruPanelState {
+  if (!cycle || cycle.snapshot.length === 0) return null;
+  const index =
+    cycle.index < 0
+      ? 0
+      : cycle.index >= cycle.snapshot.length
+        ? cycle.snapshot.length - 1
+        : cycle.index;
+  return {
+    index,
+    rows: cycle.snapshot.map((id) => {
+      const row = getRow(id);
+      return {
+        id,
+        title: (row?.title ?? "").trim(),
+        projectName: (row?.projectName ?? "").trim(),
+      };
+    }),
+  };
+}
+
 export type SessionMruChordEvent = {
   key: string;
   code?: string;

--- a/src/lib/sessionMruPanelStore.ts
+++ b/src/lib/sessionMruPanelStore.ts
@@ -1,0 +1,38 @@
+/**
+ * Live Ctrl+Tab switcher panel. The nav hook writes; the overlay reads.
+ * Kept off AppWorkbench so the shell freeze stays intact.
+ */
+
+import type { SessionMruPanelState } from "@/lib/sessionMru";
+
+type Listener = () => void;
+
+let state: SessionMruPanelState = null;
+const listeners = new Set<Listener>();
+let pickIndex: ((index: number) => void) | null = null;
+
+export function getSessionMruPanelState(): SessionMruPanelState {
+  return state;
+}
+
+export function setSessionMruPanelState(next: SessionMruPanelState): void {
+  state = next;
+  for (const listener of listeners) listener();
+}
+
+export function subscribeSessionMruPanel(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function registerSessionMruPanelPick(
+  fn: ((index: number) => void) | null,
+): void {
+  pickIndex = fn;
+}
+
+export function pickSessionMruPanelIndex(index: number): void {
+  pickIndex?.(index);
+}

--- a/src/styles/modals.part3.css
+++ b/src/styles/modals.part3.css
@@ -702,6 +702,11 @@
   padding-top: 0;
 }
 
+.overlay.session-mru-overlay {
+  align-items: center;
+  padding-top: 24px;
+}
+
 /* User message skill inline */
 .user-msg-body {
   white-space: pre-wrap;

--- a/src/styles/sidebar.part2.css
+++ b/src/styles/sidebar.part2.css
@@ -906,3 +906,30 @@ html[data-sidebar-density="compact"] .tree-date-group__head {
   margin-top: 4px;
   padding-bottom: 6px;
 }
+
+.session-mru-panel {
+  width: min(400px, 92vw);
+  max-height: min(56vh, 420px);
+  margin: 0;
+}
+.session-mru-panel .search-panel__head {
+  align-items: flex-start;
+}
+.session-mru-panel__hint {
+  margin-top: 2px;
+  font-size: 11px;
+  line-height: 1.3;
+  color: var(--text-tertiary);
+}
+.session-mru-panel .search-panel__results {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 6px;
+}
+.session-mru-panel .search-panel__row {
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  font: inherit;
+}

--- a/src/styles/sidebar.part3.css
+++ b/src/styles/sidebar.part3.css
@@ -13,6 +13,7 @@
 .prompt-history,
 .modal,
 .search-panel,
+.session-mru-panel,
 .cmm__pop,
 .auto-panel,
 .drop-overlay__card {


### PR DESCRIPTION
## Summary
- Hold Ctrl+Tab to show a glass recent-chat switcher; tap Tab / Shift+Tab to move the highlight.
- Release Ctrl to open the highlighted chat. Esc cancels. Click only changes the highlight.
- Same chord on macOS, Windows, and Linux (not Cmd+Tab). Panel reuses search-panel chrome and stays off AppWorkbench.

Closes #1125
Follows #1051 / #1052.

## Test plan
- [x] `pnpm typecheck` `pnpm lint` quality gates website self-test `pnpm build:ui`
- [x] `cargo fmt --check` `cargo clippy -D warnings`
- [x] `pnpm exec vitest run src/lib/sessionMru.test.ts src/hooks/useSessionMruNav.test.ts src/components/SessionMruSwitcher.test.tsx src/lib/whatsNew.test.ts src/i18n/messages.test.ts`
- [ ] Open chats A then B then C → hold Ctrl+Tab, see the list, release on C
- [ ] Esc while holding Ctrl cancels and stays on the current chat
- [ ] Click a row only highlights; open happens on Ctrl release
- [ ] Cmd+Tab on Mac still switches apps

## Checklist
- [x] Local typecheck, lint, gates, UI build
- [x] Local clippy + rustfmt
- [ ] Full CI on PR