### PR TITLE
perf(app): lazy-load the theme editor modal from the sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ See `docs/llm-wiki/release.md`.
 
 ## [Unreleased]
 
+### Changed
+- The theme editor modal loads on demand instead of joining app startup.
+
+**中文 · 变更**
+- 主题编辑器改为按需加载，不再拖累应用启动。
+
 ## [0.2.34] - 2026-09-09
 
 > **Highlight:** Bigger wallpaper sources, stronger Windows freeze fixes, safer chat thumbs.

--- a/src/app/WorkbenchSidebar.tsx
+++ b/src/app/WorkbenchSidebar.tsx
@@ -3,6 +3,8 @@
  * Open/new-chat and settings navigation stay with the host.
  */
 import {
+  lazy,
+  Suspense,
   useEffect,
   useState,
   type CSSProperties,
@@ -13,7 +15,6 @@ import {
 import { Tip } from "@/components/ui/tooltip";
 import { SidebarBrand } from "@/components/SidebarBrand";
 import { SidebarUpdateButton } from "@/components/SidebarUpdateButton";
-import { ThemeEditorModal } from "@/components/ThemeEditorModal";
 import { UserMenu } from "@/components/UserMenu";
 import { GrokLogo } from "@/components/GrokLogo";
 import {
@@ -63,6 +64,13 @@ import type { Theme, ThemePreference } from "@/lib/theme";
 import { requestWhatsNewOpen } from "@/lib/whatsNew";
 
 type TFn = ReturnType<typeof createT>;
+
+// Theme editor (appearance settings model, ~300KB) only loads when opened
+// from the sidebar rail, keeping it off the boot-critical App chunk.
+const ThemeEditorModal = lazy(async () => {
+  const m = await import("@/components/ThemeEditorModal");
+  return { default: m.ThemeEditorModal };
+});
 
 function quotaBarFillClass(usedPercent: number | null): string {
   if (usedPercent != null && usedPercent >= 90) return " is-danger";
@@ -559,11 +567,13 @@ export function WorkbenchSidebar(props: WorkbenchSidebarProps) {
         </div>
       </div>
       {themeEditorOpen ? (
-        <ThemeEditorModal
-          open
-          onClose={() => setThemeEditorOpen(false)}
-          locale={locale}
-        />
+        <Suspense fallback={null}>
+          <ThemeEditorModal
+            open
+            onClose={() => setThemeEditorOpen(false)}
+            locale={locale}
+          />
+        </Suspense>
       ) : null}
     </aside>
   );


### PR DESCRIPTION
## Summary
`WorkbenchSidebar` statically imported `ThemeEditorModal`, pulling the appearance-editor module closure into the boot-critical App chunk even though the modal only mounts when the user opens it from the sidebar rail. The bundle audit found this was the last big lazy-loading win on the startup path.

This switches the import to `React.lazy` + `Suspense fallback={null}` (same pattern as the app's other one-shot modals). Verified in `build:ui` output:

- `ThemeEditorModal-*.js` and `useAppearanceEditorModel-*.js` now emit as separate on-demand chunks
- the App chunk only carries the dynamic-import reference (no modal code)
- `index.html` does not preload the modal

**Stacked on #1135 (fmt/clippy repair) so CI is green; once that merges this diff is just the two files.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / chore (perf, no behavior change)

## Checklist
- [x] I ran `pnpm typecheck` and `pnpm test` (637 files / 7411 tests green)
- [x] No Rust change — frontend suite + gates + `build:ui` green locally
- [x] User-facing strings via `src/i18n/messages.ts` — CHANGELOG entry only (en + zh)
- [x] No `window.confirm` / `prompt` / `alert`
- [x] Docs / `docs/llm-wiki` — no behavior change; startup strategy matches existing lazy-modal pattern
- [x] No secrets included

## Regression notes
First open of the theme editor now pays a local-disk chunk load (tens of ms in Tauri asset protocol) — same trade-off the settings stage, Office previews, and pet window already make.