### PR TITLE
fix(deps): pin katex to the version rehype-katex renders with

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,18 @@ See `docs/llm-wiki/release.md`.
 
 ## [Unreleased]
 
+### Fixed
+- Math formulas render with one matching KaTeX version again. The bundled CSS had drifted ahead of the JS.
+
+**中文 · 修复**
+- 数学公式恢复 CSS 与 JS 同版本渲染，不再出现样式超前于脚本。
+
 ### Changed
 - The theme editor modal loads on demand instead of joining app startup.
 
 **中文 · 变更**
 - 主题编辑器改为按需加载，不再拖累应用启动。
+
 
 ## [0.2.34] - 2026-09-09
 

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "docx-preview": "^0.4.0",
     "highlight.js": "^11.11.1",
     "html-to-image": "^1.11.13",
-    "katex": "^0.18.4",
+    "katex": "^0.16.47",
     "mermaid": "^11",
     "pdfjs-dist": "^5.4.296",
     "plyr": "^3.8.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,8 +105,8 @@ importers:
         specifier: ^1.11.13
         version: 1.11.13
       katex:
-        specifier: ^0.18.4
-        version: 0.18.4
+        specifier: ^0.16.47
+        version: 0.16.47
       mermaid:
         specifier: ^11
         version: 11.17.2
@@ -2456,10 +2456,6 @@ packages:
 
   katex@0.16.47:
     resolution: {integrity: sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==}
-    hasBin: true
-
-  katex@0.18.4:
-    resolution: {integrity: sha512-IMPntbRLOU+eu88XDiFKqQ8Akhr9Tv7jDMXqPhjG9SI1JMA4DIgXk4x9k4skJz2NZJXBRbC+2pYBLj9olqcZow==}
     hasBin: true
 
   keyv@4.5.4:
@@ -5819,10 +5815,6 @@ snapshots:
       setimmediate: 1.0.5
 
   katex@0.16.47:
-    dependencies:
-      commander: 8.3.0
-
-  katex@0.18.4:
     dependencies:
       commander: 8.3.0
 


### PR DESCRIPTION
## Summary
The direct `katex` dependency (`^0.18.4`) exists only to load `katex/dist/katex.min.css` ([`markdownMath.ts`](src/lib/markdownMath.ts#L19)); the actual math HTML is rendered by `rehype-katex`, which resolves **katex 0.16.47** (mermaid and remark-math's transitive copies agree). The app has been shipping a **CSS/JS version skew** — 0.18.4 styles with 0.16.47 rendering JS — held together only by KaTeX's stable class names; any class rename between those lines would silently break math styling.

This pins the direct dep to `^0.16.47`, so CSS and JS now come from a single version and the duplicate katex 0.18.4 install (~4.3 MB) disappears from the tree:

```
before: katex 0.18.4 (direct, CSS) + katex 0.16.47 (rehype-katex/remark-math/mermaid)
after:  katex 0.16.47 (single instance)
```

**Stacked on #1135 (fmt/clippy repair) so the Rust CI leg is green; once #1135 merges this diff is just the two real files.

## Type of change
- [x] Bug fix
- [ ] Documentation
- [ ] Refactor / chore

## Checklist
- [x] I ran `pnpm typecheck` and `pnpm test` (637 files / 7411 tests green)
- [x] Docs-only Rust impact: `cargo check` n/a — no Rust change
- [x] User-facing strings go through `src/i18n/messages.ts` — CHANGELOG entry only (en + zh, first sentence ≤ 90 chars)
- [x] No `window.confirm` / `prompt` / `alert` for product dialogs
- [x] Docs / `docs/llm-wiki` updated if behavior changed — behavior unchanged (version alignment)
- [x] No secrets included

## Verification
- `pnpm why katex` → single `katex 0.16.47` across direct + rehype-katex + remark-math + mermaid
- Full local CI suite green: typecheck / vitest / lint / quality gates / website self-test / `build:ui`