### PR TITLE
fix(wallpaper): 修复公共图库缩略图下载与本地媒体显示

### DIFF
--- a/docs/llm-wiki/wallpaper-search.md
+++ b/docs/llm-wiki/wallpaper-search.md
@@ -251,11 +251,20 @@ secrets commands; the renderer never receives the stored key. A rejected key
 opens an editable replacement field, removal requires an in-app confirmation,
 and search stays disabled while credential status is unknown or unavailable.
 
-Provider results use the bounded Host thumbnail path and keep their source,
-author and licence links separate from the image-preview action. A thumbnail
-failure leaves the result card available so selecting it can still fetch the
-validated original. Initial searches replace the old gallery; explicit “load
-more” appends deduplicated results while leaving current cards selectable.
+Provider results use the provider's dedicated thumbnail URL through the bounded
+Host thumbnail path, falling back to the validated original only when no safe
+thumbnail URL exists. Once a result is present in the local catalog, its card
+uses the loopback media endpoint instead of downloading the remote thumbnail
+again. Remote image requests normally advertise only formats supported by the
+Host decoder; in particular, they never advertise AVIF and then fail thumbnail
+decoding. Openverse's fixed thumbnail endpoint requires a low-priority wildcard
+fallback on a cold request, so only that exact endpoint receives one; its response
+still passes the same MIME, signature and decoder validation. Source, author and
+licence links remain separate from the image-preview action. A thumbnail failure
+leaves the result card available so selecting it can still fetch the validated
+original. Initial searches replace the old gallery;
+explicit “load more” appends deduplicated results while leaving current cards
+selectable.
 The load-more action sits after the current cards inside the result scroller.
 Paged grids keep DOM order so revealing a prefetched page does not redistribute
 existing cards; known media dimensions preserve each thumbnail ratio, with a

--- a/src-tauri/src/image_thumb.rs
+++ b/src-tauri/src/image_thumb.rs
@@ -394,9 +394,7 @@ async fn download_remote_image_bytes_safe(start: &str) -> Result<Vec<u8>, String
 
     let policy = crate::skin_net::OriginPolicy::AnyHttps;
     let client = crate::safe_https_client::SafeHttpsClient::new();
-    let mut current = crate::skin_net::check_hop_async(start, &policy)
-        .await
-        .map_err(|e| e)?;
+    let mut current = crate::skin_net::check_hop_async(start, &policy).await?;
 
     for hop in 0..=crate::skin_net::MAX_REDIRECTS {
         let mut headers = HeaderMap::new();
@@ -418,9 +416,7 @@ async fn download_remote_image_bytes_safe(start: &str) -> Result<Vec<u8>, String
             let next = current
                 .join(location)
                 .map_err(|e| format!("redirect join: {e}"))?;
-            current = crate::skin_net::check_hop_async(next.as_str(), &policy)
-                .await
-                .map_err(|e| e)?;
+            current = crate::skin_net::check_hop_async(next.as_str(), &policy).await?;
             continue;
         }
 
@@ -451,6 +447,7 @@ async fn download_remote_image_bytes_safe(start: &str) -> Result<Vec<u8>, String
     Err("too many redirects".into())
 }
 
+#[cfg(test)]
 fn read_remote_image_body(reader: impl std::io::Read) -> Result<Vec<u8>, String> {
     use std::io::Read;
     let mut bytes = Vec::new();
@@ -574,7 +571,9 @@ mod tests {
         )
         .unwrap_err();
         assert!(
-            blocked.contains("private") || blocked.contains("metadata") || blocked.contains("blocked"),
+            blocked.contains("private")
+                || blocked.contains("metadata")
+                || blocked.contains("blocked"),
             "unexpected block reason: {blocked}"
         );
 

--- a/src-tauri/src/session_manager/control.rs
+++ b/src-tauri/src/session_manager/control.rs
@@ -953,8 +953,12 @@ impl SessionManager {
                     let _ = s.fsm.permission_resolved_continue();
                 }
                 // Permission cleared — may finish a deferred prompt_complete (#52).
-                Self::try_finish_deferred_prompt_complete(s, Some(&mut pending_emits), Some(&mut pending_persists))
-                    .flatten()
+                Self::try_finish_deferred_prompt_complete(
+                    s,
+                    Some(&mut pending_emits),
+                    Some(&mut pending_persists),
+                )
+                .flatten()
             })
             .flatten();
         Self::emit_stream_payloads(&app, pending_emits);
@@ -1058,8 +1062,12 @@ impl SessionManager {
                 if s.pending_plan_rpc_id == Some(id) || rpc_id == Some(id) {
                     s.pending_plan_rpc_id = None;
                 }
-                Self::try_finish_deferred_prompt_complete(s, Some(&mut pending_emits), Some(&mut pending_persists))
-                    .flatten()
+                Self::try_finish_deferred_prompt_complete(
+                    s,
+                    Some(&mut pending_emits),
+                    Some(&mut pending_persists),
+                )
+                .flatten()
             })
             .flatten();
         Self::emit_stream_payloads(&app, pending_emits);
@@ -1106,8 +1114,12 @@ impl SessionManager {
                 if s.pending_ask_user_rpc_id == Some(id) || rpc_id == Some(id) {
                     s.pending_ask_user_rpc_id = None;
                 }
-                Self::try_finish_deferred_prompt_complete(s, Some(&mut pending_emits), Some(&mut pending_persists))
-                    .flatten()
+                Self::try_finish_deferred_prompt_complete(
+                    s,
+                    Some(&mut pending_emits),
+                    Some(&mut pending_persists),
+                )
+                .flatten()
             })
             .flatten();
         Self::emit_stream_payloads(&app, pending_emits);

