### PR TITLE
refactor(app): type the floating-menu props instead of any bags

### DIFF
--- a/scripts/check-code-quality-gates.py
+++ b/scripts/check-code-quality-gates.py
@@ -47,6 +47,15 @@ APP_LINES_CEILING = 13750
 APP_USESTATE_CEILING = 94
 APP_USEEFFECT_CEILING = 65
 
+# Typing escape-hatch ceilings. The AppWorkbench decomposition traded
+# compile-time safety for line count (stage children typed
+# `{ [key: string]: any }`, the host-event layer under `@ts-nocheck`, and
+# settings sections casting their context to `Record<string, any>`).
+# These ratchets only ever decrease — each typing PR must lower them.
+LOOSE_PROPS_CEILING = 7
+TS_NOCHECK_CEILING = 1
+SETTINGS_ANY_CAST_CEILING = 9
+
 
 def lines_of(path: Path) -> int:
     if not path.exists():
@@ -125,6 +134,50 @@ def window_dialog_call_hits() -> list[str]:
             if len(hits) >= 8:
                 return hits
     return hits
+
+
+def _src_files(skip_tests: bool = True) -> Iterable[Path]:
+    """Non-test .ts/.tsx files under src/ (tests may mock loosely)."""
+    for p in (ROOT / "src").rglob("*"):
+        if p.suffix not in {".ts", ".tsx"}:
+            continue
+        if skip_tests and ".test." in p.name:
+            continue
+        yield p
+
+
+def loose_props_files() -> list[str]:
+    """Files declaring a loose `{ [key: string]: any }` Props bag."""
+    pat = re.compile(r"\[\s*key\s*:\s*string\s*\]\s*:\s*any")
+    hits = [
+        str(p.relative_to(ROOT))
+        for p in _src_files()
+        if pat.search(read(p))
+    ]
+    return sorted(hits)
+
+
+def ts_nocheck_files() -> list[str]:
+    """Files suppressing the compiler with a leading `// @ts-nocheck`."""
+    hits = [
+        str(p.relative_to(ROOT))
+        for p in _src_files()
+        if read(p).lstrip().startswith("// @ts-nocheck")
+    ]
+    return sorted(hits)
+
+
+def settings_any_cast_files() -> list[str]:
+    """settings sections casting the model bag down to `Record<string, any>`."""
+    pat = re.compile(r"Record\s*<\s*string\s*,\s*any\s*>")
+    hits = [
+        str(p.relative_to(ROOT))
+        for p in (ROOT / "src/components/settings").rglob("*")
+        if p.suffix in {".ts", ".tsx"}
+        and ".test." not in p.name
+        and pat.search(read(p))
+    ]
+    return sorted(hits)
 
 
 def file_imported_anywhere(symbol_or_path: str, search_roots: Iterable[Path], ignore: set[Path]) -> bool:
@@ -616,6 +669,45 @@ def build_gates() -> list[Gate]:
             ),
         ),
         Gate(
+            "LOOSE_PROPS_RATCHET",
+            "Loose `{ [key: string]: any }` Props bags ≤ decreasing ceiling",
+            "final",
+            lambda: (
+                len(loose_props_files()) <= LOOSE_PROPS_CEILING,
+                "loose props files={0} ceiling={1}: {2}".format(
+                    len(loose_props_files()),
+                    LOOSE_PROPS_CEILING,
+                    ", ".join(loose_props_files()) or "none",
+                ),
+            ),
+        ),
+        Gate(
+            "TS_NOCHECK_RATCHET",
+            "`// @ts-nocheck` files ≤ decreasing ceiling",
+            "final",
+            lambda: (
+                len(ts_nocheck_files()) <= TS_NOCHECK_CEILING,
+                "ts-nocheck files={0} ceiling={1}: {2}".format(
+                    len(ts_nocheck_files()),
+                    TS_NOCHECK_CEILING,
+                    ", ".join(ts_nocheck_files()) or "none",
+                ),
+            ),
+        ),
+        Gate(
+            "SETTINGS_ANY_CAST_RATCHET",
+            "settings `Record<string, any>` casts ≤ decreasing ceiling",
+            "final",
+            lambda: (
+                len(settings_any_cast_files()) <= SETTINGS_ANY_CAST_CEILING,
+                "settings any-cast files={0} ceiling={1}: {2}".format(
+                    len(settings_any_cast_files()),
+                    SETTINGS_ANY_CAST_CEILING,
+                    ", ".join(settings_any_cast_files()) or "none",
+                ),
+            ),
+        ),
+        Gate(
             "APP_TIMER_BALANCE",
             "App shell + AppWorkbench clearTimeout count ≥ 50% of setTimeout count (leak budget)",
             "final",
@@ -743,6 +835,9 @@ def main() -> int:
         "session_manager.rs.lines": lines_of(ROOT / "src-tauri/src/session_manager.rs"),
         "api.ts.lines": lines_of(ROOT / "src/lib/api.ts"),
         "SettingsPage.props": settings_page_prop_count(),
+        "typing.loose_props_files": len(loose_props_files()),
+        "typing.ts_nocheck_files": len(ts_nocheck_files()),
+        "typing.settings_any_cast_files": len(settings_any_cast_files()),
         "files_ge_1000": count_files_ge(
             ["src", "src-tauri/src"], 1000, {".ts", ".tsx", ".rs", ".css"}
         ),

--- a/scripts/check-code-quality-gates.py
+++ b/scripts/check-code-quality-gates.py
@@ -52,7 +52,7 @@ APP_USEEFFECT_CEILING = 65
 # `{ [key: string]: any }`, the host-event layer under `@ts-nocheck`, and
 # settings sections casting their context to `Record<string, any>`).
 # These ratchets only ever decrease — each typing PR must lower them.
-LOOSE_PROPS_CEILING = 7
+LOOSE_PROPS_CEILING = 4
 TS_NOCHECK_CEILING = 1
 SETTINGS_ANY_CAST_CEILING = 9
 

--- a/src/app/WorkbenchFloatingMenus.tsx
+++ b/src/app/WorkbenchFloatingMenus.tsx
@@ -1,13 +1,20 @@
 /**
  * Floating project/session + composer context menus.
  */
-import { ContextMenu } from "@/components/ContextMenu";
-import { buildProjectContextMenuItems } from "@/app/WorkbenchProjectContextMenu";
-import { buildSessionContextMenuItems } from "@/app/WorkbenchSessionContextMenu";
+import type { Dispatch, SetStateAction } from "react";
+import { ContextMenu, type ContextMenuItem } from "@/components/ContextMenu";
+import { buildProjectContextMenuItems, type WorkbenchProjectContextMenuProps } from "@/app/WorkbenchProjectContextMenu";
+import { buildSessionContextMenuItems, type WorkbenchSessionContextMenuProps } from "@/app/WorkbenchSessionContextMenu";
 
-export type WorkbenchFloatingMenusProps = {
-  [key: string]: any;
-};
+export type WorkbenchFloatingMenusProps =
+  WorkbenchProjectContextMenuProps &
+    WorkbenchSessionContextMenuProps & {
+      composerCtxItems: ContextMenuItem[];
+      composerCtxMenu: { x: number; y: number } | null;
+      setComposerCtxMenu: Dispatch<
+        SetStateAction<{ x: number; y: number } | null>
+      >;
+    };
 
 export function WorkbenchFloatingMenus(p: WorkbenchFloatingMenusProps) {
   const {

--- a/src/app/WorkbenchProjectContextMenu.tsx
+++ b/src/app/WorkbenchProjectContextMenu.tsx
@@ -1,21 +1,56 @@
 /**
  * Project / archive / sandbox / color sidebar context-menu items.
  */
+import type { Dispatch, SetStateAction } from "react";
 import { type ContextMenuItem } from "@/components/ContextMenu";
 import * as api from "@/lib/api";
 import { IconAppearance, IconArchive, IconCheck, IconChevronDown, IconChevronUp, IconExternalLink, IconFileText, IconFolderPlus, IconHistory, IconPin, IconPinOff, IconPlus, IconQueue, IconRename, IconShield, IconTrash } from "@/components/icons";
 import { canMoveProjectInPinGroup } from "@/lib/app/projectOrder";
-import { isGeneralProject, projectDisplayName } from "@/lib/app/sidebarModels";
-import { revealInOsLabel } from "@/lib/appPlatform";
+import { isGeneralProject, projectDisplayName, type Project, type SessionRow } from "@/lib/app/sidebarModels";
+import { revealInOsLabel, type AppPlatform } from "@/lib/appPlatform";
 import { canOfferContinueCwd } from "@/lib/continueCwd";
 import { PERMISSION_POLICIES, type PermissionPolicyId } from "@/lib/grokCatalog";
-import { PROJECT_COLOR_TOKENS, normalizeProjectColor, resolveProjectColorCss } from "@/lib/projectColor";
-import { spaceDisplayName, spaceOfProject } from "@/lib/projectSpaces";
-import { SANDBOX_PROFILES, isDangerousSandboxProfile, normalizeSandboxProfile } from "@/lib/sandboxProfile";
+import { PROJECT_COLOR_TOKENS, normalizeProjectColor, resolveProjectColorCss, type ProjectColorToken } from "@/lib/projectColor";
+import { spaceDisplayName, spaceOfProject, type CreateSpaceError, type DeleteSpaceError, type SpaceNameError } from "@/lib/projectSpaces";
+import { SANDBOX_PROFILES, isDangerousSandboxProfile, normalizeSandboxProfile, type SandboxProfileId } from "@/lib/sandboxProfile";
 import { listArchiveAgeOptionPreviews } from "@/lib/sessionArchiveAge";
+import { createT, type MessageKey } from "@/i18n";
+import { useProjectSpaces } from "@/hooks/useProjectSpaces";
+import type { AppDialog, ContextMenuState } from "@/lib/app/appDialogTypes";
+import type { SidebarProjectReorderApi } from "@/hooks/useSidebarProjectReorder";
+
+type TFn = ReturnType<typeof createT>;
+type ProjectSpacesApi = ReturnType<typeof useProjectSpaces>;
 
 export type WorkbenchProjectContextMenuProps = {
-  [key: string]: any;
+  ctxMenu: ContextMenuState;
+  applyProjectColor: (proj: Project, next: string | null) => void;
+  applyProjectPermissionPolicy: (proj: Project, next: PermissionPolicyId | null) => void;
+  applyProjectSandboxProfile: (proj: Project, next: SandboxProfileId | null) => void;
+  archiveProjectSessions: (proj: Project) => Promise<void>;
+  confirmArchiveOlderThan: (days: number) => void;
+  continueLastAgentForProject: (proj: Project) => Promise<void>;
+  moveProjectByMenu: (projId: string, direction: "up" | "down") => void;
+  openSandboxWizardGuide: () => void;
+  platform: AppPlatform;
+  projectColorLabel: (token: ProjectColorToken) => string;
+  projectReorder: SidebarProjectReorderApi;
+  projectSpaces: ProjectSpacesApi;
+  projects: Project[];
+  refreshProjects: () => Promise<void>;
+  relocateProject: (proj: Project) => Promise<void>;
+  removeProjectFromApp: (proj: Project) => void;
+  renameProject: (proj: Project) => void;
+  sandboxProfileLabel: (id: SandboxProfileId) => string;
+  sessions: SessionRow[];
+  setAppDialog: Dispatch<SetStateAction<AppDialog>>;
+  setCtxMenu: Dispatch<SetStateAction<ContextMenuState>>;
+  setLocalError: Dispatch<SetStateAction<string | null>>;
+  setProjectRulesTarget: Dispatch<SetStateAction<{ path: string; name: string } | null>>;
+  showToast: (msg: string, ms?: number) => void;
+  spaceErrorKey: (err: SpaceNameError | CreateSpaceError | DeleteSpaceError) => MessageKey;
+  tr: TFn;
+  visibleProjects: Project[];
 };
 
 export function buildProjectContextMenuItems(
@@ -71,7 +106,7 @@ export function buildProjectContextMenuItems(
             },
           }));
         } else if (ctxMenu?.kind === "project") {
-          const proj = projects.find((p: any) => p.id === ctxMenu.id);
+          const proj = projects.find((x) => x.id === ctxMenu.id);
           if (proj) {
             const canUp = canMoveProjectInPinGroup(visibleProjects, proj.id, "up");
             const canDown = canMoveProjectInPinGroup(
@@ -143,7 +178,7 @@ export function buildProjectContextMenuItems(
                 label: tr("sidebar.spaces.moveTo"),
                 icon: <IconQueue size={16} />,
                 children: [
-                  ...projectSpaces.state.spaces.map((space: any) => {
+                  ...projectSpaces.state.spaces.map((space) => {
                     const current =
                       spaceOfProject(projectSpaces.state, proj.id) ===
                       space.id;
@@ -181,7 +216,7 @@ export function buildProjectContextMenuItems(
                         title: tr("sidebar.spaces.newTitle"),
                         initial: "",
                         placeholder: tr("sidebar.spaces.namePlaceholder"),
-                        onSubmit: (value: any) => {
+                        onSubmit: (value) => {
                           const result = projectSpaces.createAndMove(
                             proj.id,
                             value,
@@ -305,7 +340,7 @@ export function buildProjectContextMenuItems(
             ];
           }
         } else if (ctxMenu?.kind === "project-policy") {
-          const proj = projects.find((p: any) => p.id === ctxMenu.id);
+          const proj = projects.find((x) => x.id === ctxMenu.id);
           if (proj && proj.trusted) {
             const current = proj.permissionPolicy?.trim() || null;
             const policyLabel = (id: PermissionPolicyId) =>
@@ -342,7 +377,7 @@ export function buildProjectContextMenuItems(
             ];
           }
         } else if (ctxMenu?.kind === "project-sandbox") {
-          const proj = projects.find((p: any) => p.id === ctxMenu.id);
+          const proj = projects.find((x) => x.id === ctxMenu.id);
           if (proj && proj.trusted) {
             const current =
               normalizeSandboxProfile(proj.sandboxProfile) ?? null;
@@ -371,7 +406,7 @@ export function buildProjectContextMenuItems(
             ];
           }
         } else if (ctxMenu?.kind === "project-color") {
-          const proj = projects.find((p: any) => p.id === ctxMenu.id);
+          const proj = projects.find((x) => x.id === ctxMenu.id);
           if (proj) {
             const current = normalizeProjectColor(proj.color);
             items = [

--- a/src/app/WorkbenchSessionContextMenu.tsx
+++ b/src/app/WorkbenchSessionContextMenu.tsx
@@ -1,19 +1,102 @@
 /**
  * Session / bulk-move sidebar context-menu items.
  */
+import type { Dispatch, RefObject, SetStateAction } from "react";
 import { type ContextMenuItem } from "@/components/ContextMenu";
 import * as api from "@/lib/api";
 import { IconArchive, IconArrowsMinimize, IconBell, IconBellOff, IconChat, IconCheck, IconCircle, IconCopy, IconExportImage, IconExternalLink, IconFiles, IconFolder, IconFork, IconGitBranch, IconList, IconListCheck, IconListNumbers, IconNotes, IconPin, IconPinOff, IconPlan, IconPuzzle, IconRename, IconRewind, IconRobot, IconSettings, IconTrash, IconUpload } from "@/components/icons";
 import { dispatchCollapseAllActivity } from "@/lib/collapseAllActivity";
-import { canRemoveWorktree, pathsEqual } from "@/lib/gitWorktree";
+import { canRemoveWorktree, pathsEqual, type GitWorktreeEntry, type SessionWorktreeBadge } from "@/lib/gitWorktree";
 import { canOpenSessionInNewWindow } from "@/lib/multiWindow";
 import { isSessionExportJournalEmpty, joinSessionExportMenuSuffix, resolveSessionExportPath, sessionExportFormatNameKey, sessionExportMenuSuffixKeys } from "@/lib/sessionExportPro";
 import { normalizeMaxAgentTurns } from "@/lib/sessionMaxAgentTurns";
 import { canOfferResumeWithCodeRestore } from "@/lib/sessionResumeRestore";
 import { sanitizeSystemPromptOverride } from "@/lib/sessionSystemPrompt";
+import { createT } from "@/i18n";
+import type { ChatMessage, SessionSnapshot } from "@/lib/session";
+import { type Project, type SessionRow } from "@/lib/app/sidebarModels";
+import type { ContextMenuState } from "@/lib/app/appDialogTypes";
+import type { StreamSessionExportFormat } from "@/lib/streamSessionExport";
+import type { TranscriptFilterMode } from "@/lib/transcriptFilterPref";
+
+type TFn = ReturnType<typeof createT>;
+
+/** Minimal session identity the export callbacks operate on. */
+export type SessionExportTarget = {
+  id: string;
+  title: string;
+  projectId?: string | null;
+};
 
 export type WorkbenchSessionContextMenuProps = {
-  [key: string]: any;
+  ctxMenu: ContextMenuState;
+  activeProject: Project | null;
+  addSessionPluginDir: (s: SessionRow) => Promise<void>;
+  applyAttachedChat: (id: string, title: string, updatedAt?: string) => void;
+  archiveSession: (s: SessionRow, archived?: boolean) => Promise<void>;
+  bulkMoveMenuItems: (ids: string[]) => ContextMenuItem[];
+  busyIds: Set<string>;
+  canRewindSession: boolean;
+  clearSessionPluginDirs: (s: SessionRow) => Promise<void>;
+  confirmExportSessionTraceUpload: (sessionId?: string | null) => void;
+  confirmForkSession: (source: SessionRow, throughUserPromptIndex?: number | null) => void;
+  confirmRemoveWorktree: (wt: GitWorktreeEntry) => void;
+  confirmResumeWithCodeRestore: (source: SessionRow) => void;
+  copyConversationMarkdown: (sessionMeta?: SessionExportTarget) => Promise<void>;
+  copySessionId: (s: SessionRow) => Promise<void>;
+  deleteSessionConfirm: (s: SessionRow) => void;
+  enterSessionSelectMode: (preselectId?: string) => void;
+  exportSessionDiagnostic: (sessionId?: string | null) => Promise<void>;
+  exportSessionHtml: (sessionMeta?: SessionExportTarget) => Promise<void>;
+  exportSessionJson: (sessionMeta?: SessionExportTarget) => Promise<void>;
+  exportSessionPlain: (sessionMeta?: SessionExportTarget) => Promise<void>;
+  exportSessionStreamNdjson: (
+    format: StreamSessionExportFormat,
+    sessionMeta?: SessionExportTarget,
+  ) => Promise<void>;
+  exportSessionTrace: (
+    sessionId?: string | null,
+    opts?: { localOnly?: boolean },
+  ) => Promise<void>;
+  forkBusy: boolean;
+  gitWorktrees: GitWorktreeEntry[];
+  gitWorktreesAvailable: boolean | null;
+  handleClearAllSessionUnread: () => void;
+  handleClearSessionUnread: (sessionId: string) => void;
+  handleMarkSessionUnread: (sessionId: string) => void;
+  handleToggleSessionMute: (sessionId: string) => void;
+  isSecondaryWindow: boolean;
+  messages: ChatMessage[];
+  moveMenuItemsFor: (row: SessionRow) => ContextMenuItem[];
+  mutedSessionIds: Set<string>;
+  navigator: Navigator;
+  openExportSessionImage: (sessionMeta?: SessionExportTarget) => void;
+  openExportSessionMd: (sessionMeta?: SessionExportTarget) => void;
+  openRewindTimeline: (sessionId: string) => Promise<void>;
+  openSessionInNewWindow: (s: SessionRow) => void;
+  openSessionMaxTurns: (s: SessionRow) => void;
+  openSessionNote: (s: SessionRow) => void;
+  openSessionRules: (s: SessionRow) => void;
+  openSessionSysPrompt: (s: SessionRow) => void;
+  openShipFlow: () => void;
+  pinSession: (s: SessionRow, pinned?: boolean) => Promise<void>;
+  projects: Project[];
+  renameSession: (s: SessionRow) => void;
+  resumeRestoreBusy: boolean;
+  runDuplicateSession: (source: SessionRow) => Promise<void>;
+  session: SessionSnapshot;
+  sessionSelectMode: boolean;
+  sessionWorktreeBadgeFor: (s: SessionRow) => SessionWorktreeBadge | null;
+  sessions: SessionRow[];
+  setLocalError: Dispatch<SetStateAction<string | null>>;
+  setShowPlanHistory: Dispatch<SetStateAction<boolean>>;
+  setShowTraces: Dispatch<SetStateAction<boolean>>;
+  showToast: (msg: string, ms?: number) => void;
+  toggleTranscriptFilter: () => void;
+  transcriptFilter: TranscriptFilterMode;
+  tr: TFn;
+  unreadSessionIds: Set<string>;
+  viewingSessionIdRef: RefObject<string | null>;
 };
 
 export function buildSessionContextMenuItems(
@@ -87,7 +170,7 @@ export function buildSessionContextMenuItems(
         if (ctxMenu?.kind === "session-move") {
           items = bulkMoveMenuItems(ctxMenu.ids);
         } else if (ctxMenu?.kind === "session") {
-          const s = sessions.find((x: any) => x.id === ctxMenu.id);
+          const s = sessions.find((x) => x.id === ctxMenu.id);
           if (s) {
             const isOpen =
               session.sessionId === s.id ||
@@ -245,7 +328,7 @@ export function buildSessionContextMenuItems(
             // Soft-empty honesty for the live session only (other sessions load on demand).
             const liveExportable =
               s.id === session.sessionId
-                ? messages.map((m: any) => ({
+                ? messages.map((m) => ({
                     role: m.role,
                     content: m.content,
                     thought: m.thought,
@@ -493,7 +576,7 @@ export function buildSessionContextMenuItems(
                     danger: true,
                     onClick: () => {
                       const fromList =
-                        gitWorktrees.find((w: any) =>
+                        gitWorktrees.find((w) =>
                           pathsEqual(w.path, wtBadge.path),
                         ) ?? null;
                       const wt: api.GitWorktreeEntry = fromList ?? {
@@ -516,7 +599,7 @@ export function buildSessionContextMenuItems(
 
             const resumeRestoreItem = (() => {
               const proj = s.projectId
-                ? projects.find((p: any) => p.id === s.projectId) ?? null
+                ? projects.find((x) => x.id === s.projectId) ?? null
                 : null;
               const path = proj?.path?.trim() || "";
               const gitKnown =


### PR DESCRIPTION
## Summary
`WorkbenchFloatingMenus` forwarded an `{ [key: string]: any }` bag to the project and session context-menu builders, so `tsc` could not guard any of the ~89 props crossing that seam — part of the compile-time safety the AppWorkbench decomposition traded away for line count.

This gives each seam an explicit Props interface, **inferred from the real call-site types via the TS checker** (not hand-copied):

- `WorkbenchProjectContextMenuProps` — 28 fields
- `WorkbenchSessionContextMenuProps` — 62 fields, plus an exported `SessionExportTarget` for the export callback shape
- `WorkbenchFloatingMenusProps` — the intersection of both + composer menu fields

Sixteen inline `(x: any)` / `(p: any)` annotations fall away with real types in scope.

Ratchet: `LOOSE_PROPS_CEILING` 7 → 4 — the ratchet added in #1150 proves its worth here (3 files leave the loose list; the gate output lists the remaining 4 for the next PRs).

**Stacked on #1150** (the gates PR) so the ratchet change lands in the same review chain.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Refactor / chore

## Checklist
- [x] I ran `pnpm typecheck`, `pnpm test` (641 files), `lint`, gates, self-test, `build:ui` — all green
- [x] No Rust change
- [x] No user-facing strings / no visual change
- [x] No `window.confirm` / `prompt` / `alert`
- [x] No secrets included