### PR TITLE
fix(whatsNew): parse the full CHANGELOG section, not up to the first Z

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,11 +23,13 @@ See `docs/llm-wiki/release.md`.
 - Math formulas render with one matching KaTeX version again. The bundled CSS had drifted ahead of the JS.
 - Wallpaper no longer flashes black while streaming or following the chat tail.
 - Imagine portrait thumbnails stay contained when the wallpaper window narrows.
+- What's New now lists every entry; some were cut off before.
 
 **中文 · 修复**
 - 数学公式恢复 CSS 与 JS 同版本渲染，不再出现样式超前于脚本。
 - 流式输出和自动跟随聊天底部时，静态及动态壁纸不再闪黑。
 - 壁纸窗口缩小时，Imagine 纵向缩略图不再挤压错位。
+- 「新功能」弹窗不再漏掉部分条目。
 
 ### Changed
 - Ctrl+Tab fills the selected chat row. Busy chats show the same spinner as the sidebar (#1146).

--- a/src/lib/whatsNew.test.ts
+++ b/src/lib/whatsNew.test.ts
@@ -107,6 +107,33 @@ describe("parseChangelogNotes", () => {
   it("returns null when the version section is missing", () => {
     expect(parseChangelogNotes(FIXTURE, "9.9.9", "en")).toBeNull();
   });
+
+  it("reads the whole section even when a capital Z appears mid-body", () => {
+    const md = [
+      "## [1.2.4] - 2026-09-01",
+      "",
+      "### Fixed",
+      "- Zoom hotkeys work again.",
+      "- ZDR wallpaper blocks show a hint.",
+      "- Windows tray quits cleanly.",
+      "",
+      "**中文 · 修复**",
+      "- 缩放快捷键恢复。",
+      "",
+      "## [1.2.3]",
+      "",
+      "### Fixed",
+      "- Older entry.",
+    ].join("\n");
+    const notes = parseChangelogNotes(md, "1.2.4", "en");
+    expect(notes?.sections[0]?.items).toEqual([
+      "Zoom hotkeys work again.",
+      "ZDR wallpaper blocks show a hint.",
+      "Windows tray quits cleanly.",
+    ]);
+    const zh = parseChangelogNotes(md, "1.2.4", "zh");
+    expect(zh?.sections[0]?.items).toEqual(["缩放快捷键恢复。"]);
+  });
 });
 
 describe("changelogPopupItem", () => {

--- a/src/lib/whatsNew.ts
+++ b/src/lib/whatsNew.ts
@@ -120,8 +120,12 @@ function extractVersionBody(
   markdown: string,
   version: string,
 ): { rest: string; body: string } | null {
+  // `(?![\s\S])` is the JS way to say "absolute end of input". `\Z` was
+  // intended for that but in JS it is a literal-Z identity escape, so any
+  // section containing a capital Z (e.g. "ZDR", "Zoom") truncated at it and
+  // silently dropped every entry after it from the What's New popup.
   const re = new RegExp(
-    `^## \\[${escapeRegExp(version)}\\]([^\\n]*)\\n([\\s\\S]*?)(?=^## \\[|\\Z)`,
+    `^## \\[${escapeRegExp(version)}\\]([^\\n]*)\\n([\\s\\S]*?)(?=^## \\[|(?![\\s\\S]))`,
     "m",
   );
   const m = re.exec(markdown);


### PR DESCRIPTION
## Summary
`extractVersionBody` ended its section lookahead with `\\Z`, intended as "absolute end of input" (PCRE/Python semantics). **In JS regex, `\\Z` is a literal-Z identity escape.** So any version section containing a capital Z parsed only up to that character, and the What's New popup silently dropped every entry after it.

Real impact on current CHANGELOG:
- **Unreleased** truncates at the "ZDR…" line in Fixed — everything after it (rest of Fixed + entire Added / Changed sections, English and Chinese) never reached the popup or the length guard
- Shipped sections 0.2.27 ("Zhipu GLM"), 0.2.24 ("*Zug*"), 0.2.21 ("ZWSP"), 0.2.13 ("A–Z"), 0.2.2 ("Zen mode") were truncated the same way while they were current

This replaces `\\Z` with `(?![\\s\\S])` (the JS way to assert absolute end-of-input) and adds a regression test with Z-bearing entries mid-section. Verified the full Unreleased now parses clean against the popup's ≤90-char first-sentence rule.

Found while verifying the CHANGELOG length guard during the #1131–#1137 batch — a 96-char line passed the test only because it sat after a "ZDR" line the parser never reached.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor / chore

## Checklist
- [x] I ran `pnpm typecheck` and `pnpm test` (whatsNew suite green incl. the new regression test)
- [x] No Rust change — frontend only
- [x] User-facing strings via CHANGELOG only (en + zh, first sentence ≤ 90 chars)
- [x] No `window.confirm` / `prompt` / `alert`
- [x] No secrets included