### PR TITLE
fix(composer): keep context-window Save button inside flyout

### DIFF
--- a/src/lib/composerWindowEdit.guard.test.ts
+++ b/src/lib/composerWindowEdit.guard.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Composer · context-window inline edit: the token input must never push the
+ * Save button out of the flyout panel.
+ *
+ * Root cause: `input[type=number]` carries an intrinsic minimum width in
+ * some engines (notably WKWebView). With `flex: 1` the input refuses
+ * to shrink below that intrinsic width, so the button overflows the
+ * `overflow-x: hidden` flyout and becomes unclickable. `width: 0` on the
+ * flex item lets the flex algorithm ignore the intrinsic width entirely.
+ */
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const css = readFileSync(
+  resolve(__dirname, "../styles/composer.part1.css"),
+  "utf8",
+);
+
+describe("composer context-window inline edit", () => {
+  it("keeps the number input shrinkable so Save stays inside the panel", () => {
+    const block = css.match(
+      /\.cmm__inline-edit input\s*\{(?<body>[^}]*)\}/s,
+    )?.groups?.body;
+    expect(block).toBeTruthy();
+    // Flex item must be allowed to shrink to zero intrinsic width.
+    expect(block).toMatch(/flex:\s*1 1 0/);
+    expect(block).toMatch(/min-width:\s*0/);
+    expect(block).toMatch(/width:\s*0/);
+  });
+
+  it("pins the Save button to its content width", () => {
+    const block = css.match(
+      /\.cmm__inline-save\s*\{(?<body>[^}]*)\}/s,
+    )?.groups?.body;
+    expect(block).toBeTruthy();
+    expect(block).toMatch(/flex:\s*0 0 auto/);
+    expect(block).toMatch(/white-space:\s*nowrap/);
+  });
+});

--- a/src/styles/composer.part1.css
+++ b/src/styles/composer.part1.css
@@ -611,8 +611,11 @@
   box-sizing: border-box;
 }
 .cmm__inline-edit input {
-  flex: 1 1 auto;
+  flex: 1 1 0;
   min-width: 0;
+  /* type=number carries an intrinsic minimum width in some engines (notably
+     WKWebView); width:0 lets flex ignore it so the Save button always fits. */
+  width: 0;
   min-height: 32px;
   padding: 6px 10px;
   font-size: 13px;


### PR DESCRIPTION
## Summary

In the composer model chip → Advanced → **Context window** flyout (custom-provider models), the **Save** button is pushed past the panel's right edge and clipped by the flyout's `overflow-x: hidden`, making it impossible to click.

Root cause: `input[type=number]` carries an intrinsic minimum width in some engines (notably WKWebView on macOS). With `flex: 1 1 auto` the input refuses to shrink below that intrinsic width, so the fixed-size Save button overflows the 260px flyout. Switching the flex item to `flex: 1 1 0` + `width: 0` lets the flex algorithm ignore the intrinsic width entirely, so the input yields space and Save always stays inside the panel — verified in-browser down to a 200px panel width.

Also adds a CSS guard test (`src/lib/composerWindowEdit.guard.test.ts`, same pattern as the other `*.guard.test.ts` files) so the shrink rules cannot regress silently.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / chore

## Checklist
- [x] I ran `pnpm typecheck` and `pnpm test` — typecheck clean; full suite 7412/7413 pass. The single failure (`src/lib/whatsNew.test.ts` › "keeps Unreleased popup lines to one short sentence") is **pre-existing on upstream/main**: both `CHANGELOG.md` and `src/lib/whatsNew.test.ts` are byte-identical to upstream/main on this branch (`git diff upstream/main` empty for both), and this PR touches neither.
- [x] I ran `cargo test` in `src-tauri` (or `cargo check` for docs-only) — N/A: no Rust changes (CSS + one TS test file); CI cargo jobs run over untouched Rust sources.
- [x] User-facing strings go through `src/i18n/messages.ts` (en + zh) — no new user-facing strings.
- [x] No `window.confirm` / `prompt` / `alert` for product dialogs.
- [x] Docs / `docs/llm-wiki` updated if behavior changed — no behavior/spec change, visual fix only.
- [x] No secrets (`secrets.json`, tokens, `auth.json`) included.
