### PR TITLE
refactor(app): extract useSessionFileChanges from the workbench host

### DIFF
--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -543,11 +543,9 @@ import { resolveSidePathDeepLink } from "@/lib/sidePathDeepLink";
 import { WorkbenchAppDialogStage } from "@/app/WorkbenchAppDialogStage";
 import { WorkbenchComposerModals } from "@/app/WorkbenchComposerModals";
 import {
-  EMPTY_SESSION_FILE_CHANGES,
   mergeSessionChange,
   sessionChangesFromMessages,
   summarizeSessionChanges,
-  type SessionFileChange,
 } from "@/lib/sessionChanges";
 
 
@@ -678,6 +676,7 @@ import {
   useSessionNavigation,
 } from "@/hooks/useSessionNavigation";
 import { useGitDirtyStatus } from "@/hooks/useGitDirtyStatus";
+import { useSessionFileChanges } from "@/hooks/useSessionFileChanges";
 import { WorkbenchSessionTree } from "@/app/WorkbenchSessionTree";
 import { WorkbenchSidebar } from "@/app/WorkbenchSidebar";
 import { WorkbenchMain } from "@/app/WorkbenchMain";
@@ -971,9 +970,8 @@ export function AppWorkbench() {
    * Files written/edited by agent tools per session (Changes / diff panel).
    * Live tool events may enrich entries with before/after snippets.
    */
-  const [sessionChangesById, setSessionChangesById] = useState<
-    Record<string, SessionFileChange[]>
-  >({});
+  const { sessionChangesById, setSessionChangesById, changesFor } =
+    useSessionFileChanges();
   const {
     getDraft,
     setDraft,
@@ -8872,10 +8870,7 @@ export function AppWorkbench() {
   /** Session file-changes chip (+/− or N files); hidden when empty. */
   const sessionChangesSummary = useMemo(() => {
     const sid = session.sessionId || "";
-    const list = sid
-      ? (sessionChangesById[sid] ?? EMPTY_SESSION_FILE_CHANGES)
-      : EMPTY_SESSION_FILE_CHANGES;
-    return summarizeSessionChanges(list);
+    return summarizeSessionChanges(changesFor(sid));
   }, [session.sessionId, sessionChangesById]);
 
   // Reset find when switching conversation (keep open across same session).
@@ -12761,10 +12756,7 @@ export function AppWorkbench() {
             retryAgentConnect={retryAgentConnect}
             runErrorBannerAction={runErrorBannerAction}
             session={session}
-            sessionChanges={
-              sessionChangesById[session.sessionId || ""] ??
-              EMPTY_SESSION_FILE_CHANGES
-            }
+            sessionChanges={changesFor(session.sessionId || "")}
             sessionJsonSchema={sessionJsonSchema}
             sessionTranscriptStore={sessionTranscriptStore}
             sessions={sessions}
@@ -13043,11 +13035,9 @@ export function AppWorkbench() {
           setSideWorkbench={setSideWorkbench}
           sideDockComposer={sideDockComposer}
           onToggleSideDockComposer={toggleDockComposer}
-          sessionChanges={
-            sessionChangesById[reviewSessionId] ??
-            sessionChangesById[session.sessionId || ""] ??
-            EMPTY_SESSION_FILE_CHANGES
-          }
+          sessionChanges={changesFor(
+            reviewSessionId ?? (session.sessionId || ""),
+          )}
           reviewFocusPath={reviewFocus?.path ?? null}
           reviewFocusToken={reviewFocus?.token ?? 0}
           reviewPinnedPaths={reviewFocus?.pinnedPaths ?? []}

--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -550,12 +550,6 @@ import {
   type SessionFileChange,
 } from "@/lib/sessionChanges";
 
-import {
-  gitDirtySummariesEqual,
-  summarizeGitDirty,
-  type GitDirtySummary,
-} from "@/lib/workspaceGit";
-import { startVisibilityPoll } from "@/lib/visibilityPoll";
 
 const AutomationsPage = lazy(async () => {
   const m = await import("@/components/AutomationsPage");
@@ -683,6 +677,7 @@ import {
   createSessionNavHost,
   useSessionNavigation,
 } from "@/hooks/useSessionNavigation";
+import { useGitDirtyStatus } from "@/hooks/useGitDirtyStatus";
 import { WorkbenchSessionTree } from "@/app/WorkbenchSessionTree";
 import { WorkbenchSidebar } from "@/app/WorkbenchSidebar";
 import { WorkbenchMain } from "@/app/WorkbenchMain";
@@ -979,12 +974,6 @@ export function AppWorkbench() {
   const [sessionChangesById, setSessionChangesById] = useState<
     Record<string, SessionFileChange[]>
   >({});
-  /**
-   * Workspace git dirty summary for the active project (composer chip).
-   * Null when not a repo, unavailable, clean, or no active project.
-   */
-  const [gitDirtySummary, setGitDirtySummary] =
-    useState<GitDirtySummary | null>(null);
   const {
     getDraft,
     setDraft,
@@ -1987,6 +1976,14 @@ export function AppWorkbench() {
   } = useGitWorktreeChrome({
     hostRef: gitWorktreeHostRef,
     projectPath: activeProject?.path ?? null,
+  });
+
+  const { gitDirtySummary } = useGitDirtyStatus({
+    projectPath: activeProject?.path,
+    busy:
+      session.state === "streaming" || session.state === "awaiting_permission",
+    busyKey: session.sessionId,
+    onStatus: applyStatusBranch,
   });
   /** Host stream-stall prompt (I06); null when dismissed or not stalled. */
   const [streamStall, setStreamStall] = useState<{
@@ -9751,60 +9748,6 @@ export function AppWorkbench() {
    * Poll workspace git status for the active project so the composer dirty chip
    * stays current (hide when clean / not a repo). Soft-fail; no toast spam.
    */
-  const gitDirtyReqRef = useRef(0);
-  const refreshGitDirtyStatus = useCallback(async () => {
-    const path = activeProject?.path?.trim() || null;
-    if (!path || !api.isTauri()) {
-      gitDirtyReqRef.current += 1;
-      setGitDirtySummary((prev) => (prev == null ? prev : null));
-      return;
-    }
-    const reqId = ++gitDirtyReqRef.current;
-    try {
-      const status = await api.gitStatus(path);
-      if (reqId !== gitDirtyReqRef.current) return;
-      const next = summarizeGitDirty(status);
-      setGitDirtySummary((prev) =>
-        gitDirtySummariesEqual(prev, next) ? prev : next,
-      );
-      // Same poll already has HEAD. Patch the composer branch chip so an
-      // in-place checkout does not stay stale until the menu is clicked.
-      applyStatusBranch(path, status);
-    } catch {
-      if (reqId !== gitDirtyReqRef.current) return;
-      setGitDirtySummary((prev) => (prev == null ? prev : null));
-    }
-  }, [activeProject?.path, applyStatusBranch]);
-
-  useEffect(() => {
-    void refreshGitDirtyStatus();
-    // Soft poll while a project is bound; refresh sooner on focus.
-    // Faster while a turn is live — agent may `git switch` mid-session.
-    // Ticks pause while the window is hidden — a minimized app has nothing
-    // to paint, and `git status` is a process spawn per poll.
-    const path = activeProject?.path?.trim() || null;
-    if (!path || !api.isTauri()) return;
-    const busy =
-      session.state === "streaming" || session.state === "awaiting_permission";
-    const intervalMs = busy ? 2000 : 8000;
-    const poll = startVisibilityPoll({
-      tick: () => void refreshGitDirtyStatus(),
-      setIntervalFn: (handler) => window.setInterval(handler, intervalMs),
-    });
-    const onFocus = () => {
-      void refreshGitDirtyStatus();
-    };
-    window.addEventListener("focus", onFocus);
-    return () => {
-      poll.dispose();
-      window.removeEventListener("focus", onFocus);
-    };
-  }, [
-    activeProject?.path,
-    refreshGitDirtyStatus,
-    session.sessionId,
-    session.state,
-  ]);
 
   /**
    * After a project is created/updated: refresh list, expand, optionally trust

--- a/src/hooks/useGitDirtyStatus.test.ts
+++ b/src/hooks/useGitDirtyStatus.test.ts
@@ -1,0 +1,74 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useGitDirtyStatus } from "./useGitDirtyStatus";
+
+vi.mock("@/lib/api", () => ({
+  isTauri: () => true,
+  gitStatus: vi.fn(),
+}));
+
+import * as api from "@/lib/api";
+
+const gitStatusMock = vi.mocked(api.gitStatus);
+
+function dirtyFile(path: string) {
+  return { path };
+}
+
+describe("useGitDirtyStatus", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("summarizes dirty files for the bound project", async () => {
+    gitStatusMock.mockResolvedValue({
+      available: true,
+      files: [dirtyFile("src/a.ts"), dirtyFile("src/b.ts")],
+    } as Awaited<ReturnType<typeof api.gitStatus>>);
+    const { result } = renderHook(() =>
+      useGitDirtyStatus({ projectPath: "/repo", busy: false }),
+    );
+    await vi.waitFor(() => {
+      expect(result.current.gitDirtySummary).not.toBeNull();
+    });
+    expect(result.current.gitDirtySummary?.count).toBe(2);
+    expect(result.current.gitDirtySummary?.label).toContain("2");
+  });
+
+  it("clears to null when no project is bound", async () => {
+    const { result } = renderHook(() =>
+      useGitDirtyStatus({ projectPath: null, busy: false }),
+    );
+    await vi.waitFor(() => {
+      expect(result.current.gitDirtySummary).toBeNull();
+    });
+    expect(gitStatusMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps null on soft-fail (repo missing) instead of erroring", async () => {
+    gitStatusMock.mockRejectedValue(new Error("not a repo"));
+    const { result } = renderHook(() =>
+      useGitDirtyStatus({ projectPath: "/repo", busy: false }),
+    );
+    await vi.waitFor(() => {
+      expect(result.current.gitDirtySummary).toBeNull();
+    });
+  });
+
+  it("forwards the raw status to onStatus (branch chip patch)", async () => {
+    const raw = { available: true, files: [dirtyFile("x.ts")] } as Awaited<
+      ReturnType<typeof api.gitStatus>
+    >;
+    gitStatusMock.mockResolvedValue(raw);
+    const onStatus = vi.fn();
+    renderHook(() =>
+      useGitDirtyStatus({ projectPath: "/repo", busy: false, onStatus }),
+    );
+    await vi.waitFor(() => {
+      expect(onStatus).toHaveBeenCalledWith("/repo", raw);
+    });
+  });
+});

--- a/src/hooks/useGitDirtyStatus.ts
+++ b/src/hooks/useGitDirtyStatus.ts
@@ -1,0 +1,92 @@
+/**
+ * Workspace git dirty summary for the active project (composer chip).
+ * Owns its polling lifecycle: soft poll while a project is bound, faster
+ * while a turn is live, refresh on window focus, paused while hidden.
+ *
+ * Extracted from AppWorkbench (WP: knowledge hiding — the host only needs
+ * the summary value; the poll cadence is this hook's business).
+ */
+import { useCallback, useEffect, useRef, useState } from "react";
+import * as api from "@/lib/api";
+import { startVisibilityPoll } from "@/lib/visibilityPoll";
+import {
+  gitDirtySummariesEqual,
+  summarizeGitDirty,
+  type GitDirtySummary,
+} from "@/lib/workspaceGit";
+
+export type GitStatusBranchPatch = (
+  path: string,
+  status: Awaited<ReturnType<typeof api.gitStatus>>,
+) => void;
+
+export function useGitDirtyStatus(opts: {
+  /** Absolute path of the active project; null when none. */
+  projectPath: string | null | undefined;
+  /** True while a turn is streaming / awaiting permission (faster poll). */
+  busy: boolean;
+  /**
+   * Side-channel: the same poll already fetched HEAD, so the composer
+   * branch chip can be patched without another spawn.
+   */
+  onStatus?: GitStatusBranchPatch;
+  /** Change key for busy (e.g. session id) to re-arm the poll cadence. */
+  busyKey?: string | number | null;
+}) {
+  const { projectPath, busy, onStatus, busyKey } = opts;
+  const onStatusRef = useRef(onStatus);
+  onStatusRef.current = onStatus;
+
+  /** Null when not a repo, unavailable, clean, or no active project. */
+  const [gitDirtySummary, setGitDirtySummary] = useState<GitDirtySummary | null>(
+    null,
+  );
+  const reqRef = useRef(0);
+
+  const refresh = useCallback(async () => {
+    const path = projectPath?.trim() || null;
+    if (!path || !api.isTauri()) {
+      reqRef.current += 1;
+      setGitDirtySummary((prev) => (prev == null ? prev : null));
+      return;
+    }
+    const reqId = ++reqRef.current;
+    try {
+      const status = await api.gitStatus(path);
+      if (reqId !== reqRef.current) return;
+      const next = summarizeGitDirty(status);
+      setGitDirtySummary((prev) =>
+        gitDirtySummariesEqual(prev, next) ? prev : next,
+      );
+      onStatusRef.current?.(path, status);
+    } catch {
+      if (reqId !== reqRef.current) return;
+      setGitDirtySummary((prev) => (prev == null ? prev : null));
+    }
+  }, [projectPath]);
+
+  useEffect(() => {
+    void refresh();
+    // Soft poll while a project is bound; refresh sooner on focus.
+    // Faster while a turn is live — agent may `git switch` mid-session.
+    // Ticks pause while the window is hidden — a minimized app has nothing
+    // to paint, and `git status` is a process spawn per poll.
+    const path = projectPath?.trim() || null;
+    if (!path || !api.isTauri()) return;
+    const intervalMs = busy ? 2000 : 8000;
+    const poll = startVisibilityPoll({
+      tick: () => void refresh(),
+      setIntervalFn: (handler) => window.setInterval(handler, intervalMs),
+    });
+    const onFocus = () => {
+      void refresh();
+    };
+    window.addEventListener("focus", onFocus);
+    return () => {
+      poll.dispose();
+      window.removeEventListener("focus", onFocus);
+    };
+  }, [projectPath, refresh, busy, busyKey]);
+
+  return { gitDirtySummary, refreshGitDirtyStatus: refresh };
+}

--- a/src/hooks/useSessionFileChanges.test.ts
+++ b/src/hooks/useSessionFileChanges.test.ts
@@ -1,0 +1,62 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { useSessionFileChanges } from "./useSessionFileChanges";
+import type { SessionFileChange } from "@/lib/sessionChanges";
+
+function change(path: string): SessionFileChange {
+  return {
+    toolCallId: "tc",
+    toolKind: "write",
+    status: "completed",
+    path,
+    name: path,
+    before: undefined,
+    after: "x",
+    updatedAt: "2026-09-10T00:00:00Z",
+  };
+}
+
+describe("useSessionFileChanges", () => {
+  it("returns an empty list for unknown sessions", () => {
+    const { result } = renderHook(() => useSessionFileChanges());
+    expect(result.current.changesFor("nope")).toEqual([]);
+  });
+
+  it("returns an empty list for null / empty session ids", () => {
+    const { result } = renderHook(() => useSessionFileChanges());
+    expect(result.current.changesFor(null)).toEqual([]);
+    expect(result.current.changesFor("")).toEqual([]);
+  });
+
+  it("returns recorded changes per session id", () => {
+    const { result } = renderHook(() => useSessionFileChanges());
+    act(() => {
+      result.current.setSessionChangesById((prev) => ({
+        ...prev,
+        "s1": [change("a.ts")],
+        "s2": [change("b.ts"), change("c.ts")],
+      }));
+    });
+    expect(result.current.changesFor("s1")).toHaveLength(1);
+    expect(result.current.changesFor("s2")).toHaveLength(2);
+    expect(result.current.changesFor("s3")).toEqual([]);
+  });
+
+  it("keeps other sessions intact when one is updated", () => {
+    const { result } = renderHook(() => useSessionFileChanges());
+    act(() => {
+      result.current.setSessionChangesById(() => ({ s1: [change("a.ts")] }));
+    });
+    act(() => {
+      result.current.setSessionChangesById((prev) => ({
+        ...prev,
+        s2: [change("b.ts")],
+      }));
+    });
+    expect(result.current.changesFor("s1")).toHaveLength(1);
+    expect(result.current.changesFor("s2")).toHaveLength(1);
+  });
+});

--- a/src/hooks/useSessionFileChanges.ts
+++ b/src/hooks/useSessionFileChanges.ts
@@ -1,0 +1,33 @@
+/**
+ * Per-session file-change records (Review panel / dirty-chip data source).
+ *
+ * Writers: the host-event layer (`session://tool` batch apply via ctx) and
+ * journal hydration (`host.hydrate.applyOpenResult` + Review seeding).
+ * Readers: chat stage, resources aside, and the dirty-chip summary — all
+ * through `changesFor`, which owns the empty-list fallback.
+ *
+ * Extracted from AppWorkbench (WP: knowledge hiding — the host only routes
+ * writers and readers; the record shape and fallback are this hook's business).
+ */
+import { useCallback, useState } from "react";
+import {
+  EMPTY_SESSION_FILE_CHANGES,
+  type SessionFileChange,
+} from "@/lib/sessionChanges";
+
+export function useSessionFileChanges() {
+  const [sessionChangesById, setSessionChangesById] = useState<
+    Record<string, SessionFileChange[]>
+  >({});
+
+  /** Changes recorded for a session; empty list when none recorded. */
+  const changesFor = useCallback(
+    (sessionId: string | null | undefined): SessionFileChange[] =>
+      sessionId
+        ? (sessionChangesById[sessionId] ?? EMPTY_SESSION_FILE_CHANGES)
+        : EMPTY_SESSION_FILE_CHANGES,
+    [sessionChangesById],
+  );
+
+  return { sessionChangesById, setSessionChangesById, changesFor };
+}


### PR DESCRIPTION
## Summary
The per-session file-change record (Review panel / dirty-chip data source) was a bare `useState` on the host with **three reader sites each re-implementing the lookup-with-empty-fallback pattern** (`sessionChangesById[sid] ?? EMPTY_SESSION_FILE_CHANGES`). One of the handoff doc's admitted knowledge-not-hidden leftovers.

Extracted to [`src/hooks/useSessionFileChanges.ts`](src/hooks/useSessionFileChanges.ts) with a `changesFor(sessionId)` accessor that owns the fallback, plus **4 tests** (unknown session, null/empty ids, per-session records, isolation across updates). Writers (host-event tool batch apply, journal hydration, Review seeding) keep the same setter; the three readers (chat stage, dirty-chip summary, resources aside) now share the one accessor.

**Stacked on #1160** (the git-dirty extraction; both are the host-state extraction series).

## Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Refactor / chore

## Checklist
- [x] `pnpm typecheck` / `pnpm test` (643 files incl. the 4 new hook tests) / `lint` / gates / self-test / `build:ui` — all green
- [x] No Rust change
- [x] No user-facing strings / no visual change
- [x] No secrets included