### PR TITLE
perf(build): ship KaTeX fonts as woff2 only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,11 @@ See `docs/llm-wiki/release.md`.
 
 ### Changed
 - The theme editor modal loads on demand instead of joining app startup.
+- Bundled KaTeX math fonts ship as woff2 only, trimming the install size.
 
 **中文 · 变更**
 - 主题编辑器改为按需加载，不再拖累应用启动。
+- 打包内的 KaTeX 数学字体只保留 woff2 格式，安装包更小。
 
 
 ## [0.2.34] - 2026-09-09

--- a/src/lib/katexFontTrim.test.ts
+++ b/src/lib/katexFontTrim.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import {
+  isKatexFallbackFontAsset,
+  stripKatexFallbackFontSrc,
+} from "./katexFontTrim";
+
+const KATEX_FONT_FACE =
+  '@font-face{font-display:block;font-family:KaTeX_AMS;font-style:normal;font-weight:400;src:url(assets/KaTeX_AMS-Regular-BQhdFMY1.woff2) format("woff2"),url(assets/KaTeX_AMS-Regular-DMm9YOAa.woff) format("woff"),url(assets/KaTeX_AMS-Regular-DRggAlZN.ttf) format("truetype")}';
+
+describe("stripKatexFallbackFontSrc", () => {
+  it("keeps only the woff2 src entry of a bundled KaTeX font-face", () => {
+    const out = stripKatexFallbackFontSrc(KATEX_FONT_FACE);
+    expect(out).toBe(
+      '@font-face{font-display:block;font-family:KaTeX_AMS;font-style:normal;font-weight:400;src:url(assets/KaTeX_AMS-Regular-BQhdFMY1.woff2) format("woff2")}',
+    );
+  });
+
+  it("keeps the woff2 url when fallbacks are quoted", () => {
+    const out = stripKatexFallbackFontSrc(
+      'src:url("assets/KaTeX_Main-Regular-xyz.woff2") format("woff2"),url("assets/KaTeX_Main-Regular-abc.woff") format("woff")',
+    );
+    expect(out).toBe(
+      'src:url("assets/KaTeX_Main-Regular-xyz.woff2") format("woff2")',
+    );
+  });
+
+  it("leaves non-KaTeX woff and truetype fallbacks untouched", () => {
+    const css =
+      'src:url(assets/MyFont-Regular.woff2) format("woff2"),url(assets/MyFont-Regular.woff) format("woff"),url(assets/MyFont-Regular.ttf) format("truetype")';
+    expect(stripKatexFallbackFontSrc(css)).toBe(css);
+  });
+
+  it("handles multiple font-faces in one sheet", () => {
+    const out = stripKatexFallbackFontSrc(
+      `${KATEX_FONT_FACE}@font-face{font-family:KaTeX_Caligraphic;src:url(a/KaTeX_Caligraphic-Bold-1.woff2) format("woff2"),url(a/KaTeX_Caligraphic-Bold-2.woff) format("woff"),url(a/KaTeX_Caligraphic-Bold-3.ttf) format("truetype")}`,
+    );
+    expect(out).not.toMatch(/\.woff\)/);
+    expect(out).not.toMatch(/\.ttf\)/);
+    expect(out).toMatch(/KaTeX_AMS-Regular-BQhdFMY1\.woff2/);
+    expect(out).toMatch(/KaTeX_Caligraphic-Bold-1\.woff2/);
+  });
+});
+
+describe("isKatexFallbackFontAsset", () => {
+  it("accepts hashed KaTeX woff and ttf assets", () => {
+    expect(isKatexFallbackFontAsset("assets/KaTeX_AMS-Regular-DMm9YOAa.woff")).toBe(true);
+    expect(isKatexFallbackFontAsset("assets/KaTeX_AMS-Regular-DRggAlZN.ttf")).toBe(true);
+  });
+
+  it("rejects woff2 assets and non-KaTeX fonts", () => {
+    expect(isKatexFallbackFontAsset("assets/KaTeX_AMS-Regular-BQhdFMY1.woff2")).toBe(false);
+    expect(isKatexFallbackFontAsset("assets/MyFont-Regular-abc.woff")).toBe(false);
+    expect(isKatexFallbackFontAsset("assets/MyFont-Regular-abc.ttf")).toBe(false);
+  });
+});

