### PR TITLE
refactor(app): extract useGitDirtyStatus from the workbench host

### DIFF
--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -550,12 +550,6 @@ import {
   type SessionFileChange,
 } from "@/lib/sessionChanges";
 
-import {
-  gitDirtySummariesEqual,
-  summarizeGitDirty,
-  type GitDirtySummary,
-} from "@/lib/workspaceGit";
-import { startVisibilityPoll } from "@/lib/visibilityPoll";
 
 const AutomationsPage = lazy(async () => {
   const m = await import("@/components/AutomationsPage");
@@ -683,6 +677,7 @@ import {
   createSessionNavHost,
   useSessionNavigation,
 } from "@/hooks/useSessionNavigation";
+import { useGitDirtyStatus } from "@/hooks/useGitDirtyStatus";
 import { WorkbenchSessionTree } from "@/app/WorkbenchSessionTree";
 import { WorkbenchSidebar } from "@/app/WorkbenchSidebar";
 import { WorkbenchMain } from "@/app/WorkbenchMain";
@@ -979,12 +974,6 @@ export function AppWorkbench() {
   const [sessionChangesById, setSessionChangesById] = useState<
     Record<string, SessionFileChange[]>
   >({});
-  /**
-   * Workspace git dirty summary for the active project (composer chip).
-   * Null when not a repo, unavailable, clean, or no active project.
-   */
-  const [gitDirtySummary, setGitDirtySummary] =
-    useState<GitDirtySummary | null>(null);
   const {
     getDraft,
     setDraft,
@@ -1987,6 +1976,14 @@ export function AppWorkbench() {
   } = useGitWorktreeChrome({
     hostRef: gitWorktreeHostRef,
     projectPath: activeProject?.path ?? null,
+  });
+
+  const { gitDirtySummary } = useGitDirtyStatus({
+    projectPath: activeProject?.path,
+    busy:
+      session.state === "streaming" || session.state === "awaiting_permission",
+    busyKey: session.sessionId,
+    onStatus: applyStatusBranch,
   });
   /** Host stream-stall prompt (I06); null when dismissed or not stalled. */
   const [streamStall, setStreamStall] = useState<{
@@ -9751,60 +9748,6 @@ export function AppWorkbench() {
    * Poll workspace git status for the active project so the composer dirty chip
    * stays current (hide when clean / not a repo). Soft-fail; no toast spam.
    */
-  const gitDirtyReqRef = useRef(0);
-  const refreshGitDirtyStatus = useCallback(async () => {
-    const path = activeProject?.path?.trim() || null;
-    if (!path || !api.isTauri()) {
-      gitDirtyReqRef.current += 1;
-      setGitDirtySummary((prev) => (prev == null ? prev : null));
-      return;
-    }
-    const reqId = ++gitDirtyReqRef.current;
-    try {
-      const status = await api.gitStatus(path);
-      if (reqId !== gitDirtyReqRef.current) return;
-      const next = summarizeGitDirty(status);
-      setGitDirtySummary((prev) =>
-        gitDirtySummariesEqual(prev, next) ? prev : next,
-      );
-      // Same poll already has HEAD. Patch the composer branch chip so an
-      // in-place checkout does not stay stale until the menu is clicked.
-      applyStatusBranch(path, status);
-    } catch {
-      if (reqId !== gitDirtyReqRef.current) return;
-      setGitDirtySummary((prev) => (prev == null ? prev : null));
-    }
-  }, [activeProject?.path, applyStatusBranch]);
-
-  useEffect(() => {
-    void refreshGitDirtyStatus();
-    // Soft poll while a project is bound; refresh sooner on focus.
-    // Faster while a turn is live — agent may `git switch` mid-session.
-    // Ticks pause while the window is hidden — a minimized app has nothing
-    // to paint, and `git status` is a process spawn per poll.
-    const path = activeProject?.path?.trim() || null;
-    if (!path || !api.isTauri()) return;
-    const busy =
-      session.state === "streaming" || session.state === "awaiting_permission";
-    const intervalMs = busy ? 2000 : 8000;
-    const poll = startVisibilityPoll({
-      tick: () => void refreshGitDirtyStatus(),
-      setIntervalFn: (handler) => window.setInterval(handler, intervalMs),
-    });
-    const onFocus = () => {
-      void refreshGitDirtyStatus();
-    };
-    window.addEventListener("focus", onFocus);
-    return () => {
-      poll.dispose();
-      window.removeEventListener("focus", onFocus);
-    };
-  }, [
-    activeProject?.path,
-    refreshGitDirtyStatus,
-    session.sessionId,
-    session.state,
-  ]);
 
   /**
    * After a project is created/updated: refresh list, expand, optionally trust

--- a/src/hooks/useGitDirtyStatus.test.ts
+++ b/src/hooks/useGitDirtyStatus.test.ts
@@ -1,0 +1,74 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useGitDirtyStatus } from "./useGitDirtyStatus";
+
+vi.mock("@/lib/api", () => ({
+  isTauri: () => true,
+  gitStatus: vi.fn(),
+}));
+
+import * as api from "@/lib/api";
+
+const gitStatusMock = vi.mocked(api.gitStatus);
+
+function dirtyFile(path: string) {
+  return { path };
+}
+
+describe("useGitDirtyStatus", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("summarizes dirty files for the bound project", async () => {
+    gitStatusMock.mockResolvedValue({
+      available: true,
+      files: [dirtyFile("src/a.ts"), dirtyFile("src/b.ts")],
+    } as Awaited<ReturnType<typeof api.gitStatus>>);
+    const { result } = renderHook(() =>
+      useGitDirtyStatus({ projectPath: "/repo", busy: false }),
+    );
+    await vi.waitFor(() => {
+      expect(result.current.gitDirtySummary).not.toBeNull();
+    });
+    expect(result.current.gitDirtySummary?.count).toBe(2);
+    expect(result.current.gitDirtySummary?.label).toContain("2");
+  });
+
+  it("clears to null when no project is bound", async () => {
+    const { result } = renderHook(() =>
+      useGitDirtyStatus({ projectPath: null, busy: false }),
+    );
+    await vi.waitFor(() => {
+      expect(result.current.gitDirtySummary).toBeNull();
+    });
+    expect(gitStatusMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps null on soft-fail (repo missing) instead of erroring", async () => {
+    gitStatusMock.mockRejectedValue(new Error("not a repo"));
+    const { result } = renderHook(() =>
+      useGitDirtyStatus({ projectPath: "/repo", busy: false }),
+    );
+    await vi.waitFor(() => {
+      expect(result.current.gitDirtySummary).toBeNull();
+    });
+  });
+
+  it("forwards the raw status to onStatus (branch chip patch)", async () => {
+    const raw = { available: true, files: [dirtyFile("x.ts")] } as Awaited<
+      ReturnType<typeof api.gitStatus>
+    >;
+    gitStatusMock.mockResolvedValue(raw);
+    const onStatus = vi.fn();
+    renderHook(() =>
+      useGitDirtyStatus({ projectPath: "/repo", busy: false, onStatus }),
+    );
+    await vi.waitFor(() => {
+      expect(onStatus).toHaveBeenCalledWith("/repo", raw);
+    });
+  });
+});

--- a/src/hooks/useGitDirtyStatus.ts
+++ b/src/hooks/useGitDirtyStatus.ts
@@ -1,0 +1,92 @@
+/**
+ * Workspace git dirty summary for the active project (composer chip).
+ * Owns its polling lifecycle: soft poll while a project is bound, faster
+ * while a turn is live, refresh on window focus, paused while hidden.
+ *
+ * Extracted from AppWorkbench (WP: knowledge hiding — the host only needs
+ * the summary value; the poll cadence is this hook's business).
+ */
+import { useCallback, useEffect, useRef, useState } from "react";
+import * as api from "@/lib/api";
+import { startVisibilityPoll } from "@/lib/visibilityPoll";
+import {
+  gitDirtySummariesEqual,
+  summarizeGitDirty,
+  type GitDirtySummary,
+} from "@/lib/workspaceGit";
+
+export type GitStatusBranchPatch = (
+  path: string,
+  status: Awaited<ReturnType<typeof api.gitStatus>>,
+) => void;
+
+export function useGitDirtyStatus(opts: {
+  /** Absolute path of the active project; null when none. */
+  projectPath: string | null | undefined;
+  /** True while a turn is streaming / awaiting permission (faster poll). */
+  busy: boolean;
+  /**
+   * Side-channel: the same poll already fetched HEAD, so the composer
+   * branch chip can be patched without another spawn.
+   */
+  onStatus?: GitStatusBranchPatch;
+  /** Change key for busy (e.g. session id) to re-arm the poll cadence. */
+  busyKey?: string | number | null;
+}) {
+  const { projectPath, busy, onStatus, busyKey } = opts;
+  const onStatusRef = useRef(onStatus);
+  onStatusRef.current = onStatus;
+
+  /** Null when not a repo, unavailable, clean, or no active project. */
+  const [gitDirtySummary, setGitDirtySummary] = useState<GitDirtySummary | null>(
+    null,
+  );
+  const reqRef = useRef(0);
+
+  const refresh = useCallback(async () => {
+    const path = projectPath?.trim() || null;
+    if (!path || !api.isTauri()) {
+      reqRef.current += 1;
+      setGitDirtySummary((prev) => (prev == null ? prev : null));
+      return;
+    }
+    const reqId = ++reqRef.current;
+    try {
+      const status = await api.gitStatus(path);
+      if (reqId !== reqRef.current) return;
+      const next = summarizeGitDirty(status);
+      setGitDirtySummary((prev) =>
+        gitDirtySummariesEqual(prev, next) ? prev : next,
+      );
+      onStatusRef.current?.(path, status);
+    } catch {
+      if (reqId !== reqRef.current) return;
+      setGitDirtySummary((prev) => (prev == null ? prev : null));
+    }
+  }, [projectPath]);
+
+  useEffect(() => {
+    void refresh();
+    // Soft poll while a project is bound; refresh sooner on focus.
+    // Faster while a turn is live — agent may `git switch` mid-session.
+    // Ticks pause while the window is hidden — a minimized app has nothing
+    // to paint, and `git status` is a process spawn per poll.
+    const path = projectPath?.trim() || null;
+    if (!path || !api.isTauri()) return;
+    const intervalMs = busy ? 2000 : 8000;
+    const poll = startVisibilityPoll({
+      tick: () => void refresh(),
+      setIntervalFn: (handler) => window.setInterval(handler, intervalMs),
+    });
+    const onFocus = () => {
+      void refresh();
+    };
+    window.addEventListener("focus", onFocus);
+    return () => {
+      poll.dispose();
+      window.removeEventListener("focus", onFocus);
+    };
+  }, [projectPath, refresh, busy, busyKey]);
+
+  return { gitDirtySummary, refreshGitDirtyStatus: refresh };
+}


### PR DESCRIPTION
## Summary
The git-dirty cluster — state, request dedup (`gitDirtyReqRef`), the visibility-gated poll cadence (2s while a turn is live / 8s idle), and window-focus refresh — lived inline in AppWorkbench even though the host only consumes the summary value for two prop pass-throughs (`WorkbenchMain` dirty chip, `WorkbenchComposerColumn` chip). One of the handoff doc's admitted knowledge-not-hidden leftovers.

Extracted to `src/hooks/useGitDirtyStatus.ts` with **4 new tests** (summary aggregation, no-project null, soft-fail null, `onStatus` branch-chip forwarding). The host now passes `projectPath` + `busy` and reads one value — **AppWorkbench: −57 net lines** (13,640), headroom for the remaining extraction PRs under the frozen ceiling.

Behavior identical: same poll cadences, same hidden-pause semantics, same request-dedup, same soft-fail-to-null, same composer branch-chip patch via the `onStatus` side-channel.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Refactor / chore

## Checklist
- [x] `pnpm typecheck` / `pnpm test` (642 files incl. the 4 new hook tests) / `lint` / gates / self-test / `build:ui` — all green
- [x] No Rust change
- [x] No user-facing strings / no visual change
- [x] No secrets included