--- a/src-tauri/src/session_manager/events.rs
+++ b/src-tauri/src/session_manager/events.rs
@@ -416,10 +416,10 @@ impl SessionManager {
                                     let _ = s.fsm.permission_resolved_continue();
                                 }
                                 Self::try_finish_deferred_prompt_complete(
-                                s,
-                                Some(&mut pending_emits),
-                                Some(&mut pending_persists),
-                            )
+                                    s,
+                                    Some(&mut pending_emits),
+                                    Some(&mut pending_persists),
+                                )
                                 .flatten()
                             } else {
                                 None
@@ -452,10 +452,10 @@ impl SessionManager {
                                     let _ = s.fsm.permission_resolved_continue();
                                 }
                                 Self::try_finish_deferred_prompt_complete(
-                                s,
-                                Some(&mut pending_emits),
-                                Some(&mut pending_persists),
-                            )
+                                    s,
+                                    Some(&mut pending_emits),
+                                    Some(&mut pending_persists),
+                                )
                                 .flatten()
                             } else {
                                 None
@@ -645,10 +645,10 @@ impl SessionManager {
                         s.tools_this_turn = s.tools_this_turn.saturating_add(1);
                         // Tools settled → apply deferred prompt_complete if any (#52).
                         let finished = Self::try_finish_deferred_prompt_complete(
-                                s,
-                                Some(&mut pending_emits),
-                                Some(&mut pending_persists),
-                            );
+                            s,
+                            Some(&mut pending_emits),
+                            Some(&mut pending_persists),
+                        );
                         (
                             s.app_session_id.clone(),
                             s.project_path.clone(),
@@ -834,10 +834,10 @@ impl SessionManager {
                         // Progress without re-arming a false open tool.
                         Self::touch_stream_progress_locked(s);
                         Self::try_finish_deferred_prompt_complete(
-                                s,
-                                Some(&mut pending_emits),
-                                Some(&mut pending_persists),
-                            )
+                            s,
+                            Some(&mut pending_emits),
+                            Some(&mut pending_persists),
+                        )
                         .flatten()
                     } else {
                         None
@@ -934,9 +934,9 @@ impl SessionManager {
                     let mut guard = self.inner.lock();
                     if let Some(s) = guard.as_mut() {
                         if !s.provider_retry_aborted {
-                            pending_persists.push(PendingSessionPersist::TurnBoundary(
-                            Self::prepare_turn_error(s, &error, &mut pending_emits),
-                        ));
+                            pending_persists.push(PendingSessionPersist::TurnBoundary(Box::new(
+                                Self::prepare_turn_error(s, &error, &mut pending_emits),
+                            )));
                         } else {
                             // Retry path already recorded the error; still drop busy
                             // markers so reconnect is not stuck Disconnected+busy.
@@ -975,12 +975,13 @@ impl SessionManager {
                                 Self::prepare_journal_turn_cancelled(s, "agent_exit")
                             {
                                 pending_persists
-                                    .push(PendingSessionPersist::TurnBoundary(boundary));
+                                    .push(PendingSessionPersist::TurnBoundary(Box::new(boundary)));
                             }
                         } else if let Some(flush) =
                             Self::prepare_stream_journal_flush(s, true, false)
                         {
-                            pending_persists.push(PendingSessionPersist::StreamJournal(flush));
+                            pending_persists
+                                .push(PendingSessionPersist::StreamJournal(Box::new(flush)));
                         }
                         // Drop human gates so UI cannot Approve into a dead process.
                         if let Some(row) = Self::take_pending_gate_invalidation(s) {
@@ -1135,11 +1136,7 @@ impl SessionManager {
 
                 // Match background emits: include sessionId so the UI can
                 // ignore retries for a non-viewed chat.
-                let live_sid = self
-                    .inner
-                    .lock()
-                    .as_ref()
-                    .map(|s| s.app_session_id.clone());
+                let live_sid = self.inner.lock().as_ref().map(|s| s.app_session_id.clone());
                 let _ = app.emit(
                     "session://retry",
                     serde_json::json!({
@@ -1170,8 +1167,8 @@ impl SessionManager {
                                 let err = provider_retry_abort_error(attempt, cap, &reason);
                                 // Chat-visible error row (must happen before clearing stream ids)
                                 pending_persists.push(PendingSessionPersist::TurnBoundary(
-                                Self::prepare_turn_error(s, &err, &mut pending_emits),
-                            ));
+                                    Box::new(Self::prepare_turn_error(s, &err, &mut pending_emits)),
+                                ));
                                 let _ = s.fsm.fail_with(err);
                                 (s.acp.clone(), s.meta.agent_session_id.clone())
                             }

--- a/src-tauri/src/session_manager/events_bg.rs
+++ b/src-tauri/src/session_manager/events_bg.rs
@@ -444,10 +444,10 @@ impl SessionManager {
                         };
                         s.tools_this_turn = s.tools_this_turn.saturating_add(1);
                         let finished = Self::try_finish_deferred_prompt_complete(
-                                s,
-                                Some(&mut pending_emits),
-                                Some(&mut pending_persists),
-                            )
+                            s,
+                            Some(&mut pending_emits),
+                            Some(&mut pending_persists),
+                        )
                         .is_some();
                         let st = if status.is_empty() {
                             "in_progress".to_string()
@@ -567,10 +567,10 @@ impl SessionManager {
                         Self::release_tool_open_on_session(s, &tool_call_id);
                         Self::touch_stream_progress_locked(s);
                         Self::try_finish_deferred_prompt_complete(
-                                s,
-                                Some(&mut pending_emits),
-                                Some(&mut pending_persists),
-                            )
+                            s,
+                            Some(&mut pending_emits),
+                            Some(&mut pending_persists),
+                        )
                         .is_some()
                     } else {
                         false
@@ -619,7 +619,7 @@ impl SessionManager {
                                 Self::prepare_journal_turn_cancelled(&mut s, "agent_exit")
                             {
                                 pending_persists
-                                    .push(PendingSessionPersist::TurnBoundary(boundary));
+                                    .push(PendingSessionPersist::TurnBoundary(Box::new(boundary)));
                             }
                             tracing::warn!(
                                 "background agent process exited mid-turn sid={}",
@@ -628,7 +628,8 @@ impl SessionManager {
                         } else if let Some(flush) =
                             Self::prepare_stream_journal_flush(&mut s, true, false)
                         {
-                            pending_persists.push(PendingSessionPersist::StreamJournal(flush));
+                            pending_persists
+                                .push(PendingSessionPersist::StreamJournal(Box::new(flush)));
                         }
                         if let Some(row) = Self::take_pending_gate_invalidation(&mut s) {
                             crate::plan_chrome::mark_gate_stale(&s.app_session_id);
@@ -671,9 +672,9 @@ impl SessionManager {
                 {
                     let mut bg = self.background.lock();
                     if let Some(s) = bg.get_mut(app_session_id) {
-                        pending_persists.push(PendingSessionPersist::TurnBoundary(
-                        Self::prepare_turn_error(s, &error, &mut pending_emits),
-                    ));
+                        pending_persists.push(PendingSessionPersist::TurnBoundary(Box::new(
+                            Self::prepare_turn_error(s, &error, &mut pending_emits),
+                        )));
                         let _ = s.fsm.fail_with(error);
                     }
                 }
@@ -910,8 +911,8 @@ impl SessionManager {
                                 s.provider_retry_aborted = true;
                                 let err = provider_retry_abort_error(attempt, cap, &reason);
                                 pending_persists.push(PendingSessionPersist::TurnBoundary(
-                                Self::prepare_turn_error(s, &err, &mut pending_emits),
-                            ));
+                                    Box::new(Self::prepare_turn_error(s, &err, &mut pending_emits)),
+                                ));
                                 let _ = s.fsm.fail_with(err);
                                 (s.acp.clone(), s.meta.agent_session_id.clone())
                             }

--- a/src-tauri/src/session_manager/stream.rs
+++ b/src-tauri/src/session_manager/stream.rs
@@ -153,8 +153,8 @@ pub(crate) struct PendingTurnBoundaryPersist {
 
 /// Lock-free disk/IPC work collected while a session-map mutex is held.
 pub(crate) enum PendingSessionPersist {
-    StreamJournal(PendingStreamJournalFlush),
-    TurnBoundary(PendingTurnBoundaryPersist),
+    StreamJournal(Box<PendingStreamJournalFlush>),
+    TurnBoundary(Box<PendingTurnBoundaryPersist>),
 }
 
 impl SessionManager {
@@ -442,7 +442,7 @@ impl SessionManager {
             if let Some(boundary) = Self::prepare_journal_turn_cancelled(s, &reason) {
                 Self::push_session_persist(
                     pending_persists,
-                    PendingSessionPersist::TurnBoundary(boundary),
+                    PendingSessionPersist::TurnBoundary(Box::new(boundary)),
                 );
             }
         } else {
@@ -451,7 +451,7 @@ impl SessionManager {
             if let Some(flush) = Self::prepare_stream_journal_flush(s, true, false) {
                 Self::push_session_persist(
                     pending_persists,
-                    PendingSessionPersist::StreamJournal(flush),
+                    PendingSessionPersist::StreamJournal(Box::new(flush)),
                 );
             }
         }
@@ -954,10 +954,10 @@ impl SessionManager {
         for item in pending {
             match item {
                 PendingSessionPersist::StreamJournal(flush) => {
-                    Self::commit_stream_journal_flush(flush);
+                    Self::commit_stream_journal_flush(*flush);
                 }
                 PendingSessionPersist::TurnBoundary(boundary) => {
-                    Self::commit_turn_boundary_persist(app, boundary);
+                    Self::commit_turn_boundary_persist(app, *boundary);
                 }
             }
         }

--- a/src-tauri/src/session_manager/turn.rs
+++ b/src-tauri/src/session_manager/turn.rs
@@ -525,9 +525,9 @@ impl SessionManager {
                         }
                         // Skip if host already recorded a retry-exhausted error this turn.
                         if !s.provider_retry_aborted {
-                            pending_persists.push(PendingSessionPersist::TurnBoundary(
-                            SessionManager::prepare_turn_error(s, &e, &mut pending_emits),
-                        ));
+                            pending_persists.push(PendingSessionPersist::TurnBoundary(Box::new(
+                                SessionManager::prepare_turn_error(s, &e, &mut pending_emits),
+                            )));
                             let _ = s.fsm.fail_with(e);
                             record_error = true;
                         }
@@ -902,7 +902,8 @@ impl SessionManager {
                 if was_busy {
                     // Shared helper: durable chip + live emit (history matches live).
                     if let Some(boundary) = Self::prepare_journal_turn_cancelled(s, "user_stop") {
-                        pending_persists.push(PendingSessionPersist::TurnBoundary(boundary));
+                        pending_persists
+                            .push(PendingSessionPersist::TurnBoundary(Box::new(boundary)));
                     }
                     if s.fsm.state() == SessionState::Streaming
                         || s.fsm.state() == SessionState::AwaitingPermission

--- a/src-tauri/src/wallpaper_provider_search.rs
+++ b/src-tauri/src/wallpaper_provider_search.rs
@@ -30,11 +30,11 @@ use probe::{validate_probe_outputs, visit_probes_as_completed};
 #[cfg(test)]
 use request_url::{provider_request_url, provider_url, PEXELS_CACHE_BUST_PARAM};
 #[cfg(test)]
-use response::{parse_openverse_page, parse_pexels_page, safe_url};
+use response::{parse_openverse_page, parse_pexels_page, provider_item, safe_url};
 use transport::{fetch_api_page, provider_client};
 
 const PEXELS_LICENSE_URL: &str = "https://www.pexels.com/license/";
-const CONTRACT_VERSION: u8 = 3;
+const CONTRACT_VERSION: u8 = 4;
 const RESULT_LIMIT: usize = 20;
 const OPENVERSE_PAGE_SIZE: usize = 20;
 const OPENVERSE_PAGES_PER_BATCH: usize = 2;
@@ -214,6 +214,7 @@ impl RequestRegistry {
 struct ProviderCandidate {
     upstream_id: String,
     image_url: String,
+    thumbnail_url: Option<String>,
     source_url: String,
     source_name: &'static str,
     title: Option<String>,

--- a/src-tauri/src/wallpaper_provider_search/response.rs
+++ b/src-tauri/src/wallpaper_provider_search/response.rs
@@ -67,6 +67,10 @@ pub(super) fn parse_openverse_page(value: &Value, page: usize) -> Result<ApiPage
         candidates.push(ProviderCandidate {
             upstream_id,
             image_url,
+            thumbnail_url: raw
+                .get("thumbnail")
+                .and_then(Value::as_str)
+                .and_then(safe_url),
             source_url,
             source_name: "Openverse",
             title: clean_text(raw.get("title").and_then(Value::as_str), 240),
@@ -101,14 +105,13 @@ pub(super) fn parse_pexels_page(value: &Value, page: usize) -> Result<ApiPage, P
         .unwrap_or_else(|| value.get("next_page").is_some_and(|next| !next.is_null()));
     let mut candidates = Vec::new();
     for raw in results.iter().take(PEXELS_PAGE_SIZE) {
-        let Some(image_url) = raw
-            .get("src")
-            .and_then(|src| src.get("original").or_else(|| src.get("large2x")))
-            .and_then(Value::as_str)
-            .and_then(safe_url)
-        else {
+        let Some(src) = raw.get("src") else {
             continue;
         };
+        let Some(image_url) = first_safe_url(src, &["original", "large2x"]) else {
+            continue;
+        };
+        let thumbnail_url = first_safe_url(src, &["large", "medium", "large2x", "landscape"]);
         let Some(source_url) = raw.get("url").and_then(Value::as_str).and_then(safe_url) else {
             continue;
         };
@@ -127,6 +130,7 @@ pub(super) fn parse_pexels_page(value: &Value, page: usize) -> Result<ApiPage, P
         candidates.push(ProviderCandidate {
             upstream_id,
             image_url,
+            thumbnail_url,
             source_url,
             source_name: "Pexels",
             title: clean_text(raw.get("alt").and_then(Value::as_str), 240),
@@ -143,6 +147,11 @@ pub(super) fn parse_pexels_page(value: &Value, page: usize) -> Result<ApiPage, P
         candidates,
         has_more,
     })
+}
+
+fn first_safe_url(value: &Value, keys: &[&str]) -> Option<String> {
+    keys.iter()
+        .find_map(|key| value.get(*key).and_then(Value::as_str).and_then(safe_url))
 }
 
 pub(super) fn safe_url(raw: &str) -> Option<String> {
@@ -203,6 +212,11 @@ pub(super) fn provider_item(
     probe: RemoteImageProbe,
 ) -> WallpaperGalleryItem {
     wallpaper_remote_media::register_media_source(source, &probe.final_url, &candidate.source_url);
+    let thumb_url = candidate
+        .thumbnail_url
+        .clone()
+        .unwrap_or_else(|| probe.final_url.clone());
+    wallpaper_remote_media::register_media_source(source, &thumb_url, &candidate.source_url);
     let mut digest = Sha256::new();
     digest.update(source.as_str().as_bytes());
     digest.update(candidate.upstream_id.as_bytes());
@@ -211,7 +225,7 @@ pub(super) fn provider_item(
     WallpaperGalleryItem {
         metadata: None,
         id: format!("{}-{}", source.as_str(), &identity[..24]),
-        thumb_url: probe.final_url.clone(),
+        thumb_url,
         full_url: probe.final_url,
         kind: "image".into(),
         width: probe.width,

--- a/src-tauri/src/wallpaper_provider_search/tests.rs
+++ b/src-tauri/src/wallpaper_provider_search/tests.rs
@@ -118,6 +118,7 @@ fn openverse_parser_requires_real_provenance_and_license() {
                 "creator": "Photographer",
                 "creator_url": "https://creator.example/profile",
                 "url": "https://images.example/mountain.jpg",
+                "thumbnail": "https://images.example/mountain-thumb.jpg",
                 "foreign_landing_url": "https://source.example/photo/1",
                 "license": "by-sa",
                 "license_version": "4.0",
@@ -139,6 +140,11 @@ fn openverse_parser_requires_real_provenance_and_license() {
     assert_eq!(item.source_name, "Openverse");
     assert_eq!(item.license, "CC BY-SA 4.0");
     assert_eq!(item.author_name, "Photographer");
+    assert_eq!(item.image_url, "https://images.example/mountain.jpg");
+    assert_eq!(
+        item.thumbnail_url.as_deref(),
+        Some("https://images.example/mountain-thumb.jpg")
+    );
 }
 
 #[test]
@@ -155,7 +161,11 @@ fn pexels_parser_ignores_upstream_next_url_and_uses_fixed_license() {
                 "photographer": "Photographer",
                 "photographer_url": "https://www.pexels.com/@photographer/",
                 "alt": "Misty lake",
-                "src": {"original": "https://images.pexels.com/photos/42/image.jpeg"}
+                "src": {
+                    "original": "https://images.pexels.com/photos/42/original.jpeg",
+                    "large": "https://images.pexels.com/photos/42/large.jpeg",
+                    "medium": "https://images.pexels.com/photos/42/medium.jpeg"
+                }
             }]
         }),
         1,
@@ -165,6 +175,108 @@ fn pexels_parser_ignores_upstream_next_url_and_uses_fixed_license() {
     assert_eq!(page.candidates.len(), 1);
     assert_eq!(page.candidates[0].license, "Pexels License");
     assert_eq!(page.candidates[0].license_url, PEXELS_LICENSE_URL);
+    assert_eq!(
+        page.candidates[0].image_url,
+        "https://images.pexels.com/photos/42/original.jpeg"
+    );
+    assert_eq!(
+        page.candidates[0].thumbnail_url.as_deref(),
+        Some("https://images.pexels.com/photos/42/large.jpeg")
+    );
+}
+
+#[test]
+fn pexels_parser_falls_back_across_missing_or_unsafe_image_variants() {
+    let page = parse_pexels_page(
+        &json!({
+            "page": 1,
+            "per_page": 40,
+            "total_results": 1,
+            "photos": [{
+                "id": 43,
+                "url": "https://www.pexels.com/photo/misty-lake-43/",
+                "photographer": "Photographer",
+                "src": {
+                    "original": "http://unsafe.example/original.jpeg",
+                    "large2x": "https://images.pexels.com/photos/43/large2x.jpeg",
+                    "large": "http://unsafe.example/large.jpeg",
+                    "medium": "https://images.pexels.com/photos/43/medium.jpeg",
+                    "landscape": "https://images.pexels.com/photos/43/landscape.jpeg"
+                }
+            }]
+        }),
+        1,
+    )
+    .unwrap();
+
+    assert_eq!(page.candidates.len(), 1);
+    assert_eq!(
+        page.candidates[0].image_url,
+        "https://images.pexels.com/photos/43/large2x.jpeg"
+    );
+    assert_eq!(
+        page.candidates[0].thumbnail_url.as_deref(),
+        Some("https://images.pexels.com/photos/43/medium.jpeg")
+    );
+}
+
+#[test]
+fn provider_item_keeps_thumbnail_and_validated_original_separate() {
+    let item = provider_item(
+        RemoteWallpaperSource::Pexels,
+        ProviderCandidate {
+            upstream_id: "44".into(),
+            image_url: "https://images.pexels.com/photos/44/original.jpeg".into(),
+            thumbnail_url: Some("https://images.pexels.com/photos/44/large.jpeg".into()),
+            source_url: "https://www.pexels.com/photo/misty-lake-44/".into(),
+            source_name: "Pexels",
+            title: Some("Misty lake".into()),
+            author_name: "Photographer".into(),
+            author_url: None,
+            license: "Pexels License".into(),
+            license_url: PEXELS_LICENSE_URL.into(),
+        },
+        crate::wallpaper_remote_media::RemoteImageProbe {
+            final_url: "https://cdn.pexels.com/photos/44/original.jpeg".into(),
+            width: Some(6_000),
+            height: Some(4_000),
+            content_length: Some(12_000_000),
+            content_fingerprint: "fingerprint-44".into(),
+        },
+    );
+
+    assert_eq!(
+        item.thumb_url,
+        "https://images.pexels.com/photos/44/large.jpeg"
+    );
+    assert_eq!(
+        item.full_url,
+        "https://cdn.pexels.com/photos/44/original.jpeg"
+    );
+
+    let fallback = provider_item(
+        RemoteWallpaperSource::Openverse,
+        ProviderCandidate {
+            upstream_id: "asset-45".into(),
+            image_url: "https://images.example/45.jpg".into(),
+            thumbnail_url: None,
+            source_url: "https://source.example/photo/45".into(),
+            source_name: "Openverse",
+            title: None,
+            author_name: "Photographer".into(),
+            author_url: None,
+            license: "CC0".into(),
+            license_url: "https://creativecommons.org/publicdomain/zero/1.0/".into(),
+        },
+        crate::wallpaper_remote_media::RemoteImageProbe {
+            final_url: "https://cdn.example/45.jpg".into(),
+            width: Some(1_920),
+            height: Some(1_080),
+            content_length: Some(1_000_000),
+            content_fingerprint: "fingerprint-45".into(),
+        },
+    );
+    assert_eq!(fallback.thumb_url, fallback.full_url);
 }
 
 #[test]

--- a/src-tauri/src/wallpaper_remote_media.rs
+++ b/src-tauri/src/wallpaper_remote_media.rs
@@ -41,6 +41,14 @@ const PRE_CANCEL_CAPACITY: usize = 128;
 const BROWSER_IMAGE_USER_AGENT: &str =
     "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36 GrokApp/WallpaperDiscovery";
 const BROWSER_IMAGE_ACCEPT_LANGUAGE: &str = "en-US,en;q=0.9,*;q=0.5";
+const SUPPORTED_IMAGE_ACCEPT: &str = "image/jpeg,image/png,image/webp,image/gif";
+const OPENVERSE_THUMBNAIL_ACCEPT: &str = "image/jpeg,image/png,image/webp,image/gif,*/*;q=0.1";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ImageAcceptProfile {
+    SupportedOnly,
+    OpenverseThumbnail,
+}
 
 #[derive(Clone)]
 struct ActiveMediaRequest {
@@ -385,6 +393,7 @@ fn response_total_length(response: &SafeHttpsResponse) -> Option<u64> {
 fn image_headers(
     referer_origin: Option<&str>,
     range: Option<&str>,
+    accept_profile: ImageAcceptProfile,
 ) -> Result<HeaderMap, RemoteImageProbeFailure> {
     let mut headers = HeaderMap::new();
     headers.insert(
@@ -393,9 +402,10 @@ fn image_headers(
     );
     headers.insert(
         ACCEPT,
-        HeaderValue::from_static(
-            "image/jpeg,image/png,image/webp;q=0.9,image/avif;q=0.8,image/*;q=0.7,*/*;q=0.5",
-        ),
+        HeaderValue::from_static(match accept_profile {
+            ImageAcceptProfile::SupportedOnly => SUPPORTED_IMAGE_ACCEPT,
+            ImageAcceptProfile::OpenverseThumbnail => OPENVERSE_THUMBNAIL_ACCEPT,
+        }),
     );
     headers.insert(
         ACCEPT_LANGUAGE,
@@ -414,6 +424,42 @@ fn image_headers(
         );
     }
     Ok(headers)
+}
+
+fn thumbnail_accept_profile(source: RemoteWallpaperSource, start: &str) -> ImageAcceptProfile {
+    if source == RemoteWallpaperSource::Openverse && is_openverse_thumbnail_endpoint(start) {
+        ImageAcceptProfile::OpenverseThumbnail
+    } else {
+        ImageAcceptProfile::SupportedOnly
+    }
+}
+
+fn accept_profile_for_hop(requested: ImageAcceptProfile, current: &Url) -> ImageAcceptProfile {
+    if requested == ImageAcceptProfile::OpenverseThumbnail
+        && is_openverse_thumbnail_endpoint(current.as_str())
+    {
+        ImageAcceptProfile::OpenverseThumbnail
+    } else {
+        ImageAcceptProfile::SupportedOnly
+    }
+}
+
+fn is_openverse_thumbnail_endpoint(raw: &str) -> bool {
+    let Ok(url) = Url::parse(raw) else {
+        return false;
+    };
+    let segments = url
+        .path_segments()
+        .map(|parts| parts.filter(|part| !part.is_empty()).collect::<Vec<_>>())
+        .unwrap_or_default();
+    url.scheme() == "https"
+        && url
+            .host_str()
+            .is_some_and(|host| host.eq_ignore_ascii_case("api.openverse.org"))
+        && url.port_or_known_default() == Some(443)
+        && url.username().is_empty()
+        && url.password().is_none()
+        && matches!(segments.as_slice(), ["v1", "images", id, "thumb"] if !id.is_empty() && id.len() <= 160)
 }
 
 async fn read_prefix(
@@ -465,7 +511,11 @@ async fn probe_image_with_client(
 
     for hop in 0..=skin_net::MAX_REDIRECTS {
         let range = format!("bytes=0-{}", PROBE_BYTES - 1);
-        let headers = image_headers(referer_origin, Some(&range))?;
+        let headers = image_headers(
+            referer_origin,
+            Some(&range),
+            ImageAcceptProfile::SupportedOnly,
+        )?;
         let mut response = tokio::select! {
             biased;
             _ = cancellation.cancelled() => return Err(RemoteImageProbeFailure::Cancelled),
@@ -522,6 +572,7 @@ async fn fetch_remote_image_bytes_with_client(
     referer_origin: Option<&str>,
     max_bytes: u64,
     cancellation: &WallpaperSearchCancellation,
+    accept_profile: ImageAcceptProfile,
 ) -> Result<(String, String, Vec<u8>), RemoteImageProbeFailure> {
     if cancellation.is_cancelled() {
         return Err(RemoteImageProbeFailure::Cancelled);
@@ -530,7 +581,11 @@ async fn fetch_remote_image_bytes_with_client(
     let mut current = check_image_hop(start, &policy, cancellation).await?;
 
     for hop in 0..=skin_net::MAX_REDIRECTS {
-        let headers = image_headers(referer_origin, None)?;
+        let headers = image_headers(
+            referer_origin,
+            None,
+            accept_profile_for_hop(accept_profile, &current),
+        )?;
         let mut response = tokio::select! {
             biased;
             _ = cancellation.cancelled() => return Err(RemoteImageProbeFailure::Cancelled),
@@ -608,6 +663,7 @@ pub(crate) async fn fetch_image_bytes(
         None,
         MAX_DOWNLOAD_BYTES,
         cancellation,
+        ImageAcceptProfile::SupportedOnly,
     )
     .await
     .map_err(remote_fetch_error)
@@ -629,6 +685,7 @@ pub(crate) async fn fetch_and_store_image(
                 Some(referer),
                 MAX_DOWNLOAD_BYTES,
                 &cancellation,
+                ImageAcceptProfile::SupportedOnly,
             )
             .await
             .map_err(remote_fetch_error)?
@@ -673,6 +730,7 @@ pub(crate) async fn fetch_thumbnail(
             referer.as_deref(),
             THUMBNAIL_SOURCE_BYTES,
             &cancellation,
+            thumbnail_accept_profile(source, start),
         )
         .await
         .map_err(|failure| match failure {
@@ -737,188 +795,4 @@ fn save_image(
 }
 
 #[cfg(test)]
-mod tests {
-    use std::io::Cursor;
-    use std::path::Path;
-
-    use crate::paths::APP_HOME_ENV_LOCK;
-
-    use super::*;
-
-    #[test]
-    fn content_range_total_shape_is_stable() {
-        let parsed = "bytes 0-65535/1048576"
-            .rsplit('/')
-            .next()
-            .and_then(|value| value.parse::<u64>().ok());
-        assert_eq!(parsed, Some(1_048_576));
-    }
-
-    #[test]
-    fn full_remote_download_rejects_partial_response_shapes() {
-        assert!(crate::wallpaper_source::is_complete_download_response(
-            200, false
-        ));
-        assert!(!crate::wallpaper_source::is_complete_download_response(
-            206, true
-        ));
-        assert!(!crate::wallpaper_source::is_complete_download_response(
-            200, true
-        ));
-    }
-
-    #[test]
-    fn image_referer_contains_only_the_source_origin() {
-        let source = Url::parse("https://photos.example/private/path?query=secret").unwrap();
-        assert_eq!(
-            origin_referer(&source).as_deref(),
-            Some("https://photos.example/")
-        );
-        assert!(origin_referer(&Url::parse("http://photos.example/path").unwrap()).is_none());
-        assert_eq!(
-            verified_source_origin("https://photos.example/private/path?token=secret").as_deref(),
-            Some("https://photos.example/")
-        );
-    }
-
-    #[test]
-    fn source_registry_is_source_scoped_bounded_and_expires() {
-        let started = Instant::now();
-        let mut registry = SourceOriginRegistry::default();
-        registry.register(
-            RemoteWallpaperSource::Web,
-            "https://cdn.example/photo.jpg".into(),
-            "https://photos.example/".into(),
-            started,
-        );
-        assert_eq!(
-            registry
-                .lookup(
-                    RemoteWallpaperSource::Web,
-                    "https://cdn.example/photo.jpg",
-                    started + Duration::from_secs(1),
-                )
-                .as_deref(),
-            Some("https://photos.example/")
-        );
-        assert!(registry
-            .lookup(
-                RemoteWallpaperSource::Openverse,
-                "https://cdn.example/photo.jpg",
-                started + Duration::from_secs(1),
-            )
-            .is_none());
-        assert!(registry
-            .lookup(
-                RemoteWallpaperSource::Web,
-                "https://cdn.example/photo.jpg",
-                started + SOURCE_ORIGIN_TTL + Duration::from_secs(1),
-            )
-            .is_none());
-
-        for index in 0..=SOURCE_ORIGIN_LIMIT {
-            registry.register(
-                RemoteWallpaperSource::Pexels,
-                format!("https://cdn.example/{index}.jpg"),
-                "https://www.pexels.com/".into(),
-                started + Duration::from_millis(index as u64),
-            );
-        }
-        assert_eq!(registry.entries.len(), SOURCE_ORIGIN_LIMIT);
-        assert!(!registry.entries.contains_key(&(
-            RemoteWallpaperSource::Pexels,
-            "https://cdn.example/0.jpg".into(),
-        )));
-    }
-
-    #[test]
-    fn source_registry_rejects_renderer_style_header_inputs() {
-        assert_eq!(
-            canonical_media_url("https://cdn.example/photo.jpg#fragment").as_deref(),
-            Some("https://cdn.example/photo.jpg")
-        );
-        assert!(canonical_media_url("http://cdn.example/photo.jpg").is_none());
-        assert!(canonical_media_url("https://user:secret@cdn.example/photo.jpg").is_none());
-        assert!(verified_source_origin("https://photos.example:444/item").is_none());
-    }
-
-    #[test]
-    fn media_cancel_before_begin_is_sticky_bounded_and_expires() {
-        let now = Instant::now();
-        let mut registry = MediaRequestRegistry::default();
-        registry.record_pre_cancel("late-media", now);
-        assert!(registry.take_pre_cancel("late-media", now));
-        assert!(!registry.take_pre_cancel("late-media", now));
-
-        for index in 0..=PRE_CANCEL_CAPACITY {
-            registry.record_pre_cancel(&format!("request-{index}"), now);
-        }
-        assert_eq!(registry.pre_cancelled.len(), PRE_CANCEL_CAPACITY);
-        assert!(!registry.take_pre_cancel("request-0", now));
-        assert!(
-            !registry.take_pre_cancel("request-1", now + PRE_CANCEL_TTL + Duration::from_secs(1),)
-        );
-    }
-
-    #[test]
-    fn remote_thumbnail_is_bounded_jpeg_data_without_persisting() {
-        let image = image::DynamicImage::new_rgb8(1_600, 900);
-        let mut png = Cursor::new(Vec::new());
-        image
-            .write_to(&mut png, image::ImageFormat::Png)
-            .expect("encode test image");
-
-        let thumbnail = thumbnail_from_bytes(png.into_inner()).expect("build thumbnail");
-        assert_eq!((thumbnail.width, thumbnail.height), (1_600, 900));
-        assert!(thumbnail.data_url.starts_with("data:image/jpeg;base64,"));
-        assert!(thumbnail.data_url.len() <= 768 * 1024);
-    }
-
-    #[test]
-    fn probe_http_failures_have_stable_categories() {
-        assert_eq!(
-            status_failure(StatusCode::FORBIDDEN),
-            RemoteImageProbeFailure::Forbidden
-        );
-        assert_eq!(
-            status_failure(StatusCode::NOT_FOUND),
-            RemoteImageProbeFailure::NotFound
-        );
-        assert_eq!(
-            status_failure(StatusCode::TOO_MANY_REQUESTS),
-            RemoteImageProbeFailure::RateLimited
-        );
-        assert_eq!(
-            status_failure(StatusCode::BAD_GATEWAY),
-            RemoteImageProbeFailure::HttpServer
-        );
-    }
-
-    #[test]
-    fn stored_remote_images_stay_in_their_source_directory() {
-        let _environment = APP_HOME_ENV_LOCK
-            .lock()
-            .unwrap_or_else(|error| error.into_inner());
-        let home = std::env::temp_dir().join(format!(
-            "grok-app-remote-image-{}-{}",
-            std::process::id(),
-            uuid::Uuid::new_v4().simple()
-        ));
-        // SAFETY: test-only mutation serialized by APP_HOME_ENV_LOCK.
-        unsafe { std::env::set_var("GROK_APP_HOME", &home) };
-        let mut png = vec![0u8; 128];
-        png[..8].copy_from_slice(b"\x89PNG\r\n\x1a\n");
-        let saved = save_image(
-            "https://images.example.test/wallpaper.png",
-            RemoteWallpaperSource::Web,
-            "image/png",
-            png,
-        )
-        .expect("save remote image");
-        assert!(Path::new(&saved.path).is_file());
-        assert!(Path::new(&saved.path).starts_with(home.join("wallpapers").join("web")));
-
-        unsafe { std::env::remove_var("GROK_APP_HOME") };
-        let _ = fs::remove_dir_all(home);
-    }
-}
+mod tests;

--- a/src-tauri/src/wallpaper_remote_media/tests.rs
+++ b/src-tauri/src/wallpaper_remote_media/tests.rs
@@ -1,0 +1,239 @@
+use std::io::Cursor;
+use std::path::Path;
+
+use crate::paths::APP_HOME_ENV_LOCK;
+
+use super::*;
+
+#[test]
+fn content_range_total_shape_is_stable() {
+    let parsed = "bytes 0-65535/1048576"
+        .rsplit('/')
+        .next()
+        .and_then(|value| value.parse::<u64>().ok());
+    assert_eq!(parsed, Some(1_048_576));
+}
+
+#[test]
+fn full_remote_download_rejects_partial_response_shapes() {
+    assert!(crate::wallpaper_source::is_complete_download_response(
+        200, false
+    ));
+    assert!(!crate::wallpaper_source::is_complete_download_response(
+        206, true
+    ));
+    assert!(!crate::wallpaper_source::is_complete_download_response(
+        200, true
+    ));
+}
+
+#[test]
+fn image_referer_contains_only_the_source_origin() {
+    let source = Url::parse("https://photos.example/private/path?query=secret").unwrap();
+    assert_eq!(
+        origin_referer(&source).as_deref(),
+        Some("https://photos.example/")
+    );
+    assert!(origin_referer(&Url::parse("http://photos.example/path").unwrap()).is_none());
+    assert_eq!(
+        verified_source_origin("https://photos.example/private/path?token=secret").as_deref(),
+        Some("https://photos.example/")
+    );
+}
+
+#[test]
+fn image_requests_advertise_only_supported_decoder_formats() {
+    let headers =
+        image_headers(None, None, ImageAcceptProfile::SupportedOnly).expect("image headers");
+    let accept = headers
+        .get(ACCEPT)
+        .and_then(|value| value.to_str().ok())
+        .expect("Accept header");
+
+    assert_eq!(accept, SUPPORTED_IMAGE_ACCEPT);
+}
+
+#[test]
+fn openverse_thumbnail_accept_fallback_is_endpoint_scoped() {
+    let openverse_thumb =
+        "https://api.openverse.org/v1/images/01234567-89ab-cdef-0123-456789abcdef/thumb/";
+    assert_eq!(
+        thumbnail_accept_profile(RemoteWallpaperSource::Openverse, openverse_thumb),
+        ImageAcceptProfile::OpenverseThumbnail
+    );
+    assert_eq!(
+        thumbnail_accept_profile(RemoteWallpaperSource::Pexels, openverse_thumb),
+        ImageAcceptProfile::SupportedOnly
+    );
+    assert_eq!(
+        thumbnail_accept_profile(
+            RemoteWallpaperSource::Openverse,
+            "https://api.openverse.org/v1/images/search/"
+        ),
+        ImageAcceptProfile::SupportedOnly
+    );
+    assert_eq!(
+        thumbnail_accept_profile(
+            RemoteWallpaperSource::Openverse,
+            "https://api.openverse.org.example/v1/images/id/thumb/"
+        ),
+        ImageAcceptProfile::SupportedOnly
+    );
+
+    let endpoint = Url::parse(openverse_thumb).unwrap();
+    let redirected = Url::parse("https://cdn.example/thumb.webp").unwrap();
+    assert_eq!(
+        accept_profile_for_hop(ImageAcceptProfile::OpenverseThumbnail, &endpoint),
+        ImageAcceptProfile::OpenverseThumbnail
+    );
+    assert_eq!(
+        accept_profile_for_hop(ImageAcceptProfile::OpenverseThumbnail, &redirected),
+        ImageAcceptProfile::SupportedOnly
+    );
+
+    let headers = image_headers(None, None, ImageAcceptProfile::OpenverseThumbnail)
+        .expect("Openverse thumbnail headers");
+    assert_eq!(
+        headers.get(ACCEPT).and_then(|value| value.to_str().ok()),
+        Some(OPENVERSE_THUMBNAIL_ACCEPT)
+    );
+}
+
+#[test]
+fn source_registry_is_source_scoped_bounded_and_expires() {
+    let started = Instant::now();
+    let mut registry = SourceOriginRegistry::default();
+    registry.register(
+        RemoteWallpaperSource::Web,
+        "https://cdn.example/photo.jpg".into(),
+        "https://photos.example/".into(),
+        started,
+    );
+    assert_eq!(
+        registry
+            .lookup(
+                RemoteWallpaperSource::Web,
+                "https://cdn.example/photo.jpg",
+                started + Duration::from_secs(1),
+            )
+            .as_deref(),
+        Some("https://photos.example/")
+    );
+    assert!(registry
+        .lookup(
+            RemoteWallpaperSource::Openverse,
+            "https://cdn.example/photo.jpg",
+            started + Duration::from_secs(1),
+        )
+        .is_none());
+    assert!(registry
+        .lookup(
+            RemoteWallpaperSource::Web,
+            "https://cdn.example/photo.jpg",
+            started + SOURCE_ORIGIN_TTL + Duration::from_secs(1),
+        )
+        .is_none());
+
+    for index in 0..=SOURCE_ORIGIN_LIMIT {
+        registry.register(
+            RemoteWallpaperSource::Pexels,
+            format!("https://cdn.example/{index}.jpg"),
+            "https://www.pexels.com/".into(),
+            started + Duration::from_millis(index as u64),
+        );
+    }
+    assert_eq!(registry.entries.len(), SOURCE_ORIGIN_LIMIT);
+    assert!(!registry.entries.contains_key(&(
+        RemoteWallpaperSource::Pexels,
+        "https://cdn.example/0.jpg".into(),
+    )));
+}
+
+#[test]
+fn source_registry_rejects_renderer_style_header_inputs() {
+    assert_eq!(
+        canonical_media_url("https://cdn.example/photo.jpg#fragment").as_deref(),
+        Some("https://cdn.example/photo.jpg")
+    );
+    assert!(canonical_media_url("http://cdn.example/photo.jpg").is_none());
+    assert!(canonical_media_url("https://user:secret@cdn.example/photo.jpg").is_none());
+    assert!(verified_source_origin("https://photos.example:444/item").is_none());
+}
+
+#[test]
+fn media_cancel_before_begin_is_sticky_bounded_and_expires() {
+    let now = Instant::now();
+    let mut registry = MediaRequestRegistry::default();
+    registry.record_pre_cancel("late-media", now);
+    assert!(registry.take_pre_cancel("late-media", now));
+    assert!(!registry.take_pre_cancel("late-media", now));
+
+    for index in 0..=PRE_CANCEL_CAPACITY {
+        registry.record_pre_cancel(&format!("request-{index}"), now);
+    }
+    assert_eq!(registry.pre_cancelled.len(), PRE_CANCEL_CAPACITY);
+    assert!(!registry.take_pre_cancel("request-0", now));
+    assert!(!registry.take_pre_cancel("request-1", now + PRE_CANCEL_TTL + Duration::from_secs(1),));
+}
+
+#[test]
+fn remote_thumbnail_is_bounded_jpeg_data_without_persisting() {
+    let image = image::DynamicImage::new_rgb8(1_600, 900);
+    let mut png = Cursor::new(Vec::new());
+    image
+        .write_to(&mut png, image::ImageFormat::Png)
+        .expect("encode test image");
+
+    let thumbnail = thumbnail_from_bytes(png.into_inner()).expect("build thumbnail");
+    assert_eq!((thumbnail.width, thumbnail.height), (1_600, 900));
+    assert!(thumbnail.data_url.starts_with("data:image/jpeg;base64,"));
+    assert!(thumbnail.data_url.len() <= 768 * 1024);
+}
+
+#[test]
+fn probe_http_failures_have_stable_categories() {
+    assert_eq!(
+        status_failure(StatusCode::FORBIDDEN),
+        RemoteImageProbeFailure::Forbidden
+    );
+    assert_eq!(
+        status_failure(StatusCode::NOT_FOUND),
+        RemoteImageProbeFailure::NotFound
+    );
+    assert_eq!(
+        status_failure(StatusCode::TOO_MANY_REQUESTS),
+        RemoteImageProbeFailure::RateLimited
+    );
+    assert_eq!(
+        status_failure(StatusCode::BAD_GATEWAY),
+        RemoteImageProbeFailure::HttpServer
+    );
+}
+
+#[test]
+fn stored_remote_images_stay_in_their_source_directory() {
+    let _environment = APP_HOME_ENV_LOCK
+        .lock()
+        .unwrap_or_else(|error| error.into_inner());
+    let home = std::env::temp_dir().join(format!(
+        "grok-app-remote-image-{}-{}",
+        std::process::id(),
+        uuid::Uuid::new_v4().simple()
+    ));
+    // SAFETY: test-only mutation serialized by APP_HOME_ENV_LOCK.
+    unsafe { std::env::set_var("GROK_APP_HOME", &home) };
+    let mut png = vec![0u8; 128];
+    png[..8].copy_from_slice(b"\x89PNG\r\n\x1a\n");
+    let saved = save_image(
+        "https://images.example.test/wallpaper.png",
+        RemoteWallpaperSource::Web,
+        "image/png",
+        png,
+    )
+    .expect("save remote image");
+    assert!(Path::new(&saved.path).is_file());
+    assert!(Path::new(&saved.path).starts_with(home.join("wallpapers").join("web")));
+
+    unsafe { std::env::remove_var("GROK_APP_HOME") };
+    let _ = fs::remove_dir_all(home);
+}

--- a/src/components/WallpaperSourceGallery.test.tsx
+++ b/src/components/WallpaperSourceGallery.test.tsx
@@ -94,29 +94,32 @@ afterEach(() => {
 });
 
 describe("WallpaperSourceGallery media details", () => {
-  it("uses the local media endpoint for saved provider images", () => {
-    const path = "C:/wallpapers/pexels/saved-photo.jpg";
-    const providerItem: WallpaperGalleryItem = {
-      ...item,
-      id: "saved-pexels-photo",
-      source: "pexels",
-      localPath: path,
-      fullUrl: `file://${path}`,
-      thumbUrl: `file://${path}`,
-    };
+  it.each(["library", "pexels"] as const)(
+    "uses the local media endpoint for saved provider images in %s",
+    (tab) => {
+      const path = "C:/wallpapers/pexels/saved-photo.jpg";
+      const providerItem: WallpaperGalleryItem = {
+        ...item,
+        id: "saved-pexels-photo",
+        source: "pexels",
+        localPath: path,
+        fullUrl: `file://${path}`,
+        thumbUrl: `file://${path}`,
+      };
 
-    render(
-      <WallpaperSourceGallery
-        {...galleryProps([providerItem])}
-        tab="library"
-      />,
-    );
+      render(
+        <WallpaperSourceGallery
+          {...galleryProps([providerItem])}
+          tab={tab}
+        />,
+      );
 
-    expect(screen.queryByTestId("remote-provider-thumbnail")).toBeNull();
-    expect(screen.getByRole("img").getAttribute("src")).toBe(
-      `http://127.0.0.1/media/${encodeURIComponent(path)}`,
-    );
-  });
+      expect(screen.queryByTestId("remote-provider-thumbnail")).toBeNull();
+      expect(screen.getByRole("img").getAttribute("src")).toBe(
+        `http://127.0.0.1/media/${encodeURIComponent(path)}`,
+      );
+    },
+  );
 
   it("keeps the existing media fallback when endpoint boot fails", async () => {
     ensureMediaEndpoint.mockRejectedValueOnce(new Error("endpoint unavailable"));

--- a/src/components/WallpaperSourceGallery.tsx
+++ b/src/components/WallpaperSourceGallery.tsx
@@ -209,9 +209,11 @@ export function WallpaperSourceGallery({
             const loadingThis = previewingId === item.id;
             const src = itemThumbSrc(item);
             const canCreateFromImage = isWallpaperImageItem(item);
+            const localMedia =
+              !!item.localPath || item.fullUrl.startsWith("file://");
             const localVideo =
               item.kind === "video" &&
-              (!!item.localPath || item.fullUrl.startsWith("file://"));
+              localMedia;
             const cite =
               item.source === "x" || (!item.source && tab === "x")
                 ? resolveWallpaperXCitation(item)
@@ -282,6 +284,7 @@ export function WallpaperSourceGallery({
                             onUnavailable={dropItem}
                           />
                         ) : !isLibraryTab &&
+                          !localMedia &&
                           (item.source === "openverse" ||
                             item.source === "pexels") ? (
                           <WallpaperProviderThumbnail item={item} t={t} />


### PR DESCRIPTION
## Summary

- 修复 v0.2.34 基线中的 Rust 格式与 Clippy 门禁问题，并对较大的待持久化枚举载荷装箱，避免 `large_enum_variant`。
- Openverse / Pexels 搜索结果分离原图与服务商专用缩略图；已保存的公共图库图片改走本地 loopback 媒体端点，不再重复远程拉缩略图。
- 远程图片只协商 Host 可解码的 JPEG / PNG / WebP / GIF；仅 Openverse 固定缩略图端点允许最低优先级 `*/*`，且重定向后立即恢复严格协商。
- 升级 Provider 缓存契约并补充解析、请求头、重定向边界及 UI 回归测试；同步更新壁纸搜索开发文档。

## Root cause

公共图库卡片此前把验证后的原图 URL 同时当作缩略图使用，既增加传输量，也会绕过服务商提供的缩略图。Host 还声明接受 AVIF，但当前解码链并不支持它；Openverse 的固定缩略图端点在冷请求下又会对完全严格的 Accept 返回 406。保存后的 Provider 项在来源标签页中仍被送入远程缩略图组件，因此本地已有文件也可能再次联网。

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Refactor / chore

## Validation

- [x] `pnpm deps:check`
- [x] `pnpm audit:prod`
- [x] `pnpm typecheck`
- [x] `pnpm test`（637 files / 7412 tests）
- [x] `pnpm lint`
- [x] `python scripts/check-code-quality-gates.py --mode final`
- [x] `python scripts/publish-website-downloads.py --self-test`
- [x] `pnpm build:ui`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] Windows 测试 harness 嵌入 `windows-test-manifest.xml` 后直接运行（1856 passed / 0 failed / 1 ignored）
- [x] Openverse 现网未访问页复验：20/20 个缩略图成功下载并解码
- [x] User-facing strings go through `src/i18n/messages.ts`（本 PR 未新增文案键）
- [x] No `window.confirm` / `prompt` / `alert` for product dialogs
- [x] Docs / `docs/llm-wiki` updated if behavior changed
- [x] No secrets (`secrets.json`, tokens, `auth.json`) included

未找到可准确关联的现有 Issue，因此不添加 `Fixes #...`。