--- a/src/lib/katexFontTrim.ts
+++ b/src/lib/katexFontTrim.ts
@@ -1,0 +1,24 @@
+/**
+ * KaTeX ships every @font-face in three formats (woff2 + woff + ttf).
+ * The desktop WebViews Grok App runs on (WKWebView / WebView2 / WebKitGTK)
+ * all support woff2, so the woff / truetype fallbacks are ~700KB of dead
+ * dist weight. Build-time helpers below strip the fallback `src` entries
+ * from bundled CSS so the matching font assets can be dropped from the
+ * bundle (see the `katex-woff2-only` plugin in vite.config.ts).
+ */
+
+/**
+ * Remove the non-woff2 `url(...)` src entries of KaTeX @font-face rules.
+ * Scoped to KaTeX_ font files so a custom font's wof/ttf fallbacks stay.
+ */
+export function stripKatexFallbackFontSrc(css: string): string {
+  return css.replace(
+    /,\s*url\((["']?)[^)]*?KaTeX_[^)]*?\.(?:woff|ttf)\1\)\s*format\("(?:woff|truetype)"\)/g,
+    "",
+  );
+}
+
+/** True for a bundled KaTeX font asset that also ships as woff2. */
+export function isKatexFallbackFontAsset(fileName: string): boolean {
+  return /KaTeX_[^/]*\.(?:woff|ttf)$/.test(fileName);
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,15 +1,37 @@
-import { defineConfig } from "vite";
+import { defineConfig, type Plugin } from "vite";
 // SWC avoids Babel codegen deopt on large modules (App.tsx ~800KB+).
 import react from "@vitejs/plugin-react-swc";
 import tailwindcss from "@tailwindcss/vite";
 import path from "node:path";
 import process from "node:process";
 import { vendorManualChunk } from "./src/lib/viteManualChunks";
+import {
+  isKatexFallbackFontAsset,
+  stripKatexFallbackFontSrc,
+} from "./src/lib/katexFontTrim";
 
 const host = process.env.TAURI_DEV_HOST;
 
+// KaTeX ships woff2 + woff + ttf per font; the desktop WebViews all do
+// woff2, so drop the fallback src entries and their assets (~700KB).
+function katexWoff2Only(): Plugin {
+  return {
+    name: "katex-woff2-only",
+    generateBundle(_options, bundle) {
+      for (const [fileName, chunk] of Object.entries(bundle)) {
+        if (chunk.type !== "asset") continue;
+        if (fileName.endsWith(".css")) {
+          chunk.source = stripKatexFallbackFontSrc(String(chunk.source));
+        } else if (isKatexFallbackFontAsset(fileName)) {
+          delete bundle[fileName];
+        }
+      }
+    },
+  };
+}
+
 export default defineConfig(() => ({
-  plugins: [react(), tailwindcss()],
+  plugins: [react(), tailwindcss(), katexWoff2Only()],
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),


### PR DESCRIPTION
## Summary
KaTeX emits every `@font-face` with three `src` entries — woff2 + woff + ttf. Grok App's target WebViews (WKWebView / WebView2 / WebKitGTK) all load woff2, so the fallback formats were dead weight: **~700KB / 40 font asset files** in every dist build.

This adds a small `generateBundle` Vite plugin (`katex-woff2-only`) that:
- strips the non-woff2 `url(...)` src entries from bundled CSS (`stripKatexFallbackFontSrc`)
- deletes the matching `KaTeX_*.woff` / `KaTeX_*.ttf` assets from the bundle

The pure helpers live in [`src/lib/katexFontTrim.ts`](src/lib/katexFontTrim.ts) with unit tests (bundled-asset naming, quoted urls, multi-font-face sheets, non-KaTeX fonts left intact). Verified on `build:ui` output:

```
before: 19 woff2 + 20 woff + 20 ttf KaTeX font assets
after:  19 woff2 +  0 woff +  0 ttf
```

CSS contains zero `format("woff")` / `format("truetype")` references afterwards; every font-face keeps its woff2 entry, so rendering is unchanged.

**Stacked on #1135 → #1132 so CI stays green; once those merge the diff is just the four files.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / chore (build size, no behavior change)

## Checklist
- [x] I ran `pnpm typecheck` and `pnpm test` (638 files / 7417 tests green, including new `katexFontTrim.test.ts`)
- [x] No Rust change — frontend suite + gates + `build:ui` green locally
- [x] User-facing strings via `src/i18n/messages.ts` — CHANGELOG entry only (en + zh)
- [x] No `window.confirm` / `prompt` / `alert`
- [x] Docs / `docs/llm-wiki` — no behavior change (build output only)
- [x] No secrets included