### PR TITLE
feat(session): fill Ctrl+Tab selected row and show working spinner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,12 +22,14 @@ See `docs/llm-wiki/release.md`.
 - 流式输出和自动跟随聊天底部时，静态及动态壁纸不再闪黑。
 
 ### Changed
+- Ctrl+Tab fills the selected chat row. Busy chats show the same spinner as the sidebar (#1146).
 - About shows the git short hash when the build is not an exact release tag (#1139).
 - The theme editor modal loads on demand instead of joining app startup.
 - Bundled KaTeX math fonts ship as woff2 only, trimming the install size.
 - Settings reads and writes run on the blocking pool, off the async command path.
 
 **中文 · 变更**
+- Ctrl+Tab 预选行有背景高亮。进行中的对话显示与侧栏相同的转圈（#1146）。
 - 构建不是精确的 release tag 时，About 显示 git short hash（#1139）。
 - 主题编辑器改为按需加载，不再拖累应用启动。
 - 打包内的 KaTeX 数学字体只保留 woff2 格式，安装包更小。

--- a/src/components/SessionMruSwitcher.test.tsx
+++ b/src/components/SessionMruSwitcher.test.tsx
@@ -4,14 +4,27 @@
 import { afterEach, describe, expect, it } from "vitest";
 import "@testing-library/jest-dom/vitest";
 import "@/test/jsdomStubs";
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, render, screen, within } from "@testing-library/react";
 import { SessionMruSwitcher } from "./SessionMruSwitcher";
+import { sessionLiveMapStore } from "@/lib/sessionLiveMapStore";
 import { setSessionMruPanelState } from "@/lib/sessionMruPanelStore";
+import { projectHostIntoLiveMap } from "@/lib/sessionLiveStore";
 
 afterEach(() => {
   cleanup();
   setSessionMruPanelState(null);
+  sessionLiveMapStore.resetForTests();
 });
+
+function showPanel() {
+  setSessionMruPanelState({
+    index: 1,
+    rows: [
+      { id: "b", title: "Beta", projectName: "App" },
+      { id: "a", title: "Alpha", projectName: "" },
+    ],
+  });
+}
 
 describe("SessionMruSwitcher", () => {
   it("renders nothing when idle", () => {
@@ -20,26 +33,39 @@ describe("SessionMruSwitcher", () => {
   });
 
   it("lists chats and marks the highlighted row", () => {
-    setSessionMruPanelState({
-      index: 1,
-      rows: [
-        { id: "b", title: "Beta", projectName: "App" },
-        { id: "a", title: "Alpha", projectName: "" },
-      ],
-    });
+    showPanel();
     render(<SessionMruSwitcher locale="en" />);
     expect(
       screen.getByRole("listbox", { name: "Recently used chats" }),
     ).toBeInTheDocument();
     expect(screen.getByText("Release Ctrl to open")).toBeInTheDocument();
-    expect(screen.getByRole("option", { name: /Beta/ })).toHaveAttribute(
-      "aria-selected",
-      "false",
-    );
-    expect(screen.getByRole("option", { name: /Alpha/ })).toHaveAttribute(
-      "aria-selected",
-      "true",
-    );
+    const beta = screen.getByRole("option", { name: /Beta/ });
+    const alpha = screen.getByRole("option", { name: /Alpha/ });
+    expect(beta).toHaveAttribute("aria-selected", "false");
+    expect(beta).not.toHaveClass("is-active");
+    expect(alpha).toHaveAttribute("aria-selected", "true");
+    expect(alpha).toHaveClass("is-active");
     expect(screen.getByText("App")).toBeInTheDocument();
+  });
+
+  it("shows the sidebar working spinner for a busy chat", () => {
+    sessionLiveMapStore.setMap((prev) =>
+      projectHostIntoLiveMap(prev, {
+        sessionId: "a",
+        state: "streaming",
+      }),
+    );
+    showPanel();
+    render(<SessionMruSwitcher locale="en" />);
+    expect(
+      within(screen.getByRole("option", { name: /Alpha/ })).getByLabelText(
+        "Working…",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByRole("option", { name: /Beta/ })).queryByLabelText(
+        "Working…",
+      ),
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/components/SessionMruSwitcher.tsx
+++ b/src/components/SessionMruSwitcher.tsx
@@ -3,6 +3,8 @@
  */
 import { useEffect, useRef, useSyncExternalStore } from "react";
 import { createPortal } from "react-dom";
+import { Spinner } from "@/components/ui/spinner";
+import { useLiveMapBusyIds } from "@/hooks/useSessionLiveMap";
 import { createT, type Locale } from "@/i18n";
 import {
   getSessionMruPanelState,
@@ -16,6 +18,7 @@ export function SessionMruSwitcher({ locale }: { locale: Locale }) {
     getSessionMruPanelState,
     getSessionMruPanelState,
   );
+  const busyIds = useLiveMapBusyIds();
   const activeRef = useRef<HTMLButtonElement | null>(null);
   const tr = createT(locale);
 
@@ -54,6 +57,7 @@ export function SessionMruSwitcher({ locale }: { locale: Locale }) {
         <div className="search-panel__results">
           {state.rows.map((row, index) => {
             const active = index === state.index;
+            const working = busyIds.has(row.id);
             const title = row.title || tr("tray.untitled");
             return (
               <button
@@ -78,6 +82,14 @@ export function SessionMruSwitcher({ locale }: { locale: Locale }) {
                     </span>
                   ) : null}
                 </span>
+                {working ? (
+                  <span
+                    className="tree-l3__status"
+                    aria-label={tr("sidebar.sessionWorking")}
+                  >
+                    <Spinner size={14} className="tree-l3__spinner" />
+                  </span>
+                ) : null}
               </button>
             );
           })}

--- a/src/styles/sidebar.part2.css
+++ b/src/styles/sidebar.part2.css
@@ -933,3 +933,10 @@ html[data-sidebar-density="compact"] .tree-date-group__head {
   cursor: pointer;
   font: inherit;
 }
+.session-mru-panel .search-panel__row:hover:not(.is-active) {
+  background: var(--menu-hover);
+}
+.session-mru-panel .search-panel__row.is-active {
+  background: var(--accent-muted);
+  color: var(--text-primary);
+}


### PR DESCRIPTION
## Summary
- Fill the Ctrl+Tab preselected chat row so the transparent-row rule no longer hides the highlight.
- Working chats show the same sidebar spinner, gated on liveMap busy ids.

Closes #1146
Follows #1125 / #1127.

## Test plan
- [x] `pnpm exec vitest run src/components/SessionMruSwitcher.test.tsx`
- [ ] Hold Ctrl+Tab: selected row has a filled background
- [ ] A streaming chat shows the sidebar working spinner in the panel
- [ ] Release Ctrl opens the filled row; Esc still cancels

## Checklist
- [x] Local panel unit tests
- [ ] Full CI on PR