### PR TITLE
refactor(app): type WorkbenchChatStage props (91 fields)

### DIFF
--- a/scripts/check-code-quality-gates.py
+++ b/scripts/check-code-quality-gates.py
@@ -52,7 +52,7 @@ APP_USEEFFECT_CEILING = 65
 # `{ [key: string]: any }`, the host-event layer under `@ts-nocheck`, and
 # settings sections casting their context to `Record<string, any>`).
 # These ratchets only ever decrease — each typing PR must lower them.
-LOOSE_PROPS_CEILING = 4
+LOOSE_PROPS_CEILING = 3
 TS_NOCHECK_CEILING = 1
 SETTINGS_ANY_CAST_CEILING = 9
 

--- a/scripts/check-code-quality-gates.py
+++ b/scripts/check-code-quality-gates.py
@@ -47,6 +47,15 @@ APP_LINES_CEILING = 13750
 APP_USESTATE_CEILING = 94
 APP_USEEFFECT_CEILING = 65
 
+# Typing escape-hatch ceilings. The AppWorkbench decomposition traded
+# compile-time safety for line count (stage children typed
+# `{ [key: string]: any }`, the host-event layer under `@ts-nocheck`, and
+# settings sections casting their context to `Record<string, any>`).
+# These ratchets only ever decrease — each typing PR must lower them.
+LOOSE_PROPS_CEILING = 7
+TS_NOCHECK_CEILING = 1
+SETTINGS_ANY_CAST_CEILING = 9
+
 
 def lines_of(path: Path) -> int:
     if not path.exists():
@@ -125,6 +134,50 @@ def window_dialog_call_hits() -> list[str]:
             if len(hits) >= 8:
                 return hits
     return hits
+
+
+def _src_files(skip_tests: bool = True) -> Iterable[Path]:
+    """Non-test .ts/.tsx files under src/ (tests may mock loosely)."""
+    for p in (ROOT / "src").rglob("*"):
+        if p.suffix not in {".ts", ".tsx"}:
+            continue
+        if skip_tests and ".test." in p.name:
+            continue
+        yield p
+
+
+def loose_props_files() -> list[str]:
+    """Files declaring a loose `{ [key: string]: any }` Props bag."""
+    pat = re.compile(r"\[\s*key\s*:\s*string\s*\]\s*:\s*any")
+    hits = [
+        str(p.relative_to(ROOT))
+        for p in _src_files()
+        if pat.search(read(p))
+    ]
+    return sorted(hits)
+
+
+def ts_nocheck_files() -> list[str]:
+    """Files suppressing the compiler with a leading `// @ts-nocheck`."""
+    hits = [
+        str(p.relative_to(ROOT))
+        for p in _src_files()
+        if read(p).lstrip().startswith("// @ts-nocheck")
+    ]
+    return sorted(hits)
+
+
+def settings_any_cast_files() -> list[str]:
+    """settings sections casting the model bag down to `Record<string, any>`."""
+    pat = re.compile(r"Record\s*<\s*string\s*,\s*any\s*>")
+    hits = [
+        str(p.relative_to(ROOT))
+        for p in (ROOT / "src/components/settings").rglob("*")
+        if p.suffix in {".ts", ".tsx"}
+        and ".test." not in p.name
+        and pat.search(read(p))
+    ]
+    return sorted(hits)
 
 
 def file_imported_anywhere(symbol_or_path: str, search_roots: Iterable[Path], ignore: set[Path]) -> bool:
