### PR TITLE
perf(layout): snap Win sidebar toggle off the host render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,7 @@ See `docs/llm-wiki/release.md`.
 - 壁纸来源可在安全登录校验后浏览 Grok Saved 相册（#1103）。
 
 ### Changed
+- Left sidebar toggle on Windows snaps instead of sliding the chat column. Opening it skips growing a window that already fits.
 - Finished Worked-for rails fold after the turn. Failed tools stay as one-line excerpts.
 - Sent quotes show the excerpt and comment in the bubble, not a notes chip.
 - Account quota sits in the user menu again, with remaining % beside the name.
@@ -135,6 +136,7 @@ See `docs/llm-wiki/release.md`.
 - Startup skips TipTap and markdown preloads; Office and Settings load on demand (#1055, #1063).
 
 **中文 · 变更**
+- Windows 上开关左侧栏不再把聊天列跟着宽度滑动。窗口已经够宽时展开也不再拉大窗口。
 - 结束后的「Worked for」工具栏会收起。失败步骤保留为一行摘要。
 - 发送后的引用在气泡里直接显示摘录和评论，不再收成「N 条注释」。
 - 额度卡片回到用户菜单顶部，名字旁显示剩余百分比。

--- a/docs/plans/2026-09-10-sidebar-toggle-ctrl-b.md
+++ b/docs/plans/2026-09-10-sidebar-toggle-ctrl-b.md
@@ -1,0 +1,164 @@
+# Ctrl+B 左侧栏展开/收起响应优化
+
+**日期**：2026-09-10  
+**基线**：`main` @ `2b43acbb`（`feat(session): show a recent-chat list while holding Ctrl+Tab (#1127)`）  
+**来源**：Ctrl+B 侧栏「响应慢」诊断（快捷键本身无 debounce；慢在 host 重渲染 + in-flow `width` 插值）  
+**执行位置**：worktree `D:/code/grok-app-sidebar-toggle-ctrl-b` · 分支 `perf/sidebar-toggle-ctrl-b`  
+**状态**：WP-A/B/C 已实施、未开 PR、不 merge `main`（`zzzzz` 前禁止）
+
+`.husky/post-checkout` 不存在（无 symlink 步骤）。`android/capacitor.settings.gradle` 不存在，`skip-worktree` 跳过。
+
+---
+
+## 1. 问题
+
+桌面按 Ctrl+B（或顶栏 PaneToggle）展开/收起左栏，体感慢。拖分隔条跟手，说明 **不是 WebView 画不出侧栏**，是 click/shortcut 这条路径重。
+
+对号：
+
+| 体感 | 层 |
+|------|----|
+| 按下过一会儿才动 | L1 输入延迟：`setLayout` 在 `AppWorkbench` 纤维上，约 1.3 万行 / 289 hook 先跑完才提交宽度 |
+| 立刻动但滑 ~1/3 秒 | L2 设计时长：`--motion-pane: 320ms` |
+| 滑动掉帧 | L3 布局动画：in-flow 同时 tween `width/min-width/max-width/flex-basis`，chat 列每帧 reflow（Win WebView2 尤差） |
+| 展开比收起卡 | L4 展开多 `ensureWindowFitsLayout`（连续 Tauri `isFullscreen` / `isMaximized` / `innerSize` / `scaleFactor`，不够再 `setSize`） |
+
+快捷键路径无排队：`keydown` capture → `toggleSidebar` → `openSidebarPane` / `closeSidebarPane`。不要去改 `matchGlobalShortcut`。
+
+---
+
+## 2. 已落地（不要重做）
+
+这些已经在 `main` 或平行分支里，本刀只借用，不另起炉灶：
+
+- **窄窗 overlay**：`resolveWorkbenchPaneOverlay` — 挤不下时 `transform`，不插值 flex。
+- **拖拽不走 React**：`applyLiveSplitWidth` + `.is-resizing { transition: none }`。Ctrl+B 应对齐「先改 used size、后 reconcile」。
+- **底栏终端已 snap**：`perf/bottom-terminal-snap` 思路；左栏不要再给 `.bt` 加 pane motion。
+- **未合并参考**（勿直接 cherry-pick 整个 AppWorkbench 大 diff）：`fix/narrow-ctrl-b-window-size` @ `35841009` 的 `windowFitWouldGrow` / `shouldFitWindowOnSidebarOpen`。窄窗 overlay 后仍应用 JS `innerWidth` 判断跳过 Tauri fit。
+
+---
+
+## 3. 约束（不可破）
+
+- AGENTS.md §7：App shell + `AppWorkbench` 合计行数只降不升。禁止往 host 加 `useState` / 大功能块。新逻辑进 `useWorkbenchLayout` / `src/lib/*`。
+- 新文件 <1000 行。i18n 走 `createT`；无 `window.confirm` / `prompt` / `alert`。
+- **WKWebView 合同**（`src/lib/paneSplitMotion.test.ts` 锁死，改行为必须改测试并写明平台理由）：
+  - `.sidebar--hidden` 禁止 `width: 0 !important`（硬切掉 transition）。
+  - 禁止用 `.workbench--sidebar-motion .sidebar` 开关 `transition`（blur 层重建闪缝）。
+  - in-flow Mac 侧栏禁止 `backdrop-filter`；禁止 motion 期 `contain`。
+- 拖拽跟手、窄窗 overlay、右栏 overlay、phone drawer 行为不变。
+- 一次一个 worktree。禁止 merge `main`，除非用户明确说。
+
+---
+
+## 4. 否决
+
+| 方案 | 否决原因 |
+|------|----------|
+| 给 `WorkbenchSidebar` / `WorkbenchMain` 套 `memo` 当主修复 | host 仍跑 289 个 hook；host JSX 大量 inline 回调会打穿 memo |
+| 全局把 `--motion-pane` 改 0 / 砍到 80ms | 掩盖 L1；Mac 硬切回潮；底栏/右栏共用 token |
+| 始终 overlay、永远不把栏收回 flex | 宽窗 chat 宽度不还；与 overlay「窄窗 fallback」语义冲突 |
+| motion 期 `contain: strict` / 给 in-flow 加 blur | 测试明确禁止；Mac 缝闪 |
+| 把 `layout` 再抬进 `App.tsx` | 违反 growth freeze；重渲染边界只是上移一层 |
+| 重写 AppWorkbench 为 LayoutProvider 当本 PR 主 diff | 正确长期方向（§7 WP-E），但和动画/fit 缠在一起无法回滚 |
+
+---
+
+## 5. 锁定方案
+
+目标：**第一帧侧栏 used size 已变，且不依赖 `AppWorkbench` commit**。动画不再用 320ms flex 插值拖着 chat 列（至少 Windows）。
+
+### WP-A — 同步 paint 接缝（和 B/C 同一提交，不单独发布）
+
+在 `openSidebarPane` / `closeSidebarPane` 里、`setLayout` 之前：
+
+1. `queryWorkbenchSplitPane("sidebar")`（已有）写成下一帧的 `paneSplitSizeStyle(0 | openW, "x")`。
+2. `classList.toggle("sidebar--hidden" | "sidebar--collapsed", nextCollapsed)`，与 React 最终 class 一致，避免 commit 时 class 互殴 restart transition。
+3. `saveLayout` 立刻写（不要等 transition 的 updater）；`setLayout` 用 `startTransition`，让 host reconcile 让出首帧。
+4. **不要**在 handler 里 `beginPaneSplitMotion` 再让 `usePaneSplitMotion` 因 key 变化 `end` 掉同一个 token（会提前 `flushDeferred`，virtualizer/xterm 在动画中爆发）。Motion token 仍由 hook 在 commit 时 begin。接受最多 1 帧 RO。
+
+单测（jsdom）：调用 close/open 后，在 `act` flush 之前断言 sidebar 节点 width/min/max/flexBasis 已是目标值。
+
+### WP-B — 展开跳过无用 Tauri fit
+
+纯函数（可放 `src/lib/windowFit.ts`，从 `35841009` 收回思路，不搬 AppWorkbench 旧 diff）：
+
+- `windowFitTargetWidth(layout)` / `windowFitWouldGrow(viewportWidth, layout)`
+- `openSidebarPane`：已 overlay → 不 fit（现状）；`!windowFitWouldGrow(window.innerWidth, projected)` → **不** `await ensureWindowFitsLayout`（现状：宽窗每次仍打 4 次 IPC，即使 `growWindowTo` 最终 return null）
+- 真要长宽时仍走现有 `fitWindowThenClampAside`；aside 已折叠则 then 里不要第二次 `setLayout`
+
+测试：`windowFit.test.ts` + `useWorkbenchLayout` 源码合同（`paneOverlay.test.ts` 已在读该文件）断言 `windowFitWouldGrow` / overlay 早退。
+
+### WP-C — Windows：flex 尺寸一帧到位，内容淡出（L2/L3）
+
+Mac 继续 in-flow width 插值（WKWebView 合同）。Windows / 无 vibrancy 平台：
+
+```css
+.platform-win .sidebar:not(.is-resizing),
+.platform-linux .sidebar:not(.is-resizing) {
+  /* 保留 border-color / opacity / filter；不要 width/min/max/flex-basis */
+}
+```
+
+- `.sidebar__clip` 已有 `opacity` transition，收起仍淡出，避免「内容被压扁」。
+- used size 一帧到位 → chat 只 reflow **一次**，不再跟 320ms。
+- `.workbench--sidebar-motion .main__top { padding-left }` 可保留，只动 40px 顶栏，不带动正文。
+- 覆盖测试：`paneSplitMotion.test.ts` 把「`.sidebar` 必带 width transition」改成 **默认（Mac）必带**；新增 Win 选择器 **不得** width tween。拖拽 `.is-resizing` 仍 `transition: none`。
+
+不在本刀把 Mac 改成 snap。若后续 Mac 同样掉帧，再开独立 PR，用 overlay-during-motion（先 `transform`，`transitionend` 再 commit in-flow），不要用 `!important:0`。
+
+### WP-D — 不在本 worktree（结构隔离，后续）
+
+host 不再订阅 `layout.sidebarCollapsed`：抽出 `WorkbenchSplit`（sidebar+main+aside chrome）读 layout，host 只留 `layoutRef` + 动词。这是 L1 的彻底解，行数下降，符合拆解 handoff「layout/panes 先抽」。本分支不拆，避免和 CSS 合同、fit 逻辑缠成无法 revert 的大 PR。
+
+---
+
+## 6. 文件
+
+| 文件 | 动作 |
+|------|------|
+| `src/hooks/useWorkbenchLayout.ts` | WP-A 同步 paint + `startTransition`；WP-B 早退 fit |
+| `src/lib/windowFit.ts` | `windowFitTargetWidth` / `windowFitWouldGrow` |
+| `src/lib/windowFit.test.ts` | grow / 不 grow |
+| `src/lib/paneDragLive.ts` | 只复用 `queryWorkbenchSplitPane`，不改拖拽 |
+| `src/styles/sidebar.part1.css` | WP-C Win/Linux 去掉 in-flow width tween |
+| `src/lib/paneSplitMotion.test.ts` | 平台拆分合同；禁止回退 `width:0 !important` |
+| `src/hooks/usePaneSplitMotion.ts` | 原则上不改 token 生命周期；若 A 误 begin 再补 no-op |
+| `src/hooks/useWorkbenchLayout` 合同（overlay/split 测试里的源码断言） | 断言 fit 早退、paint 在 `setLayout` 前 |
+| `CHANGELOG.md` | 一句：Win 侧栏开关不再插值宽度；展开不再对已足够宽的窗口打 fit |
+| `src/app/AppWorkbench.tsx` | **不改**（toggle 已走 hook 动词） |
+
+不新增 `useState`。不改 `src/lib/shortcuts.ts`。
+
+---
+
+## 7. 实施顺序
+
+1. WP-B 函数 + 测试（无 UI，先绿）。
+2. WP-A paint + `startTransition` + jsdom 断言「act 前 width 已变」。
+3. WP-C CSS + 合同测试。
+4. `pnpm vitest run src/lib/windowFit.test.ts src/lib/paneSplitMotion.test.ts src/lib/paneOverlay.test.ts src/hooks/usePaneSplitMotion.test.tsx`
+5. 桌面手测（本机 Win）：
+   - 宽窗、会话树很长、当前会话消息很多：Ctrl+B 收/开，对比拖拽。
+   - 窄窗 overlay：仍滑入，不 `setSize`。
+   - 右栏开着：左栏开关不把 aside 挤没、不无故长窗。
+   - 分隔条拖拽仍跟手；底栏 `` Ctrl+` `` 仍 snap。
+
+---
+
+## 8. 成功标准
+
+- 宽窗 Ctrl+B：侧栏 used width 在 **当前事件栈内** 已是 0 或 open px（不先等 AppWorkbench commit）。
+- 宽窗且 `innerWidth >= required+16`：展开 **0 次** `getCurrentWindow` / `setSize`。
+- Win：动画期间 chat 列不跟侧栏宽度逐帧插值（Performance：Layout 次数接近 1，而不是 ~20）。
+- Mac：仍 width 插值；无硬切、无缝闪。
+- `AppWorkbench.tsx` 行数不增。
+
+---
+
+## 9. 风险
+
+- **React commit 重启 CSS transition**：乐观 style 必须与 `sidebarPaint` + hidden class 字节级一致；比较 `paneSplitSizeStyle`。
+- **`startTransition` 让 class 晚到**：所以 hidden class 也在 handler 写，不能只写 width。
+- **Strict Mode 双调用 updater**：persist 已从 paint 路径提出，避免双写动画；`saveLayout` 幂等。
+- **Mac 回归**：WP-C 选择器用 `.platform-win` / `.platform-linux`，不要写进裸 `.sidebar`。

--- a/src/hooks/useWorkbenchLayout.sidebarPaint.test.tsx
+++ b/src/hooks/useWorkbenchLayout.sidebarPaint.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import "@/test/jsdomStubs";
+import {
+  DEFAULT_LAYOUT,
+  LAYOUT_STORAGE_KEY,
+} from "@/lib/layout";
+import { applyLiveSplitWidth } from "@/lib/paneDragLive";
+import { useWorkbenchLayout } from "./useWorkbenchLayout";
+
+function usedSize(el: HTMLElement): {
+  width: string;
+  minWidth: string;
+  maxWidth: string;
+  flexBasis: string;
+} {
+  const s = el.style;
+  return {
+    width: s.width,
+    minWidth: s.minWidth,
+    maxWidth: s.maxWidth,
+    flexBasis: s.flexBasis,
+  };
+}
+
+function px(n: number): string {
+  return `${n}px`;
+}
+
+describe("useWorkbenchLayout sidebar sync paint", () => {
+  let sidebar: HTMLElement;
+
+  beforeEach(() => {
+    localStorage.removeItem(LAYOUT_STORAGE_KEY);
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: 1400,
+    });
+    const workbench = document.createElement("div");
+    workbench.className = "workbench";
+    sidebar = document.createElement("aside");
+    sidebar.className = "sidebar";
+    workbench.appendChild(sidebar);
+    document.body.appendChild(workbench);
+    applyLiveSplitWidth(sidebar, DEFAULT_LAYOUT.sidebarWidth);
+  });
+
+  afterEach(() => {
+    cleanup();
+    document.body.replaceChildren();
+    localStorage.removeItem(LAYOUT_STORAGE_KEY);
+  });
+
+  it("writes destination used size before React flushes the host commit", () => {
+    const { result } = renderHook(() => useWorkbenchLayout());
+    const openPx = px(DEFAULT_LAYOUT.sidebarWidth);
+
+    // Do not wrap in act: the paint must land on this turn, before React
+    // flushes startTransition / host reconcile.
+    result.current.closeSidebarPane();
+    expect(usedSize(sidebar)).toEqual({
+      width: px(0),
+      minWidth: px(0),
+      maxWidth: px(0),
+      flexBasis: px(0),
+    });
+    expect(sidebar.classList.contains("sidebar--hidden")).toBe(true);
+    expect(sidebar.classList.contains("sidebar--collapsed")).toBe(true);
+
+    result.current.openSidebarPane();
+    expect(usedSize(sidebar)).toEqual({
+      width: openPx,
+      minWidth: openPx,
+      maxWidth: openPx,
+      flexBasis: openPx,
+    });
+    expect(sidebar.classList.contains("sidebar--hidden")).toBe(false);
+    expect(sidebar.classList.contains("sidebar--collapsed")).toBe(false);
+
+    act(() => {});
+  });
+});

--- a/src/hooks/useWorkbenchLayout.ts
+++ b/src/hooks/useWorkbenchLayout.ts
@@ -2,7 +2,14 @@
  * Workbench pane layout: prefs, zen, phone chrome, overlay fit, open/close,
  * window grow, and splitter drag. Domain owns persistence; callers get verbs.
  */
-import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import {
+  startTransition,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 import {
   ASIDE_WIDTH_MIN,
   DEFAULT_LAYOUT,
@@ -39,11 +46,13 @@ import {
 import { resolveWorkbenchPaneOverlay } from "@/lib/paneOverlay";
 import {
   applyLiveSplitWidth,
+  paintSidebarRail,
   queryWorkbenchSplitPane,
 } from "@/lib/paneDragLive";
 import {
   ensureWindowFitsLayout,
   isWindowFitSuppressed,
+  windowFitWouldGrow,
 } from "@/lib/windowFit";
 import { isDesktopHost } from "@/lib/api";
 import {
@@ -97,7 +106,35 @@ export function useWorkbenchLayout(opts?: { onAsideClose?: () => void }) {
 
   const [layout, setLayout] = useState(initialLayout);
   const layoutRef = useRef(layout);
-  layoutRef.current = layout;
+  const pendingLayoutRef = useRef<LayoutPrefs | null>(null);
+  if (pendingLayoutRef.current) {
+    layoutRef.current = pendingLayoutRef.current;
+  } else {
+    layoutRef.current = layout;
+  }
+
+  useLayoutEffect(() => {
+    const pending = pendingLayoutRef.current;
+    if (!pending) {
+      layoutRef.current = layout;
+      return;
+    }
+    if (layout.sidebarCollapsed === pending.sidebarCollapsed) {
+      pendingLayoutRef.current = null;
+      layoutRef.current = layout;
+    }
+  }, [layout]);
+
+  // Paint-then-transition: keep layoutRef on the painted prefs until the
+  // startTransition commit lands, so a second Ctrl+B does not see the old flag.
+  const commitSidebarLayout = useCallback((next: LayoutPrefs) => {
+    persist(next);
+    pendingLayoutRef.current = next;
+    layoutRef.current = next;
+    startTransition(() => {
+      setLayout(next);
+    });
+  }, []);
 
   const [zenMode, setZenModeState] = useState(() => loadZenMode(localStorage));
   const zenModeRef = useRef(zenMode);
@@ -345,10 +382,14 @@ export function useWorkbenchLayout(opts?: { onAsideClose?: () => void }) {
 
   const openSidebarPane = useCallback(() => {
     if (phoneLayout) {
-      setLayout((l) => {
-        if (!l.sidebarCollapsed) return l;
-        return persist({ ...l, sidebarCollapsed: false });
+      const cur = layoutRef.current;
+      if (!cur.sidebarCollapsed) return;
+      paintSidebarRail(queryWorkbenchSplitPane("sidebar"), {
+        collapsed: false,
+        openWidth: cur.sidebarWidth || SIDEBAR_DEFAULT_WIDTH,
+        overlay: true,
       });
+      commitSidebarLayout({ ...cur, sidebarCollapsed: false });
       return;
     }
     const cur = layoutRef.current;
@@ -372,13 +413,15 @@ export function useWorkbenchLayout(opts?: { onAsideClose?: () => void }) {
       asideOccupiedWidth:
         cur.asideCollapsed || overlay.asideOverlay ? 0 : cur.asideWidth || 0,
     });
-    setLayout((l) => {
-      if (!l.sidebarCollapsed && (l.sidebarWidth || 0) === openWidth) return l;
-      return persist({
-        ...l,
-        sidebarCollapsed: false,
-        sidebarWidth: openWidth,
-      });
+    paintSidebarRail(queryWorkbenchSplitPane("sidebar"), {
+      collapsed: false,
+      openWidth,
+      overlay: overlay.sidebarOverlay,
+    });
+    commitSidebarLayout({
+      ...cur,
+      sidebarCollapsed: false,
+      sidebarWidth: openWidth,
     });
     const projected = {
       sidebarCollapsed: false as const,
@@ -389,6 +432,7 @@ export function useWorkbenchLayout(opts?: { onAsideClose?: () => void }) {
         : Math.max(cur.asideWidth || 0, DEFAULT_LAYOUT.asideWidth),
     };
     if (overlay.sidebarOverlay || overlay.asideOverlay) return;
+    if (!windowFitWouldGrow(vw, projected)) return;
     const fitGen = ++sidebarFitGenRef.current;
     void fitWindowThenClampAside(projected).then((width) => {
       if (sidebarFitGenRef.current !== fitGen) return;
@@ -399,23 +443,44 @@ export function useWorkbenchLayout(opts?: { onAsideClose?: () => void }) {
         return persist({ ...l, asideWidth: width });
       });
     });
-  }, [fitWindowThenClampAside, phoneLayout, viewportWidth]);
+  }, [commitSidebarLayout, fitWindowThenClampAside, phoneLayout, viewportWidth]);
 
   const closeSidebarPane = useCallback(() => {
     sidebarFitGenRef.current += 1;
-    setLayout((l) => {
-      if (l.sidebarCollapsed) return l;
-      return persist({ ...l, sidebarCollapsed: true });
+    const cur = layoutRef.current;
+    if (cur.sidebarCollapsed) return;
+    const vw =
+      typeof window !== "undefined" ? window.innerWidth : viewportWidth;
+    const overlay = resolveWorkbenchPaneOverlay({
+      viewportWidth: vw,
+      sidebarOpen: true,
+      sidebarWidth: cur.sidebarWidth || SIDEBAR_DEFAULT_WIDTH,
+      asideOpen: !cur.asideCollapsed,
+      asideWidth: Math.max(
+        cur.asideWidth || 0,
+        DEFAULT_LAYOUT.asideWidth,
+        ASIDE_WIDTH_MIN,
+      ),
     });
-  }, []);
+    paintSidebarRail(queryWorkbenchSplitPane("sidebar"), {
+      collapsed: true,
+      openWidth: cur.sidebarWidth || SIDEBAR_DEFAULT_WIDTH,
+      overlay: phoneLayout || overlay.sidebarOverlay,
+    });
+    commitSidebarLayout({ ...cur, sidebarCollapsed: true });
+  }, [commitSidebarLayout, phoneLayout, viewportWidth]);
 
   const closePhoneDrawer = closeSidebarPane;
   const openPhoneDrawer = useCallback(() => {
-    setLayout((l) => {
-      if (!l.sidebarCollapsed) return l;
-      return persist({ ...l, sidebarCollapsed: false });
+    const cur = layoutRef.current;
+    if (!cur.sidebarCollapsed) return;
+    paintSidebarRail(queryWorkbenchSplitPane("sidebar"), {
+      collapsed: false,
+      openWidth: cur.sidebarWidth || SIDEBAR_DEFAULT_WIDTH,
+      overlay: true,
     });
-  }, []);
+    commitSidebarLayout({ ...cur, sidebarCollapsed: false });
+  }, [commitSidebarLayout]);
 
   const beginSidebarResize = useCallback((clientX: number, width: number) => {
     sidebarResizeStartRef.current = { x: clientX, width };

--- a/src/lib/paneDragLive.test.ts
+++ b/src/lib/paneDragLive.test.ts
@@ -2,7 +2,11 @@
  * @vitest-environment jsdom
  */
 import { describe, expect, it } from "vitest";
-import { applyLiveSplitWidth, queryWorkbenchSplitPane } from "./paneDragLive";
+import {
+  applyLiveSplitWidth,
+  paintSidebarRail,
+  queryWorkbenchSplitPane,
+} from "./paneDragLive";
 
 describe("applyLiveSplitWidth", () => {
   it("writes the flex size tuple and rounds", () => {
@@ -16,6 +20,28 @@ describe("applyLiveSplitWidth", () => {
 
   it("is a no-op on a missing node", () => {
     expect(applyLiveSplitWidth(null, 180)).toBe(180);
+  });
+});
+
+describe("paintSidebarRail", () => {
+  it("snaps in-flow used size to 0 when collapsing", () => {
+    const el = document.createElement("aside");
+    applyLiveSplitWidth(el, 268);
+    paintSidebarRail(el, { collapsed: true, openWidth: 268, overlay: false });
+    expect(el.style.width).toBe("0px");
+    expect(el.style.minWidth).toBe("0px");
+    expect(el.style.maxWidth).toBe("0px");
+    expect(el.style.flexBasis).toBe("0px");
+    expect(el.classList.contains("sidebar--hidden")).toBe(true);
+    expect(el.classList.contains("sidebar--collapsed")).toBe(true);
+  });
+
+  it("keeps overlay width at the open size while collapsing", () => {
+    const el = document.createElement("aside");
+    applyLiveSplitWidth(el, 268);
+    paintSidebarRail(el, { collapsed: true, openWidth: 268, overlay: true });
+    expect(el.style.width).toBe("268px");
+    expect(el.classList.contains("sidebar--hidden")).toBe(true);
   });
 });
 

--- a/src/lib/paneDragLive.ts
+++ b/src/lib/paneDragLive.ts
@@ -29,3 +29,21 @@ export function applyLiveSplitWidth(
   el.style.flexBasis = px;
   return n;
 }
+
+/**
+ * Click/shortcut paint: write used size + hidden class before React commit.
+ * Overlay keeps the open width (transform owns the motion).
+ */
+export function paintSidebarRail(
+  el: HTMLElement | null,
+  opts: { collapsed: boolean; openWidth: number; overlay: boolean },
+): void {
+  if (!el) return;
+  el.classList.toggle("sidebar--hidden", opts.collapsed);
+  el.classList.toggle("sidebar--collapsed", opts.collapsed);
+  if (opts.overlay) {
+    if (!opts.collapsed) applyLiveSplitWidth(el, opts.openWidth);
+    return;
+  }
+  applyLiveSplitWidth(el, opts.collapsed ? 0 : opts.openWidth);
+}

--- a/src/lib/paneOverlay.test.ts
+++ b/src/lib/paneOverlay.test.ts
@@ -111,5 +111,8 @@ describe("resolveWorkbenchPaneOverlay", () => {
     expect(openSidebarPane).toContain(
       "if (overlay.sidebarOverlay || overlay.asideOverlay) return;",
     );
+    expect(openSidebarPane).toContain(
+      "if (!windowFitWouldGrow(vw, projected)) return;",
+    );
   });
 });

--- a/src/lib/paneSplitMotion.test.ts
+++ b/src/lib/paneSplitMotion.test.ts
@@ -132,6 +132,22 @@ describe("desktop hidden CSS must not force width 0", () => {
     expect(ruleBody(sidebar, "\n.sidebar {")).toMatch(
       /width var\(--motion-pane\)[^,]*,[^}]*min-width var\(--motion-pane\)[^,]*,[^}]*max-width var\(--motion-pane\)[^,]*,[^}]*flex-basis var\(--motion-pane\)/s,
     );
+    const winInFlow =
+      ".platform-win .sidebar:not(.is-resizing):not(.sidebar--overlay):not(.sidebar--phone-drawer)";
+    const linuxInFlow =
+      ".platform-linux .sidebar:not(.is-resizing):not(.sidebar--overlay):not(.sidebar--phone-drawer)";
+    expect(sidebar).toContain(winInFlow);
+    expect(sidebar).toContain(linuxInFlow);
+    const winBody = ruleBody(sidebar, winInFlow);
+    const linuxBody = ruleBody(sidebar, linuxInFlow);
+    expect(winBody).not.toMatch(/width var\(--motion-pane\)/);
+    expect(winBody).not.toMatch(/min-width var\(--motion-pane\)/);
+    expect(winBody).not.toMatch(/max-width var\(--motion-pane\)/);
+    expect(winBody).not.toMatch(/flex-basis var\(--motion-pane\)/);
+    expect(linuxBody).not.toMatch(/width var\(--motion-pane\)/);
+    expect(linuxBody).not.toMatch(/min-width var\(--motion-pane\)/);
+    expect(linuxBody).not.toMatch(/max-width var\(--motion-pane\)/);
+    expect(linuxBody).not.toMatch(/flex-basis var\(--motion-pane\)/);
     expect(sidebar).not.toMatch(
       /^\s*\.workbench--sidebar-motion[^\n{]*\.sidebar/m,
     );

--- a/src/lib/windowFit.test.ts
+++ b/src/lib/windowFit.test.ts
@@ -1,6 +1,15 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { measureWorkbenchFitNeed } from "./windowFit";
-import { MAIN_CHAT_MIN_WIDTH } from "./layout";
+import {
+  FIT_PAD,
+  measureWorkbenchFitNeed,
+  windowFitTargetWidth,
+  windowFitWouldGrow,
+} from "./windowFit";
+import {
+  DEFAULT_LAYOUT,
+  MAIN_CHAT_MIN_WIDTH,
+  requiredWorkbenchInnerWidth,
+} from "./layout";
 
 function rect(width: number): DOMRect {
   return {
@@ -28,6 +37,48 @@ function el(
     getBoundingClientRect: () => rect(width),
   };
 }
+
+describe("windowFitWouldGrow", () => {
+  const railOpen = {
+    sidebarCollapsed: false,
+    sidebarWidth: DEFAULT_LAYOUT.sidebarWidth,
+    asideCollapsed: true,
+    asideWidth: DEFAULT_LAYOUT.asideWidth,
+  } as const;
+
+  const bothOpen = {
+    ...railOpen,
+    asideCollapsed: false,
+  };
+
+  it("matches the grow request (required inner width plus fit pad)", () => {
+    expect(windowFitTargetWidth(railOpen)).toBe(
+      Math.ceil(requiredWorkbenchInnerWidth(railOpen) + FIT_PAD),
+    );
+    expect(windowFitTargetWidth(bothOpen)).toBe(
+      Math.ceil(requiredWorkbenchInnerWidth(bothOpen) + FIT_PAD),
+    );
+  });
+
+  it("does not grow when the viewport already meets required+pad", () => {
+    const target = windowFitTargetWidth(railOpen);
+    expect(windowFitWouldGrow(target, railOpen)).toBe(false);
+    expect(windowFitWouldGrow(target + 80, railOpen)).toBe(false);
+  });
+
+  it("grows when the viewport is below required+pad", () => {
+    const target = windowFitTargetWidth(railOpen);
+    expect(windowFitWouldGrow(target - 1, railOpen)).toBe(true);
+    const bothTarget = windowFitTargetWidth(bothOpen);
+    expect(windowFitWouldGrow(bothTarget - 1, bothOpen)).toBe(true);
+    expect(windowFitWouldGrow(bothTarget, bothOpen)).toBe(false);
+  });
+
+  it("does not grow on a missing or zero viewport", () => {
+    expect(windowFitWouldGrow(0, railOpen)).toBe(false);
+    expect(windowFitWouldGrow(Number.NaN, railOpen)).toBe(false);
+  });
+});
 
 describe("measureWorkbenchFitNeed", () => {
   afterEach(() => {

--- a/src/lib/windowFit.ts
+++ b/src/lib/windowFit.ts
@@ -13,7 +13,29 @@ import {
 } from "@/lib/layout";
 
 /** Padding so chrome / scrollbars do not immediately re-clamp. */
-const FIT_PAD = 16;
+export const FIT_PAD = 16;
+
+type FitLayout = Pick<
+  LayoutPrefs,
+  "sidebarCollapsed" | "sidebarWidth" | "asideCollapsed" | "asideWidth"
+>;
+
+/** Inner width `ensureWindowFitsLayout` would request. */
+export function windowFitTargetWidth(layout: FitLayout): number {
+  const need = requiredWorkbenchInnerWidth(layout);
+  if (!Number.isFinite(need) || need <= 0) return 0;
+  return Math.ceil(need + FIT_PAD);
+}
+
+/** True when a fit would `setSize` wider than the current viewport. */
+export function windowFitWouldGrow(
+  viewportWidth: number,
+  layout: FitLayout,
+): boolean {
+  if (!(viewportWidth > 0) || !Number.isFinite(viewportWidth)) return false;
+  const target = windowFitTargetWidth(layout);
+  return target > viewportWidth + 0.5;
+}
 
 /** Ignore cascade resize events after we call setSize. */
 const SUPPRESS_MS = 500;

--- a/src/styles/sidebar.part1.css
+++ b/src/styles/sidebar.part1.css
@@ -508,6 +508,20 @@ html.platform-win .window-edge-n {
   user-select: none;
 }
 
+/*
+ * Win/Linux WebView: interpolating used width reflows chat every frame.
+ * Snap the flex box; clip opacity still fades. Mac keeps the base
+ * `.sidebar` size tween (WKWebView hard-cut / seam contract).
+ * Overlay / phone keep their transform rule (excluded here).
+ */
+.platform-win .sidebar:not(.is-resizing):not(.sidebar--overlay):not(.sidebar--phone-drawer),
+.platform-linux .sidebar:not(.is-resizing):not(.sidebar--overlay):not(.sidebar--phone-drawer) {
+  transition:
+    border-color var(--motion-pane) ease,
+    opacity 180ms ease,
+    filter 180ms ease;
+}
+
 /* Right-edge drag handle (mirrors .aside-resizer) */
 .sidebar-resizer {
   position: absolute;


### PR DESCRIPTION
Fixes #1147

Ctrl+B / left pane toggle felt laggy on Windows because the rail waited on the workbench host commit and interpolated flex width (chat reflow every frame). Opening also ran window-fit IPC when the viewport already fit.

- Paint used size and hidden class in the toggle turn, then `startTransition` the layout prefs
- Skip window-fit when overlaying or `innerWidth` already meets required + 16px
- Windows/Linux in-flow rails snap size; Mac keeps the width tween contract