### PR TITLE
perf(host): run settings store IO on the blocking pool in commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,10 +22,12 @@ See `docs/llm-wiki/release.md`.
 ### Changed
 - The theme editor modal loads on demand instead of joining app startup.
 - Bundled KaTeX math fonts ship as woff2 only, trimming the install size.
+- Settings reads and writes run on the blocking pool, off the async command path.
 
 **中文 · 变更**
 - 主题编辑器改为按需加载，不再拖累应用启动。
 - 打包内的 KaTeX 数学字体只保留 woff2 格式，安装包更小。
+- 设置的读写改走阻塞线程池，异步命令不再被设置文件锁卡住。
 
 
 ## [0.2.34] - 2026-09-09

--- a/src-tauri/src/commands/account.rs
+++ b/src-tauri/src/commands/account.rs
@@ -6,7 +6,7 @@ pub async fn account_status(
     include_local_usage: Option<bool>,
     manual_cli_path: Option<String>,
 ) -> Result<crate::account::AccountStatus, String> {
-    let settings = store::load_settings();
+    let settings = store::load_settings_async().await;
     let manual = manual_cli_path
         .or(settings.manual_cli_path)
         .filter(|s| !s.is_empty());
@@ -25,7 +25,7 @@ pub async fn account_login(
     method: Option<String>,
     manual_cli_path: Option<String>,
 ) -> Result<crate::account::LoginResult, String> {
-    let settings = store::load_settings();
+    let settings = store::load_settings_async().await;
     let manual = manual_cli_path
         .or(settings.manual_cli_path)
         .filter(|s| !s.is_empty());
@@ -62,7 +62,7 @@ pub async fn account_logout(
     mgr: State<'_, Arc<SessionManager>>,
     manual_cli_path: Option<String>,
 ) -> Result<crate::account::AccountProfile, String> {
-    let settings = store::load_settings();
+    let settings = store::load_settings_async().await;
     let manual = manual_cli_path
         .or(settings.manual_cli_path)
         .filter(|s| !s.is_empty());

--- a/src-tauri/src/commands/automation.rs
+++ b/src-tauri/src/commands/automation.rs
@@ -64,7 +64,7 @@ pub async fn automation_runner_status(
 #[tauri::command]
 pub async fn schedules_launch_agent_status(
 ) -> Result<crate::schedules_launch_agent::SchedulesLaunchAgentStatus, String> {
-    let enabled = store::load_settings().schedules_launch_agent;
+    let enabled = store::load_settings_async().await.schedules_launch_agent;
     Ok(crate::schedules_launch_agent::status(enabled))
 }
 
@@ -78,10 +78,10 @@ pub async fn schedules_launch_agent_set_enabled(
     } else {
         crate::schedules_launch_agent::disable()?
     };
-    let mut settings = store::load_settings();
+    let mut settings = store::load_settings_async().await;
     // Non-macOS never claims enabled; install is a no-op there.
     settings.schedules_launch_agent = enabled && status.supported;
-    store::save_settings(&settings)?;
+    store::save_settings_async(&settings).await?;
     Ok(crate::schedules_launch_agent::status(
         settings.schedules_launch_agent,
     ))

--- a/src-tauri/src/commands/doctor_p1.rs
+++ b/src-tauri/src/commands/doctor_p1.rs
@@ -19,9 +19,9 @@ pub async fn import_grok_cli_config() -> Result<serde_json::Value, String> {
     if config.is_file() {
         msg.push("Found ~/.grok/config.toml".to_string());
     }
-    let mut settings = store::load_settings();
+    let mut settings = store::load_settings_async().await;
     apply_import_onboarding_done(&mut settings);
-    store::save_settings(&settings)?;
+    store::save_settings_async(&settings).await?;
     Ok(serde_json::json!({
         "ok": auth.is_file(),
         "messages": msg,
@@ -67,9 +67,9 @@ pub async fn import_grok_go_config() -> Result<serde_json::Value, String> {
                 secrets.relay_base_url = Some(base.to_string());
             }
             store::save_secrets(&secrets)?;
-            let mut settings = store::load_settings();
+            let mut settings = store::load_settings_async().await;
             apply_import_onboarding_done(&mut settings);
-            store::save_settings(&settings)?;
+            store::save_settings_async(&settings).await?;
             return Ok(serde_json::json!({
                 "ok": true,
                 "path": c,
@@ -130,7 +130,7 @@ fn doctor_check(
 
 #[tauri::command]
 pub async fn doctor_report() -> Result<serde_json::Value, String> {
-    let settings = store::load_settings();
+    let settings = store::load_settings_async().await;
     let probe = cli_probe::probe_cli(settings.manual_cli_path.as_deref());
     let projects = store::load_projects();
     let sessions = store::load_sessions_index();

--- a/src-tauri/src/commands/hooks_setup_p1.rs
+++ b/src-tauri/src/commands/hooks_setup_p1.rs
@@ -774,7 +774,7 @@ pub async fn settings_remember_last_session(
     session_id: Option<String>,
     project_id: Option<String>,
 ) -> Result<(), String> {
-    let mut s = store::load_settings();
+    let mut s = store::load_settings_async().await;
     let next_session = session_id.and_then(|id| {
         let t = id.trim().to_string();
         if t.is_empty() {
@@ -796,7 +796,7 @@ pub async fn settings_remember_last_session(
     }
     s.last_session_id = next_session;
     s.last_project_id = next_project;
-    store::save_settings(&s)
+    store::save_settings_async(&s).await
 }
 
 // from PR #79

--- a/src-tauri/src/commands/misc_p1.rs
+++ b/src-tauri/src/commands/misc_p1.rs
@@ -8,7 +8,7 @@ pub async fn memory_clear(
     cwd: Option<String>,
     scope: Option<String>,
 ) -> Result<crate::agent_memory::MemoryClearResult, String> {
-    let settings = store::load_settings();
+    let settings = store::load_settings_async().await;
     let path = cwd
         .as_deref()
         .map(str::trim)
@@ -35,7 +35,7 @@ pub async fn memory_clear(
 pub async fn memory_list(
     cwd: Option<String>,
 ) -> Result<crate::agent_memory::MemoryListResult, String> {
-    let settings = store::load_settings();
+    let settings = store::load_settings_async().await;
     let path = cwd
         .as_deref()
         .map(str::trim)
@@ -56,7 +56,7 @@ pub async fn memory_list(
 pub async fn memory_delete_file(
     path: String,
 ) -> Result<crate::agent_memory::MemoryDeleteResult, String> {
-    let settings = store::load_settings();
+    let settings = store::load_settings_async().await;
     let p = std::path::PathBuf::from(path.trim());
     if p.as_os_str().is_empty() {
         return Err("path is required".into());
@@ -74,7 +74,7 @@ pub async fn memory_delete_file(
 #[tauri::command]
 pub async fn agent_config_toml_read(
 ) -> Result<crate::agent_config_view::AgentConfigTomlReadResult, String> {
-    let settings = store::load_settings();
+    let settings = store::load_settings_async().await;
     let mode = settings.session_data_mode.clone();
     tokio::task::spawn_blocking(move || crate::agent_config_view::read_agent_config_toml(&mode))
         .await
@@ -94,7 +94,7 @@ pub async fn memory_search(
     cwd: Option<String>,
     limit: Option<usize>,
 ) -> Result<crate::agent_memory::MemorySearchResult, String> {
-    let settings = store::load_settings();
+    let settings = store::load_settings_async().await;
     let path = cwd
         .as_deref()
         .map(str::trim)

--- a/src-tauri/src/commands/providers.rs
+++ b/src-tauri/src/commands/providers.rs
@@ -104,7 +104,7 @@ pub async fn providers_activate(
     .await
     .map_err(|e| e.to_string())??;
 
-    let mode = store::load_settings().session_data_mode.clone();
+    let mode = store::load_settings_async().await.session_data_mode.clone();
     let _ = crate::official_aux::sync_native_media_block_hook_for_current(&mode);
     let _ = crate::extensions::sync_user_mcp_for_official_aux_inject(&mode);
     // Parked processes keep old GROK_HOME auth/config in memory — kill them.
@@ -239,7 +239,7 @@ pub async fn providers_remove(
     .map_err(|e| e.to_string())??;
     // Removing a provider (esp. the active one) must not leave warm agents on
     // a deleted route id.
-    let mode = store::load_settings().session_data_mode.clone();
+    let mode = store::load_settings_async().await.session_data_mode.clone();
     let _ = crate::official_aux::sync_native_media_block_hook_for_current(&mode);
     let _ = crate::extensions::sync_user_mcp_for_official_aux_inject(&mode);
     mgr.recycle_all_agents(&app, "provider_route").await;
@@ -284,7 +284,7 @@ pub async fn providers_set_default(
     .await
     .map_err(|e| e.to_string())??;
 
-    let mode = store::load_settings().session_data_mode.clone();
+    let mode = store::load_settings_async().await.session_data_mode.clone();
     let _ = crate::official_aux::sync_native_media_block_hook_for_current(&mode);
     let _ = crate::extensions::sync_user_mcp_for_official_aux_inject(&mode);
     mgr.recycle_all_agents(&app, "provider_route").await;
@@ -526,7 +526,7 @@ pub async fn open_in_editor(
     line: Option<u32>,
     editor: Option<String>,
 ) -> Result<(), String> {
-    let settings = store::load_settings();
+    let settings = store::load_settings_async().await;
     let target = editor
         .filter(|s| !s.trim().is_empty())
         .unwrap_or_else(|| settings.default_open_target.clone());

--- a/src-tauri/src/commands/session_p1.rs
+++ b/src-tauri/src/commands/session_p1.rs
@@ -397,13 +397,15 @@ pub async fn cli_install_latest(
     app: tauri::AppHandle,
     allow_unverified: Option<bool>,
 ) -> Result<crate::cli_install::CliInstallResult, String> {
-    let allow =
-        allow_unverified.unwrap_or_else(|| store::load_settings().allow_unverified_cli_install);
+    let allow = match allow_unverified {
+        Some(v) => v,
+        None => store::load_settings_async().await.allow_unverified_cli_install,
+    };
     let result = crate::cli_install::install_cli_latest(app, allow).await?;
     // Remember last install verification for Doctor.
-    let mut s = store::load_settings();
+    let mut s = store::load_settings_async().await;
     s.last_cli_checksum_verified = result.checksum_verified;
-    let _ = store::save_settings(&s);
+    let _ = store::save_settings_async(&s).await;
     Ok(result)
 }
 
@@ -665,7 +667,7 @@ pub async fn sessions_search(
 /// List Grok Build CLI sessions under GROK_HOME (shared-mode discovery, E03).
 #[tauri::command]
 pub async fn cli_sessions_list() -> Result<Vec<crate::cli_sessions::CliSessionSummary>, String> {
-    let mode = store::load_settings().session_data_mode;
+    let mode = store::load_settings_async().await.session_data_mode;
     crate::cli_sessions::list_cli_sessions(&mode)
 }
 
@@ -676,7 +678,7 @@ pub async fn cli_sessions_search(
     query: String,
     limit: Option<u32>,
 ) -> Result<Vec<crate::cli_sessions::CliSessionSearchHit>, String> {
-    let settings = store::load_settings();
+    let settings = store::load_settings_async().await;
     let mode = settings.session_data_mode.clone();
     let probe = cli_probe::probe_cli(settings.manual_cli_path.as_deref());
     let cli_path = probe
@@ -697,7 +699,7 @@ pub async fn cli_session_import(
     dir: Option<String>,
     project_id: Option<String>,
 ) -> Result<SessionMeta, String> {
-    let mode = store::load_settings().session_data_mode;
+    let mode = store::load_settings_async().await.session_data_mode;
     crate::cli_sessions::import_cli_session(&agent_session_id, dir.as_deref(), project_id, &mode)
 }
 
@@ -707,7 +709,7 @@ pub async fn cli_session_import(
 pub async fn cli_session_find_latest_for_cwd(
     project_path: String,
 ) -> Result<Option<crate::cli_sessions::CliSessionSummary>, String> {
-    let mode = store::load_settings().session_data_mode;
+    let mode = store::load_settings_async().await.session_data_mode;
     let path = project_path;
     tauri::async_runtime::spawn_blocking(move || {
         crate::cli_sessions::find_latest_cli_session_for_cwd(&path, &mode)
@@ -723,7 +725,7 @@ pub async fn cli_session_continue_cwd(
     project_path: String,
     project_id: Option<String>,
 ) -> Result<Option<SessionMeta>, String> {
-    let mode = store::load_settings().session_data_mode;
+    let mode = store::load_settings_async().await.session_data_mode;
     tauri::async_runtime::spawn_blocking(move || {
         crate::cli_sessions::continue_cli_session_for_cwd(&project_path, project_id, &mode)
     })
@@ -734,7 +736,7 @@ pub async fn cli_session_continue_cwd(
 /// Import up to `limit` not-yet-linked CLI sessions (default 50).
 #[tauri::command]
 pub async fn cli_sessions_import_all(limit: Option<u32>) -> Result<Vec<SessionMeta>, String> {
-    let mode = store::load_settings().session_data_mode;
+    let mode = store::load_settings_async().await.session_data_mode;
     let lim = limit.unwrap_or(50).min(100) as usize;
     crate::cli_sessions::import_all_cli_sessions(&mode, lim)
 }
@@ -746,7 +748,7 @@ pub async fn cli_sessions_delete(
     agent_session_id: String,
     dir: Option<String>,
 ) -> Result<(), String> {
-    let mode = store::load_settings().session_data_mode;
+    let mode = store::load_settings_async().await.session_data_mode;
     // Blocking disk IO off the async runtime.
     tauri::async_runtime::spawn_blocking(move || {
         crate::cli_sessions::delete_cli_session(&agent_session_id, dir.as_deref(), &mode)

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -1,6 +1,6 @@
 #[tauri::command]
 pub async fn settings_get() -> Result<AppSettings, String> {
-    Ok(store::load_settings())
+    Ok(store::load_settings_async().await)
 }
 
 /// One-shot notice after corrupt store files were quarantined on load.
@@ -15,7 +15,7 @@ pub async fn settings_set(
     mgr: State<'_, Arc<SessionManager>>,
     settings: AppSettings,
 ) -> Result<AppSettings, String> {
-    let prev = store::load_settings();
+    let prev = store::load_settings_async().await;
     let mut settings = settings;
     settings.wallpaper_x_search_mode =
         store::normalize_wallpaper_x_search_mode(&settings.wallpaper_x_search_mode).into();
@@ -138,7 +138,7 @@ pub async fn settings_set(
     let schedules_launch_agent_flip =
         prev.schedules_launch_agent != settings.schedules_launch_agent;
 
-    store::save_settings(&settings)?;
+    store::save_settings_async(&settings).await?;
 
     if proxy_flip {
         crate::wallpaper_grok_album::close_for_proxy_change(&app);
@@ -153,7 +153,7 @@ pub async fn settings_set(
         if let Err(e) = res {
             let mut rolled = settings.clone();
             rolled.schedules_launch_agent = prev.schedules_launch_agent;
-            let _ = store::save_settings(&rolled);
+            let _ = store::save_settings_async(&rolled).await;
             return Err(format!("schedules LaunchAgent: {e}"));
         }
         // Non-macOS enable is unsupported — keep flag false.
@@ -161,7 +161,7 @@ pub async fn settings_set(
         if settings.schedules_launch_agent {
             let mut rolled = settings.clone();
             rolled.schedules_launch_agent = false;
-            let _ = store::save_settings(&rolled);
+            let _ = store::save_settings_async(&rolled).await;
             settings.schedules_launch_agent = false;
         }
     }
@@ -172,7 +172,7 @@ pub async fn settings_set(
         {
             let mut rolled = settings.clone();
             rolled.store_api_keys_in_keychain = prev.store_api_keys_in_keychain;
-            let _ = store::save_settings(&rolled);
+            let _ = store::save_settings_async(&rolled).await;
             return Err(e);
         }
     }
@@ -188,7 +188,7 @@ pub async fn settings_set(
         if let Err(e) = res {
             let mut rolled = settings.clone();
             rolled.launch_at_login = prev.launch_at_login;
-            let _ = store::save_settings(&rolled);
+            let _ = store::save_settings_async(&rolled).await;
             return Err(format!("launch at login: {e}"));
         }
     }
@@ -199,7 +199,7 @@ pub async fn settings_set(
         if settings.session_data_mode == "shared"
             && crate::providers::ensure_independent_for_custom_route()
         {
-            settings = store::load_settings();
+            settings = store::load_settings_async().await;
             tracing::info!(
                 "settings_set: custom route self-healed session_data_mode shared → independent"
             );
@@ -604,7 +604,7 @@ pub async fn secrets_get_masked() -> Result<serde_json::Value, String> {
             crate::secrets::SecretsBackendKind::Keychain => "keychain",
             crate::secrets::SecretsBackendKind::File => "file",
         },
-        "storeApiKeysInKeychain": store::load_settings().store_api_keys_in_keychain,
+        "storeApiKeysInKeychain": store::load_settings_async().await.store_api_keys_in_keychain,
     }))
 }
 

--- a/src-tauri/src/commands/worktree_agents_p1.rs
+++ b/src-tauri/src/commands/worktree_agents_p1.rs
@@ -127,7 +127,7 @@ pub async fn workflows_list(
         .map(str::trim)
         .filter(|s| !s.is_empty())
         .map(|s| s.to_string());
-    let mode = store::load_settings().session_data_mode.clone();
+    let mode = store::load_settings_async().await.session_data_mode.clone();
     let result = tauri::async_runtime::spawn_blocking(move || {
         crate::agent_workflows::discover_workflows(project.as_deref(), &mode)
     })

--- a/src-tauri/src/store.rs
+++ b/src-tauri/src/store.rs
@@ -1314,6 +1314,26 @@ pub fn save_settings(s: &AppSettings) -> Result<(), String> {
     write_json(&settings_file(), &normalized)
 }
 
+/// Async-context variant of [`load_settings`]. The settings file sits behind
+/// an exclusive lock and `load_settings` may even rewrite it during one-time
+/// migrations, so async commands must not block their worker on the IO
+/// (same class as the git_status blocking-pool fix in #990).
+pub async fn load_settings_async() -> AppSettings {
+    // JoinError can only come from a panic inside load_settings itself,
+    // which already falls back to defaults on IO failure.
+    tokio::task::spawn_blocking(load_settings)
+        .await
+        .unwrap_or_default()
+}
+
+/// Async-context variant of [`save_settings`].
+pub async fn save_settings_async(s: &AppSettings) -> Result<(), String> {
+    let s = s.clone();
+    tokio::task::spawn_blocking(move || save_settings(&s))
+        .await
+        .map_err(|e| format!("settings save task failed: {e}"))?
+}
+
 /// Stable pin partition: all pinned first, then unpinned.
 /// Relative order within each group is preserved (user order / file order).
 /// Does **not** sort by `last_opened_at` — sidebar order is manual.


### PR DESCRIPTION
## Summary
Tauri commands called `store::load_settings()` / `store::save_settings()` directly on their async worker. The settings file sits behind an **exclusive store lock**, and `load_settings` may even rewrite it during one-time migrations — so a contended lock blocks the async worker, the same freeze class the Windows remediation wave removed from session-map locks (cf. `git_status` moving to the blocking pool in #990).

This adds `store::load_settings_async` / `store::save_settings_async` (thin `spawn_blocking` delegations) and converts the **command entry points** in `src/commands/`:

- **42 call sites** now go through the async accessors (verified by the compiler)
- **12 sites** correctly stay sync — they already run inside `spawn_blocking` closures and were initially misconverted; `cargo check` caught every one and they were reverted
- **7 sites** in sync `*_blocking` helpers (already pool-only) stay sync
- one closure call site (`cli_install_latest`) was restructured to a `match` that keeps the lazy-load semantics

Out of scope (deliberately): the ~118 deeper internal call sites in `session_manager`, `serve.rs`, background workers — those run in mixed contexts that need case-by-case analysis, not a drive-by.

## Type of change
- [x] Bug fix (reliability — async workers no longer block on the settings file lock)
- [ ] New feature
- [ ] Refactor / chore

## Checklist
- [x] I ran `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test` in `src-tauri` (all green; 1,841 tests)
- [x] I ran `pnpm typecheck` / `pnpm test` (638 files) / `lint` / gates / `build:ui` (CHANGELOG entry only on the frontend side)
- [x] User-facing strings — CHANGELOG entry only (en + zh)
- [x] No `window.confirm` / `prompt` / `alert`
- [x] No secrets included

**Stacked on #1135 → #1132 → #1133 → #1134 → #1136 so CI stays green.