@@ -616,6 +669,45 @@ def build_gates() -> list[Gate]:
             ),
         ),
         Gate(
+            "LOOSE_PROPS_RATCHET",
+            "Loose `{ [key: string]: any }` Props bags ≤ decreasing ceiling",
+            "final",
+            lambda: (
+                len(loose_props_files()) <= LOOSE_PROPS_CEILING,
+                "loose props files={0} ceiling={1}: {2}".format(
+                    len(loose_props_files()),
+                    LOOSE_PROPS_CEILING,
+                    ", ".join(loose_props_files()) or "none",
+                ),
+            ),
+        ),
+        Gate(
+            "TS_NOCHECK_RATCHET",
+            "`// @ts-nocheck` files ≤ decreasing ceiling",
+            "final",
+            lambda: (
+                len(ts_nocheck_files()) <= TS_NOCHECK_CEILING,
+                "ts-nocheck files={0} ceiling={1}: {2}".format(
+                    len(ts_nocheck_files()),
+                    TS_NOCHECK_CEILING,
+                    ", ".join(ts_nocheck_files()) or "none",
+                ),
+            ),
+        ),
+        Gate(
+            "SETTINGS_ANY_CAST_RATCHET",
+            "settings `Record<string, any>` casts ≤ decreasing ceiling",
+            "final",
+            lambda: (
+                len(settings_any_cast_files()) <= SETTINGS_ANY_CAST_CEILING,
+                "settings any-cast files={0} ceiling={1}: {2}".format(
+                    len(settings_any_cast_files()),
+                    SETTINGS_ANY_CAST_CEILING,
+                    ", ".join(settings_any_cast_files()) or "none",
+                ),
+            ),
+        ),
+        Gate(
             "APP_TIMER_BALANCE",
             "App shell + AppWorkbench clearTimeout count ≥ 50% of setTimeout count (leak budget)",
             "final",
@@ -743,6 +835,9 @@ def main() -> int:
         "session_manager.rs.lines": lines_of(ROOT / "src-tauri/src/session_manager.rs"),
         "api.ts.lines": lines_of(ROOT / "src/lib/api.ts"),
         "SettingsPage.props": settings_page_prop_count(),
+        "typing.loose_props_files": len(loose_props_files()),
+        "typing.ts_nocheck_files": len(ts_nocheck_files()),
+        "typing.settings_any_cast_files": len(settings_any_cast_files()),
         "files_ge_1000": count_files_ge(
             ["src", "src-tauri/src"], 1000, {".ts", ".tsx", ".rs", ".css"}
         ),

--- a/scripts/check-code-quality-gates.py
+++ b/scripts/check-code-quality-gates.py
@@ -52,7 +52,7 @@ APP_USEEFFECT_CEILING = 65
 # `{ [key: string]: any }`, the host-event layer under `@ts-nocheck`, and
 # settings sections casting their context to `Record<string, any>`).
 # These ratchets only ever decrease — each typing PR must lower them.
-LOOSE_PROPS_CEILING = 7
+LOOSE_PROPS_CEILING = 4
 TS_NOCHECK_CEILING = 1
 SETTINGS_ANY_CAST_CEILING = 9
 

--- a/src/app/WorkbenchChatStage.tsx
+++ b/src/app/WorkbenchChatStage.tsx
@@ -3,10 +3,11 @@
  * banner, a11y live region, and ConversationThreadLive. Composer is passed
  * as children so it stays inside main__stage.
  */
-import type { CSSProperties } from "react";
+import type { CSSProperties, Dispatch, ReactNode, RefObject, SetStateAction } from "react";
 import * as api from "@/lib/api";
 import type { MessageKey } from "@/i18n";
-import { pathsEqual } from "@/lib/gitWorktree";
+import { createT, resolveLocale } from "@/i18n";
+import { pathsEqual, type GitWorktreeEntry } from "@/lib/gitWorktree";
 import {
   classifyTasksBindCwdError,
   classifyTasksStopError,
@@ -18,8 +19,24 @@ import {
   stallTierFromProgress,
   normalizeStallTier,
 } from "@/lib/sessionPhase";
-import { goalOrchPhaseLabelKey } from "@/lib/goalOrch";
-import { AttachedChatLookupContext } from "@/components/AttachedChatLookup";
+import { goalOrchPhaseLabelKey, type GoalOrchEvent } from "@/lib/goalOrch";
+import { AttachedChatLookupContext, type AttachedChatLookup } from "@/components/AttachedChatLookup";
+import type { ResourceOpenTarget } from "@/components/resource-viewer/types";
+import type { ModelOption } from "@/lib/grokCatalog";
+import type { MessageTimeFormat } from "@/lib/messageTimeFormatPref";
+import type { SessionPlanState } from "@/lib/planSession";
+import type { GoalOrchSessionIndicator } from "@/lib/goalOrchView";
+import type { StopAllSurface } from "@/lib/stopAllHonesty";
+import type { StopLatchState } from "@/lib/stopLatch";
+import type { UiBusyGate } from "@/lib/sessionPhase";
+import type { SessionLiveMap } from "@/lib/sessionLiveStore";
+import { sessionTranscriptStore as sessionTranscriptStoreInstance } from "@/lib/sessionTranscriptStore";
+import type { ErrorBannerView } from "@/lib/session/errors";
+import type { ErrorDeckAction } from "@/lib/errorDeck";
+import type { Attachment } from "@/lib/attachments";
+import type { SessionFileChange } from "@/lib/sessionChanges";
+import { type Project, type SessionRow } from "@/lib/app/sidebarModels";
+import type { ChatMessage, SessionSnapshot } from "@/lib/session";
 import { UiErrorBoundary } from "@/components/UiErrorBoundary";
 import { ConversationThreadLive } from "@/components/lobe-chat";
 import { GoalOrchSessionChip } from "@/components/GoalOrchSessionChip";
@@ -27,10 +44,159 @@ import { PlanStatusBar } from "@/components/PlanStatusBar";
 import { ChatFindLive } from "@/components/ChatFindLive";
 import { AgentTasksPanelLive } from "@/components/AgentTasksPanelLive";
 
-export type WorkbenchChatStageProps = {
-  [key: string]: any;
-};
+type TFn = ReturnType<typeof createT>;
+type TStore = typeof sessionTranscriptStoreInstance;
+type StreamStallView = {
+  sessionId?: string;
+  stallSeconds: number;
+  tier?: string;
+  sawModelOutput?: boolean;
+  sawToolActivity?: boolean;
+} | null;
 
+export type WorkbenchChatStageProps = {
+  children: ReactNode;
+  activeProject: Project | null;
+  approvePlan: () => Promise<void>;
+  attachLabels: {
+    open: string;
+    reveal: string;
+    copyPath: string;
+    copyImage: string;
+    addToComposer: string;
+    remove: string;
+    viewImage: string;
+    previewBroken: string;
+    previewMissing: string;
+    previewPending: string;
+  };
+  attachedChatLookup: AttachedChatLookup;
+  availableModels: ModelOption[];
+  beginEditLastUser: (msg: ChatMessage) => void;
+  canEditLastUser: boolean;
+  canRewindSession: boolean;
+  cancelEditUser: () => void;
+  chatFindFocusKey: number;
+  composerFloatPad: number;
+  connecting: boolean;
+  copyGoalOrchControlSummary: () => Promise<void>;
+  dismissPlan: () => void;
+  editAttachments: Attachment[];
+  editSubmitting: boolean;
+  editingUserMessageId: string | null;
+  effectiveProjectPath: string | null;
+  errorBanner: ErrorBannerView | null;
+  errorDetailOpen: boolean;
+  exitPlanMode: () => void;
+  gitWorktrees: GitWorktreeEntry[];
+  goalMode: boolean;
+  goalOrchSessionChip: GoalOrchSessionIndicator | null;
+  goalOrchSessionEvents: GoalOrchEvent[];
+  hasChatTurnError: boolean;
+  isSecondaryWindow: boolean;
+  journalPending: boolean;
+  lastUserMessageId: string | null;
+  liveMap: SessionLiveMap;
+  locale: string;
+  mainPane: "chat" | "automations" | "kanban";
+  markSessionWorktree: (
+    sessionId: string | null | undefined,
+    path: string,
+    branch: string | null | undefined,
+  ) => Promise<void>;
+  messageTimeFormat: MessageTimeFormat;
+  mode: string;
+  modelId: string;
+  onForkFromAssistantMessage: (msg: ChatMessage) => void;
+  onRewindToUserMessage: (msg: ChatMessage) => void;
+  onThreadAddAttachmentToComposer: (att: Attachment) => void;
+  onThreadAddQuote: (quote: {
+    text: string;
+    comment: string;
+    sourceMessageId?: string;
+  }) => void;
+  onThreadContinueInterrupted: () => void;
+  onThreadOpenError: (message: string) => void;
+  onThreadOpenModifiedPath: (path: string) => void;
+  onThreadOpenResource: (target: ResourceOpenTarget) => void;
+  onThreadOpenSessionChanges: () => void;
+  onThreadRemoveEditAttachment: (att: Attachment) => void;
+  openExternalLinkFromChat: (url: string) => void;
+  openPlanInResource: () => void;
+  openReliability: () => void;
+  openRequestPlanChanges: () => void;
+  openSession: (s: SessionRow, project?: Project | null) => Promise<void>;
+  plan: SessionPlanState;
+  projects: Project[];
+  regenerateLastAssistant: (
+    message: ChatMessage,
+    opts?: { modelId?: string },
+  ) => Promise<void>;
+  requestClearLocalGoalOrchTimeline: () => void;
+  retryAgentConnect: () => void;
+  runErrorBannerAction: (action: ErrorDeckAction) => void;
+  session: SessionSnapshot;
+  sessionChanges: SessionFileChange[];
+  sessionJsonSchema: string | null;
+  sessionTranscriptStore: TStore;
+  sessions: SessionRow[];
+  setAgentDashboardOpen: Dispatch<SetStateAction<boolean>>;
+  setErrorDetailOpen: Dispatch<SetStateAction<boolean>>;
+  setGoalMode: Dispatch<SetStateAction<boolean>>;
+  setLiveMap: (
+    next: SessionLiveMap | ((prev: SessionLiveMap) => SessionLiveMap),
+  ) => void;
+  setShowChatFind: Dispatch<SetStateAction<boolean>>;
+  setStreamStall: Dispatch<SetStateAction<StreamStallView>>;
+  setTasksPanelOpen: Dispatch<SetStateAction<boolean>>;
+  shouldDisableReconnectBecauseConnecting: (connecting: boolean) => boolean;
+  showChatFind: boolean;
+  showMessageTimestamps: boolean;
+  showReplyLength: boolean;
+  showToast: (msg: string, ms?: number) => void;
+  stop: () => Promise<void>;
+  stopAllBusySessions: (surface?: StopAllSurface) => void;
+  stopGate: UiBusyGate;
+  stopLatch: StopLatchState;
+  streamA11yNote: string;
+  streamStall: StreamStallView;
+  structuredOutputLabels: {
+    title: string;
+    badge: string;
+    copy: string;
+    copied: string;
+    export: string;
+    invalidJson: string;
+    empty: string;
+    valid: string;
+    schemaMismatch: string;
+    missingRequired: string;
+    streaming?: string;
+    partial?: string;
+    partialKeys?: string;
+    timeline?: string;
+    usage?: string;
+    usageIo?: string;
+    usageTotal?: string;
+  };
+  structuredOutputUsage: {
+    inputTokens: number | null;
+    outputTokens: number | null;
+    totalTokens: number | null;
+  } | null;
+  subagentWorktreeSnapshotEnabled: boolean;
+  submitEditLastUser: (msg: ChatMessage, storedDisplay: string) => Promise<void>;
+  switchToWorktree: (wt: GitWorktreeEntry) => Promise<void>;
+  tasksPanelOpen: boolean;
+  tr: TFn;
+  turnStartedAt: number | null;
+  viewingSessionIdRef: RefObject<string | null>;
+  welcomeSession: boolean;
+  worktreeEntryForPath: (
+    path: string | null,
+    worktrees?: GitWorktreeEntry[] | null,
+  ) => GitWorktreeEntry | null;
+};
 export function WorkbenchChatStage(p: WorkbenchChatStageProps) {
   const {
     activeProject, approvePlan, attachLabels, attachedChatLookup, availableModels, beginEditLastUser,
@@ -281,10 +447,9 @@ export function WorkbenchChatStage(p: WorkbenchChatStageProps) {
               currentSessionId={session.sessionId}
               untitledLabel={tr("session.untitled")}
               onSelectSession={(id) => {
-                const row = sessions.find((s: { id: string; projectId?: string }) => s.id === id);
+                const row = sessions.find((s) => s.id === id);
                 if (!row) return;
-                const proj =
-                  projects.find((p: { id: string }) => p.id === row.projectId) || null;
+                const proj = projects.find((p) => p.id === row.projectId) || null;
                 void openSession(row, proj);
               }}
               onStopSession={async (id) => {
@@ -444,7 +609,7 @@ export function WorkbenchChatStage(p: WorkbenchChatStageProps) {
           <ConversationThreadLive
             onContinueInterrupted={onThreadContinueInterrupted}
             onAddQuote={onThreadAddQuote}
-            locale={locale}
+            locale={resolveLocale(locale)}
             sessionState={
               stopLatch.phase === "force_idle" || stopGate.forceIdle
                 ? "ready"

--- a/src/app/WorkbenchFloatingMenus.tsx
+++ b/src/app/WorkbenchFloatingMenus.tsx
@@ -1,13 +1,20 @@
 /**
  * Floating project/session + composer context menus.
  */
-import { ContextMenu } from "@/components/ContextMenu";
-import { buildProjectContextMenuItems } from "@/app/WorkbenchProjectContextMenu";
-import { buildSessionContextMenuItems } from "@/app/WorkbenchSessionContextMenu";
+import type { Dispatch, SetStateAction } from "react";
+import { ContextMenu, type ContextMenuItem } from "@/components/ContextMenu";
+import { buildProjectContextMenuItems, type WorkbenchProjectContextMenuProps } from "@/app/WorkbenchProjectContextMenu";
+import { buildSessionContextMenuItems, type WorkbenchSessionContextMenuProps } from "@/app/WorkbenchSessionContextMenu";
 
-export type WorkbenchFloatingMenusProps = {
-  [key: string]: any;
-};
+export type WorkbenchFloatingMenusProps =
+  WorkbenchProjectContextMenuProps &
+    WorkbenchSessionContextMenuProps & {
+      composerCtxItems: ContextMenuItem[];
+      composerCtxMenu: { x: number; y: number } | null;
+      setComposerCtxMenu: Dispatch<
+        SetStateAction<{ x: number; y: number } | null>
+      >;
+    };
 
 export function WorkbenchFloatingMenus(p: WorkbenchFloatingMenusProps) {
   const {

--- a/src/app/WorkbenchProjectContextMenu.tsx
+++ b/src/app/WorkbenchProjectContextMenu.tsx
@@ -1,21 +1,56 @@
 /**
  * Project / archive / sandbox / color sidebar context-menu items.
  */
+import type { Dispatch, SetStateAction } from "react";
 import { type ContextMenuItem } from "@/components/ContextMenu";
 import * as api from "@/lib/api";
 import { IconAppearance, IconArchive, IconCheck, IconChevronDown, IconChevronUp, IconExternalLink, IconFileText, IconFolderPlus, IconHistory, IconPin, IconPinOff, IconPlus, IconQueue, IconRename, IconShield, IconTrash } from "@/components/icons";
 import { canMoveProjectInPinGroup } from "@/lib/app/projectOrder";
-import { isGeneralProject, projectDisplayName } from "@/lib/app/sidebarModels";
-import { revealInOsLabel } from "@/lib/appPlatform";
+import { isGeneralProject, projectDisplayName, type Project, type SessionRow } from "@/lib/app/sidebarModels";
+import { revealInOsLabel, type AppPlatform } from "@/lib/appPlatform";
 import { canOfferContinueCwd } from "@/lib/continueCwd";
 import { PERMISSION_POLICIES, type PermissionPolicyId } from "@/lib/grokCatalog";
-import { PROJECT_COLOR_TOKENS, normalizeProjectColor, resolveProjectColorCss } from "@/lib/projectColor";
-import { spaceDisplayName, spaceOfProject } from "@/lib/projectSpaces";
-import { SANDBOX_PROFILES, isDangerousSandboxProfile, normalizeSandboxProfile } from "@/lib/sandboxProfile";
+import { PROJECT_COLOR_TOKENS, normalizeProjectColor, resolveProjectColorCss, type ProjectColorToken } from "@/lib/projectColor";
+import { spaceDisplayName, spaceOfProject, type CreateSpaceError, type DeleteSpaceError, type SpaceNameError } from "@/lib/projectSpaces";
+import { SANDBOX_PROFILES, isDangerousSandboxProfile, normalizeSandboxProfile, type SandboxProfileId } from "@/lib/sandboxProfile";
 import { listArchiveAgeOptionPreviews } from "@/lib/sessionArchiveAge";
+import { createT, type MessageKey } from "@/i18n";
+import { useProjectSpaces } from "@/hooks/useProjectSpaces";
+import type { AppDialog, ContextMenuState } from "@/lib/app/appDialogTypes";
+import type { SidebarProjectReorderApi } from "@/hooks/useSidebarProjectReorder";
+
+type TFn = ReturnType<typeof createT>;
+type ProjectSpacesApi = ReturnType<typeof useProjectSpaces>;
 
 export type WorkbenchProjectContextMenuProps = {
-  [key: string]: any;
+  ctxMenu: ContextMenuState;
+  applyProjectColor: (proj: Project, next: string | null) => void;
+  applyProjectPermissionPolicy: (proj: Project, next: PermissionPolicyId | null) => void;
+  applyProjectSandboxProfile: (proj: Project, next: SandboxProfileId | null) => void;
+  archiveProjectSessions: (proj: Project) => Promise<void>;
+  confirmArchiveOlderThan: (days: number) => void;
+  continueLastAgentForProject: (proj: Project) => Promise<void>;
+  moveProjectByMenu: (projId: string, direction: "up" | "down") => void;
+  openSandboxWizardGuide: () => void;
+  platform: AppPlatform;
+  projectColorLabel: (token: ProjectColorToken) => string;
+  projectReorder: SidebarProjectReorderApi;
+  projectSpaces: ProjectSpacesApi;
+  projects: Project[];
+  refreshProjects: () => Promise<void>;
+  relocateProject: (proj: Project) => Promise<void>;
+  removeProjectFromApp: (proj: Project) => void;
+  renameProject: (proj: Project) => void;
+  sandboxProfileLabel: (id: SandboxProfileId) => string;
+  sessions: SessionRow[];
+  setAppDialog: Dispatch<SetStateAction<AppDialog>>;
+  setCtxMenu: Dispatch<SetStateAction<ContextMenuState>>;
+  setLocalError: Dispatch<SetStateAction<string | null>>;
+  setProjectRulesTarget: Dispatch<SetStateAction<{ path: string; name: string } | null>>;
+  showToast: (msg: string, ms?: number) => void;
+  spaceErrorKey: (err: SpaceNameError | CreateSpaceError | DeleteSpaceError) => MessageKey;
+  tr: TFn;
+  visibleProjects: Project[];
 };
 
 export function buildProjectContextMenuItems(
@@ -71,7 +106,7 @@ export function buildProjectContextMenuItems(
             },
           }));
         } else if (ctxMenu?.kind === "project") {
-          const proj = projects.find((p: any) => p.id === ctxMenu.id);
+          const proj = projects.find((x) => x.id === ctxMenu.id);
           if (proj) {
             const canUp = canMoveProjectInPinGroup(visibleProjects, proj.id, "up");
             const canDown = canMoveProjectInPinGroup(
@@ -143,7 +178,7 @@ export function buildProjectContextMenuItems(
                 label: tr("sidebar.spaces.moveTo"),
                 icon: <IconQueue size={16} />,
                 children: [
-                  ...projectSpaces.state.spaces.map((space: any) => {
+                  ...projectSpaces.state.spaces.map((space) => {
                     const current =
                       spaceOfProject(projectSpaces.state, proj.id) ===
                       space.id;
@@ -181,7 +216,7 @@ export function buildProjectContextMenuItems(
                         title: tr("sidebar.spaces.newTitle"),
                         initial: "",
                         placeholder: tr("sidebar.spaces.namePlaceholder"),
-                        onSubmit: (value: any) => {
+                        onSubmit: (value) => {
                           const result = projectSpaces.createAndMove(
                             proj.id,
                             value,
@@ -305,7 +340,7 @@ export function buildProjectContextMenuItems(
             ];
           }
         } else if (ctxMenu?.kind === "project-policy") {
-          const proj = projects.find((p: any) => p.id === ctxMenu.id);
+          const proj = projects.find((x) => x.id === ctxMenu.id);
           if (proj && proj.trusted) {
             const current = proj.permissionPolicy?.trim() || null;
             const policyLabel = (id: PermissionPolicyId) =>
@@ -342,7 +377,7 @@ export function buildProjectContextMenuItems(
             ];
           }
         } else if (ctxMenu?.kind === "project-sandbox") {
-          const proj = projects.find((p: any) => p.id === ctxMenu.id);
+          const proj = projects.find((x) => x.id === ctxMenu.id);
           if (proj && proj.trusted) {
             const current =
               normalizeSandboxProfile(proj.sandboxProfile) ?? null;
@@ -371,7 +406,7 @@ export function buildProjectContextMenuItems(
             ];
           }
         } else if (ctxMenu?.kind === "project-color") {
-          const proj = projects.find((p: any) => p.id === ctxMenu.id);
+          const proj = projects.find((x) => x.id === ctxMenu.id);
           if (proj) {
             const current = normalizeProjectColor(proj.color);
             items = [

--- a/src/app/WorkbenchSessionContextMenu.tsx
+++ b/src/app/WorkbenchSessionContextMenu.tsx
@@ -1,19 +1,102 @@
 /**
  * Session / bulk-move sidebar context-menu items.
  */
+import type { Dispatch, RefObject, SetStateAction } from "react";
 import { type ContextMenuItem } from "@/components/ContextMenu";
 import * as api from "@/lib/api";
 import { IconArchive, IconArrowsMinimize, IconBell, IconBellOff, IconChat, IconCheck, IconCircle, IconCopy, IconExportImage, IconExternalLink, IconFiles, IconFolder, IconFork, IconGitBranch, IconList, IconListCheck, IconListNumbers, IconNotes, IconPin, IconPinOff, IconPlan, IconPuzzle, IconRename, IconRewind, IconRobot, IconSettings, IconTrash, IconUpload } from "@/components/icons";
 import { dispatchCollapseAllActivity } from "@/lib/collapseAllActivity";
-import { canRemoveWorktree, pathsEqual } from "@/lib/gitWorktree";
+import { canRemoveWorktree, pathsEqual, type GitWorktreeEntry, type SessionWorktreeBadge } from "@/lib/gitWorktree";
 import { canOpenSessionInNewWindow } from "@/lib/multiWindow";
 import { isSessionExportJournalEmpty, joinSessionExportMenuSuffix, resolveSessionExportPath, sessionExportFormatNameKey, sessionExportMenuSuffixKeys } from "@/lib/sessionExportPro";
 import { normalizeMaxAgentTurns } from "@/lib/sessionMaxAgentTurns";
 import { canOfferResumeWithCodeRestore } from "@/lib/sessionResumeRestore";
 import { sanitizeSystemPromptOverride } from "@/lib/sessionSystemPrompt";
+import { createT } from "@/i18n";
+import type { ChatMessage, SessionSnapshot } from "@/lib/session";
+import { type Project, type SessionRow } from "@/lib/app/sidebarModels";
+import type { ContextMenuState } from "@/lib/app/appDialogTypes";
+import type { StreamSessionExportFormat } from "@/lib/streamSessionExport";
+import type { TranscriptFilterMode } from "@/lib/transcriptFilterPref";
+
+type TFn = ReturnType<typeof createT>;
+
+/** Minimal session identity the export callbacks operate on. */
+export type SessionExportTarget = {
+  id: string;
+  title: string;
+  projectId?: string | null;
+};
 
 export type WorkbenchSessionContextMenuProps = {
-  [key: string]: any;
+  ctxMenu: ContextMenuState;
+  activeProject: Project | null;
+  addSessionPluginDir: (s: SessionRow) => Promise<void>;
+  applyAttachedChat: (id: string, title: string, updatedAt?: string) => void;
+  archiveSession: (s: SessionRow, archived?: boolean) => Promise<void>;
+  bulkMoveMenuItems: (ids: string[]) => ContextMenuItem[];
+  busyIds: Set<string>;
+  canRewindSession: boolean;
+  clearSessionPluginDirs: (s: SessionRow) => Promise<void>;
+  confirmExportSessionTraceUpload: (sessionId?: string | null) => void;
+  confirmForkSession: (source: SessionRow, throughUserPromptIndex?: number | null) => void;
+  confirmRemoveWorktree: (wt: GitWorktreeEntry) => void;
+  confirmResumeWithCodeRestore: (source: SessionRow) => void;
+  copyConversationMarkdown: (sessionMeta?: SessionExportTarget) => Promise<void>;
+  copySessionId: (s: SessionRow) => Promise<void>;
+  deleteSessionConfirm: (s: SessionRow) => void;
+  enterSessionSelectMode: (preselectId?: string) => void;
+  exportSessionDiagnostic: (sessionId?: string | null) => Promise<void>;
+  exportSessionHtml: (sessionMeta?: SessionExportTarget) => Promise<void>;
+  exportSessionJson: (sessionMeta?: SessionExportTarget) => Promise<void>;
+  exportSessionPlain: (sessionMeta?: SessionExportTarget) => Promise<void>;
+  exportSessionStreamNdjson: (
+    format: StreamSessionExportFormat,
+    sessionMeta?: SessionExportTarget,
+  ) => Promise<void>;
+  exportSessionTrace: (
+    sessionId?: string | null,
+    opts?: { localOnly?: boolean },
+  ) => Promise<void>;
+  forkBusy: boolean;
+  gitWorktrees: GitWorktreeEntry[];
+  gitWorktreesAvailable: boolean | null;
+  handleClearAllSessionUnread: () => void;
+  handleClearSessionUnread: (sessionId: string) => void;
+  handleMarkSessionUnread: (sessionId: string) => void;
+  handleToggleSessionMute: (sessionId: string) => void;
+  isSecondaryWindow: boolean;
+  messages: ChatMessage[];
+  moveMenuItemsFor: (row: SessionRow) => ContextMenuItem[];
+  mutedSessionIds: Set<string>;
+  navigator: Navigator;
+  openExportSessionImage: (sessionMeta?: SessionExportTarget) => void;
+  openExportSessionMd: (sessionMeta?: SessionExportTarget) => void;
+  openRewindTimeline: (sessionId: string) => Promise<void>;
+  openSessionInNewWindow: (s: SessionRow) => void;
+  openSessionMaxTurns: (s: SessionRow) => void;
+  openSessionNote: (s: SessionRow) => void;
+  openSessionRules: (s: SessionRow) => void;
+  openSessionSysPrompt: (s: SessionRow) => void;
+  openShipFlow: () => void;
+  pinSession: (s: SessionRow, pinned?: boolean) => Promise<void>;
+  projects: Project[];
+  renameSession: (s: SessionRow) => void;
+  resumeRestoreBusy: boolean;
+  runDuplicateSession: (source: SessionRow) => Promise<void>;
+  session: SessionSnapshot;
+  sessionSelectMode: boolean;
+  sessionWorktreeBadgeFor: (s: SessionRow) => SessionWorktreeBadge | null;
+  sessions: SessionRow[];
+  setLocalError: Dispatch<SetStateAction<string | null>>;
+  setShowPlanHistory: Dispatch<SetStateAction<boolean>>;
+  setShowTraces: Dispatch<SetStateAction<boolean>>;
+  showToast: (msg: string, ms?: number) => void;
+  toggleTranscriptFilter: () => void;
+  transcriptFilter: TranscriptFilterMode;
+  tr: TFn;
+  unreadSessionIds: Set<string>;
+  viewingSessionIdRef: RefObject<string | null>;
 };
 
 export function buildSessionContextMenuItems(
@@ -87,7 +170,7 @@ export function buildSessionContextMenuItems(
         if (ctxMenu?.kind === "session-move") {
           items = bulkMoveMenuItems(ctxMenu.ids);
         } else if (ctxMenu?.kind === "session") {
-          const s = sessions.find((x: any) => x.id === ctxMenu.id);
+          const s = sessions.find((x) => x.id === ctxMenu.id);
           if (s) {
             const isOpen =
               session.sessionId === s.id ||
@@ -245,7 +328,7 @@ export function buildSessionContextMenuItems(
             // Soft-empty honesty for the live session only (other sessions load on demand).
             const liveExportable =
               s.id === session.sessionId
-                ? messages.map((m: any) => ({
+                ? messages.map((m) => ({
                     role: m.role,
                     content: m.content,
                     thought: m.thought,
@@ -493,7 +576,7 @@ export function buildSessionContextMenuItems(
                     danger: true,
                     onClick: () => {
                       const fromList =
-                        gitWorktrees.find((w: any) =>
+                        gitWorktrees.find((w) =>
                           pathsEqual(w.path, wtBadge.path),
                         ) ?? null;
                       const wt: api.GitWorktreeEntry = fromList ?? {
@@ -516,7 +599,7 @@ export function buildSessionContextMenuItems(
 
             const resumeRestoreItem = (() => {
               const proj = s.projectId
-                ? projects.find((p: any) => p.id === s.projectId) ?? null
+                ? projects.find((x) => x.id === s.projectId) ?? null
                 : null;
               const path = proj?.path?.trim() || "";
               const gitKnown =


### PR DESCRIPTION
## Summary
Replaces `WorkbenchChatStage`'s `{ [key: string]: any }` bag with an explicit 91-field Props interface, **inferred from the real call-site types via the TS checker**. This is the chat-surface seam (ConversationThreadLive, plan/status bars, chat find, tasks panel, error banner) — prop typos now fail `tsc` instead of surfacing at runtime as undefined chrome.

Typing surfaced two real shapes worth encoding (both verified against their sources):
- `structuredOutputUsage` is nullable at the source (`… | null`)
- `markSessionWorktree` takes `string | null | undefined` ids per the hook's actual signature

Plus a local `StreamStallView` alias documenting the nullable stall state, and `resolveLocale()` at the `ConversationThreadLive` boundary (it wants `Locale`, the prop is a plain string).

Ratchet: `LOOSE_PROPS_CEILING` 4 → 3.

**Stacked on #1150 → #1151** (gates + floating menus) — the chain keeps each PR one concern.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Refactor / chore

## Checklist
- [x] `pnpm typecheck` / `pnpm test` (641 files) / `lint` / gates / self-test / `build:ui` — all green
- [x] No Rust change
- [x] No user-facing strings / no visual change
- [x] No secrets included