### PR TITLE
docs(changelog): trim over-length Unreleased first sentences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,11 @@ See `docs/llm-wiki/release.md`.
 ## [Unreleased]
 
 ### Fixed
-- Sending with images or attachments no longer shows two identical user bubbles while the reply streams (#1119, #1124).
-- After an idle reconnect, the same user turn is not painted twice when Host and optimistic rows race (#1124).
-- Custom relays show retry progress and a waiting hint under Thinking instead of a blank “working” state (#1126).
-- Wallpaper search keeps media favorites and local paths across pages, and restores the multi-source gallery layout (#1120).
-- Switching wallpaper sources no longer cancels in-flight search; ZDR privacy blocks show a clear image-to-video hint (#1121).
+- Sending with images or attachments no longer paints the user bubble twice mid-stream (#1119, #1124).
+- After an idle reconnect, racing Host rows no longer paint the same user turn twice (#1124).
+- Custom relays show retry progress and a wait hint under Thinking (#1126). The blank “working” state is gone.
+- Wallpaper search keeps media favorites and local paths across pages (#1120). The multi-source gallery layout is restored.
+- Switching wallpaper sources no longer cancels an in-flight search (#1121). ZDR privacy blocks show a clear image-to-video hint.
 - Long chats stay smoother on a Windows touchscreen. Slow pans no longer hitch while the finger is down (#1122).
 - Windows no longer freezes when stream IPC or tool journals ran under session locks.
 - Opening a chat times out stuck history loads and keeps the cached transcript.


### PR DESCRIPTION
## Summary
Five recent Unreleased entries (#1119 / #1124 / #1126 / #1120 / #1121) exceed the 90-character popup first-sentence cap, so `whatsNew.test.ts` (`keeps Unreleased popup lines to one short sentence`) fails on current **main** — every open PR's CI is red right now.

This trims those five English first sentences to ≤ 90 chars and moves the extra detail into the one follow-up sentence the CHANGELOG rule allows (popup shows first sentence only). No meaning change; the zh lines already comply.

## Type of change
- [ ] Bug fix
- [x] Documentation
- [ ] Refactor / chore

## Checklist
- [x] I ran `pnpm typecheck` and `pnpm test` (637 files / 7411 tests green, including `whatsNew.test.ts`)
- [x] Docs-only change (no Rust touch): `cargo check` n/a — frontend suite + `build:ui` + quality gates all pass locally
- [x] User-facing strings go through `src/i18n/messages.ts` (en + zh) — CHANGELOG copy only
- [x] No `window.confirm` / `prompt` / `alert` for product dialogs
- [x] Docs / `docs/llm-wiki` updated if behavior changed — behavior unchanged
- [x] No secrets included