### PR TITLE
fix(session): route error-banner actions through a table; fix stale deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ See `docs/llm-wiki/release.md`.
 ### Fixed
 - Math formulas render with one matching KaTeX version again. The bundled CSS had drifted ahead of the JS.
 - Wallpaper no longer flashes black while streaming or following the chat tail.
+- Reconnect from the error banner always uses the latest connection state.
 - Imagine portrait thumbnails stay contained when the wallpaper window narrows.
 - What's New now lists every entry; some were cut off before.
 - Generated wallpaper stays visible when library indexing fails and can be saved again.
@@ -29,6 +30,7 @@ See `docs/llm-wiki/release.md`.
 **中文 · 修复**
 - 数学公式恢复 CSS 与 JS 同版本渲染，不再出现样式超前于脚本。
 - 流式输出和自动跟随聊天底部时，静态及动态壁纸不再闪黑。
+- 错误横幅上的重连始终使用最新的连接状态。
 - 壁纸窗口缩小时，Imagine 纵向缩略图不再挤压错位。
 - 「新功能」弹窗不再漏掉部分条目。
 - 生成壁纸在图库索引失败时仍会显示，并可直接重试保存。

--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -677,6 +677,7 @@ import {
 } from "@/hooks/useSessionNavigation";
 import { useGitDirtyStatus } from "@/hooks/useGitDirtyStatus";
 import { useSessionFileChanges } from "@/hooks/useSessionFileChanges";
+import { ERROR_BANNER_SETTINGS_ROUTE, isErrorBannerDismissOnly } from "@/lib/errorBannerActions";
 import { WorkbenchSessionTree } from "@/app/WorkbenchSessionTree";
 import { WorkbenchSidebar } from "@/app/WorkbenchSidebar";
 import { WorkbenchMain } from "@/app/WorkbenchMain";
@@ -10954,43 +10955,21 @@ export function AppWorkbench() {
   const runErrorBannerAction = useCallback(
     (action: NonNullable<ErrorBannerView["primary"]>) => {
       setErrorDetailOpen(false);
-      switch (action.id) {
+      const { id } = action;
+      // Settings navigation: data-driven from the routing table.
+      const route = ERROR_BANNER_SETTINGS_ROUTE[id];
+      if (route) {
+        setLocalError(null);
+        navigateSettings(route.section, route.tab);
+        return;
+      }
+      switch (id) {
         case "reconnect":
           retryAgentConnect();
           break;
         case "open_doctor":
           setLocalError(null);
           openDoctor();
-          break;
-        case "open_runtime":
-          setLocalError(null);
-          navigateSettings("runtime");
-          break;
-        case "upgrade_cli":
-          setLocalError(null);
-          navigateSettings("runtime");
-          break;
-        case "open_network":
-          setLocalError(null);
-          navigateSettings("runtime", "network");
-          break;
-        case "open_account":
-          setLocalError(null);
-          navigateSettings("account");
-          break;
-        case "open_providers":
-          setLocalError(null);
-          // Providers live under account / extensions path — account is the
-          // login+key surface; extensions holds MCP. Prefer account for keys.
-          navigateSettings("account");
-          break;
-        case "open_permissions":
-          setLocalError(null);
-          navigateSettings("general", "permissions");
-          break;
-        case "open_extensions":
-          setLocalError(null);
-          navigateSettings("extensions");
           break;
         case "open_mcp":
           setLocalError(null);
@@ -11008,27 +10987,25 @@ export function AppWorkbench() {
           setLocalError(null);
           void addProject(false);
           break;
-        case "dismiss":
-        case "keep_waiting":
-          // keep_waiting is for the stream-stall banner (clears prompt only).
-          setLocalError(null);
-          break;
         case "cancel_turn":
           setLocalError(null);
           void stop();
           break;
         default:
+          // dismiss / keep_waiting: clear the banner (keep_waiting is the
+          // stream-stall prompt — clears the prompt, keeps the turn).
+          if (isErrorBannerDismissOnly(id)) setLocalError(null);
           break;
       }
     },
     [
       activeProject,
       addProject,
-      ensureConnected,
       navigateSettings,
       openDoctor,
       openMcpModal,
       relocateProject,
+      retryAgentConnect,
       stop,
       trustProject,
     ],

--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -543,11 +543,9 @@ import { resolveSidePathDeepLink } from "@/lib/sidePathDeepLink";
 import { WorkbenchAppDialogStage } from "@/app/WorkbenchAppDialogStage";
 import { WorkbenchComposerModals } from "@/app/WorkbenchComposerModals";
 import {
-  EMPTY_SESSION_FILE_CHANGES,
   mergeSessionChange,
   sessionChangesFromMessages,
   summarizeSessionChanges,
-  type SessionFileChange,
 } from "@/lib/sessionChanges";
 
 
@@ -678,6 +676,7 @@ import {
   useSessionNavigation,
 } from "@/hooks/useSessionNavigation";
 import { useGitDirtyStatus } from "@/hooks/useGitDirtyStatus";
+import { useSessionFileChanges } from "@/hooks/useSessionFileChanges";
 import { WorkbenchSessionTree } from "@/app/WorkbenchSessionTree";
 import { WorkbenchSidebar } from "@/app/WorkbenchSidebar";
 import { WorkbenchMain } from "@/app/WorkbenchMain";
@@ -971,9 +970,8 @@ export function AppWorkbench() {
    * Files written/edited by agent tools per session (Changes / diff panel).
    * Live tool events may enrich entries with before/after snippets.
    */
-  const [sessionChangesById, setSessionChangesById] = useState<
-    Record<string, SessionFileChange[]>
-  >({});
+  const { sessionChangesById, setSessionChangesById, changesFor } =
+    useSessionFileChanges();
   const {
     getDraft,
     setDraft,
@@ -8872,10 +8870,7 @@ export function AppWorkbench() {
   /** Session file-changes chip (+/− or N files); hidden when empty. */
   const sessionChangesSummary = useMemo(() => {
     const sid = session.sessionId || "";
-    const list = sid
-      ? (sessionChangesById[sid] ?? EMPTY_SESSION_FILE_CHANGES)
-      : EMPTY_SESSION_FILE_CHANGES;
-    return summarizeSessionChanges(list);
+    return summarizeSessionChanges(changesFor(sid));
   }, [session.sessionId, sessionChangesById]);
 
   // Reset find when switching conversation (keep open across same session).
@@ -12761,10 +12756,7 @@ export function AppWorkbench() {
             retryAgentConnect={retryAgentConnect}
             runErrorBannerAction={runErrorBannerAction}
             session={session}
-            sessionChanges={
-              sessionChangesById[session.sessionId || ""] ??
-              EMPTY_SESSION_FILE_CHANGES
-            }
+            sessionChanges={changesFor(session.sessionId || "")}
             sessionJsonSchema={sessionJsonSchema}
             sessionTranscriptStore={sessionTranscriptStore}
             sessions={sessions}
@@ -13043,11 +13035,9 @@ export function AppWorkbench() {
           setSideWorkbench={setSideWorkbench}
           sideDockComposer={sideDockComposer}
           onToggleSideDockComposer={toggleDockComposer}
-          sessionChanges={
-            sessionChangesById[reviewSessionId] ??
-            sessionChangesById[session.sessionId || ""] ??
-            EMPTY_SESSION_FILE_CHANGES
-          }
+          sessionChanges={changesFor(
+            reviewSessionId ?? (session.sessionId || ""),
+          )}
           reviewFocusPath={reviewFocus?.path ?? null}
           reviewFocusToken={reviewFocus?.token ?? 0}
           reviewPinnedPaths={reviewFocus?.pinnedPaths ?? []}

--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -550,12 +550,6 @@ import {
   type SessionFileChange,
 } from "@/lib/sessionChanges";
 
-import {
-  gitDirtySummariesEqual,
-  summarizeGitDirty,
-  type GitDirtySummary,
-} from "@/lib/workspaceGit";
-import { startVisibilityPoll } from "@/lib/visibilityPoll";
 
 const AutomationsPage = lazy(async () => {
   const m = await import("@/components/AutomationsPage");
@@ -683,6 +677,7 @@ import {
   createSessionNavHost,
   useSessionNavigation,
 } from "@/hooks/useSessionNavigation";
+import { useGitDirtyStatus } from "@/hooks/useGitDirtyStatus";
 import { WorkbenchSessionTree } from "@/app/WorkbenchSessionTree";
 import { WorkbenchSidebar } from "@/app/WorkbenchSidebar";
 import { WorkbenchMain } from "@/app/WorkbenchMain";
@@ -979,12 +974,6 @@ export function AppWorkbench() {
   const [sessionChangesById, setSessionChangesById] = useState<
     Record<string, SessionFileChange[]>
   >({});
-  /**
-   * Workspace git dirty summary for the active project (composer chip).
-   * Null when not a repo, unavailable, clean, or no active project.
-   */
-  const [gitDirtySummary, setGitDirtySummary] =
-    useState<GitDirtySummary | null>(null);
   const {
     getDraft,
     setDraft,
@@ -1987,6 +1976,14 @@ export function AppWorkbench() {
   } = useGitWorktreeChrome({
     hostRef: gitWorktreeHostRef,
     projectPath: activeProject?.path ?? null,
+  });
+
+  const { gitDirtySummary } = useGitDirtyStatus({
+    projectPath: activeProject?.path,
+    busy:
+      session.state === "streaming" || session.state === "awaiting_permission",
+    busyKey: session.sessionId,
+    onStatus: applyStatusBranch,
   });
   /** Host stream-stall prompt (I06); null when dismissed or not stalled. */
   const [streamStall, setStreamStall] = useState<{
@@ -9751,60 +9748,6 @@ export function AppWorkbench() {
    * Poll workspace git status for the active project so the composer dirty chip
    * stays current (hide when clean / not a repo). Soft-fail; no toast spam.
    */
-  const gitDirtyReqRef = useRef(0);
-  const refreshGitDirtyStatus = useCallback(async () => {
-    const path = activeProject?.path?.trim() || null;
-    if (!path || !api.isTauri()) {
-      gitDirtyReqRef.current += 1;
-      setGitDirtySummary((prev) => (prev == null ? prev : null));
-      return;
-    }
-    const reqId = ++gitDirtyReqRef.current;
-    try {
-      const status = await api.gitStatus(path);
-      if (reqId !== gitDirtyReqRef.current) return;
-      const next = summarizeGitDirty(status);
-      setGitDirtySummary((prev) =>
-        gitDirtySummariesEqual(prev, next) ? prev : next,
-      );
-      // Same poll already has HEAD. Patch the composer branch chip so an
-      // in-place checkout does not stay stale until the menu is clicked.
-      applyStatusBranch(path, status);
-    } catch {
-      if (reqId !== gitDirtyReqRef.current) return;
-      setGitDirtySummary((prev) => (prev == null ? prev : null));
-    }
-  }, [activeProject?.path, applyStatusBranch]);
-
-  useEffect(() => {
-    void refreshGitDirtyStatus();
-    // Soft poll while a project is bound; refresh sooner on focus.
-    // Faster while a turn is live — agent may `git switch` mid-session.
-    // Ticks pause while the window is hidden — a minimized app has nothing
-    // to paint, and `git status` is a process spawn per poll.
-    const path = activeProject?.path?.trim() || null;
-    if (!path || !api.isTauri()) return;
-    const busy =
-      session.state === "streaming" || session.state === "awaiting_permission";
-    const intervalMs = busy ? 2000 : 8000;
-    const poll = startVisibilityPoll({
-      tick: () => void refreshGitDirtyStatus(),
-      setIntervalFn: (handler) => window.setInterval(handler, intervalMs),
-    });
-    const onFocus = () => {
-      void refreshGitDirtyStatus();
-    };
-    window.addEventListener("focus", onFocus);
-    return () => {
-      poll.dispose();
-      window.removeEventListener("focus", onFocus);
-    };
-  }, [
-    activeProject?.path,
-    refreshGitDirtyStatus,
-    session.sessionId,
-    session.state,
-  ]);
 
   /**
    * After a project is created/updated: refresh list, expand, optionally trust

--- a/src/hooks/useGitDirtyStatus.test.ts
+++ b/src/hooks/useGitDirtyStatus.test.ts
@@ -1,0 +1,74 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useGitDirtyStatus } from "./useGitDirtyStatus";
+
+vi.mock("@/lib/api", () => ({
+  isTauri: () => true,
+  gitStatus: vi.fn(),
+}));
+
+import * as api from "@/lib/api";
+
+const gitStatusMock = vi.mocked(api.gitStatus);
+
+function dirtyFile(path: string) {
+  return { path };
+}
+
+describe("useGitDirtyStatus", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("summarizes dirty files for the bound project", async () => {
+    gitStatusMock.mockResolvedValue({
+      available: true,
+      files: [dirtyFile("src/a.ts"), dirtyFile("src/b.ts")],
+    } as Awaited<ReturnType<typeof api.gitStatus>>);
+    const { result } = renderHook(() =>
+      useGitDirtyStatus({ projectPath: "/repo", busy: false }),
+    );
+    await vi.waitFor(() => {
+      expect(result.current.gitDirtySummary).not.toBeNull();
+    });
+    expect(result.current.gitDirtySummary?.count).toBe(2);
+    expect(result.current.gitDirtySummary?.label).toContain("2");
+  });
+
+  it("clears to null when no project is bound", async () => {
+    const { result } = renderHook(() =>
+      useGitDirtyStatus({ projectPath: null, busy: false }),
+    );
+    await vi.waitFor(() => {
+      expect(result.current.gitDirtySummary).toBeNull();
+    });
+    expect(gitStatusMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps null on soft-fail (repo missing) instead of erroring", async () => {
+    gitStatusMock.mockRejectedValue(new Error("not a repo"));
+    const { result } = renderHook(() =>
+      useGitDirtyStatus({ projectPath: "/repo", busy: false }),
+    );
+    await vi.waitFor(() => {
+      expect(result.current.gitDirtySummary).toBeNull();
+    });
+  });
+
+  it("forwards the raw status to onStatus (branch chip patch)", async () => {
+    const raw = { available: true, files: [dirtyFile("x.ts")] } as Awaited<
+      ReturnType<typeof api.gitStatus>
+    >;
+    gitStatusMock.mockResolvedValue(raw);
+    const onStatus = vi.fn();
+    renderHook(() =>
+      useGitDirtyStatus({ projectPath: "/repo", busy: false, onStatus }),
+    );
+    await vi.waitFor(() => {
+      expect(onStatus).toHaveBeenCalledWith("/repo", raw);
+    });
+  });
+});

--- a/src/hooks/useGitDirtyStatus.ts
+++ b/src/hooks/useGitDirtyStatus.ts
@@ -1,0 +1,92 @@
+/**
+ * Workspace git dirty summary for the active project (composer chip).
+ * Owns its polling lifecycle: soft poll while a project is bound, faster
+ * while a turn is live, refresh on window focus, paused while hidden.
+ *
+ * Extracted from AppWorkbench (WP: knowledge hiding — the host only needs
+ * the summary value; the poll cadence is this hook's business).
+ */
+import { useCallback, useEffect, useRef, useState } from "react";
+import * as api from "@/lib/api";
+import { startVisibilityPoll } from "@/lib/visibilityPoll";
+import {
+  gitDirtySummariesEqual,
+  summarizeGitDirty,
+  type GitDirtySummary,
+} from "@/lib/workspaceGit";
+
+export type GitStatusBranchPatch = (
+  path: string,
+  status: Awaited<ReturnType<typeof api.gitStatus>>,
+) => void;
+
+export function useGitDirtyStatus(opts: {
+  /** Absolute path of the active project; null when none. */
+  projectPath: string | null | undefined;
+  /** True while a turn is streaming / awaiting permission (faster poll). */
+  busy: boolean;
+  /**
+   * Side-channel: the same poll already fetched HEAD, so the composer
+   * branch chip can be patched without another spawn.
+   */
+  onStatus?: GitStatusBranchPatch;
+  /** Change key for busy (e.g. session id) to re-arm the poll cadence. */
+  busyKey?: string | number | null;
+}) {
+  const { projectPath, busy, onStatus, busyKey } = opts;
+  const onStatusRef = useRef(onStatus);
+  onStatusRef.current = onStatus;
+
+  /** Null when not a repo, unavailable, clean, or no active project. */
+  const [gitDirtySummary, setGitDirtySummary] = useState<GitDirtySummary | null>(
+    null,
+  );
+  const reqRef = useRef(0);
+
+  const refresh = useCallback(async () => {
+    const path = projectPath?.trim() || null;
+    if (!path || !api.isTauri()) {
+      reqRef.current += 1;
+      setGitDirtySummary((prev) => (prev == null ? prev : null));
+      return;
+    }
+    const reqId = ++reqRef.current;
+    try {
+      const status = await api.gitStatus(path);
+      if (reqId !== reqRef.current) return;
+      const next = summarizeGitDirty(status);
+      setGitDirtySummary((prev) =>
+        gitDirtySummariesEqual(prev, next) ? prev : next,
+      );
+      onStatusRef.current?.(path, status);
+    } catch {
+      if (reqId !== reqRef.current) return;
+      setGitDirtySummary((prev) => (prev == null ? prev : null));
+    }
+  }, [projectPath]);
+
+  useEffect(() => {
+    void refresh();
+    // Soft poll while a project is bound; refresh sooner on focus.
+    // Faster while a turn is live — agent may `git switch` mid-session.
+    // Ticks pause while the window is hidden — a minimized app has nothing
+    // to paint, and `git status` is a process spawn per poll.
+    const path = projectPath?.trim() || null;
+    if (!path || !api.isTauri()) return;
+    const intervalMs = busy ? 2000 : 8000;
+    const poll = startVisibilityPoll({
+      tick: () => void refresh(),
+      setIntervalFn: (handler) => window.setInterval(handler, intervalMs),
+    });
+    const onFocus = () => {
+      void refresh();
+    };
+    window.addEventListener("focus", onFocus);
+    return () => {
+      poll.dispose();
+      window.removeEventListener("focus", onFocus);
+    };
+  }, [projectPath, refresh, busy, busyKey]);
+
+  return { gitDirtySummary, refreshGitDirtyStatus: refresh };
+}

--- a/src/hooks/useSessionFileChanges.test.ts
+++ b/src/hooks/useSessionFileChanges.test.ts
@@ -1,0 +1,62 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { useSessionFileChanges } from "./useSessionFileChanges";
+import type { SessionFileChange } from "@/lib/sessionChanges";
+
+function change(path: string): SessionFileChange {
+  return {
+    toolCallId: "tc",
+    toolKind: "write",
+    status: "completed",
+    path,
+    name: path,
+    before: undefined,
+    after: "x",
+    updatedAt: "2026-09-10T00:00:00Z",
+  };
+}
+
+describe("useSessionFileChanges", () => {
+  it("returns an empty list for unknown sessions", () => {
+    const { result } = renderHook(() => useSessionFileChanges());
+    expect(result.current.changesFor("nope")).toEqual([]);
+  });
+
+  it("returns an empty list for null / empty session ids", () => {
+    const { result } = renderHook(() => useSessionFileChanges());
+    expect(result.current.changesFor(null)).toEqual([]);
+    expect(result.current.changesFor("")).toEqual([]);
+  });
+
+  it("returns recorded changes per session id", () => {
+    const { result } = renderHook(() => useSessionFileChanges());
+    act(() => {
+      result.current.setSessionChangesById((prev) => ({
+        ...prev,
+        "s1": [change("a.ts")],
+        "s2": [change("b.ts"), change("c.ts")],
+      }));
+    });
+    expect(result.current.changesFor("s1")).toHaveLength(1);
+    expect(result.current.changesFor("s2")).toHaveLength(2);
+    expect(result.current.changesFor("s3")).toEqual([]);
+  });
+
+  it("keeps other sessions intact when one is updated", () => {
+    const { result } = renderHook(() => useSessionFileChanges());
+    act(() => {
+      result.current.setSessionChangesById(() => ({ s1: [change("a.ts")] }));
+    });
+    act(() => {
+      result.current.setSessionChangesById((prev) => ({
+        ...prev,
+        s2: [change("b.ts")],
+      }));
+    });
+    expect(result.current.changesFor("s1")).toHaveLength(1);
+    expect(result.current.changesFor("s2")).toHaveLength(1);
+  });
+});

--- a/src/hooks/useSessionFileChanges.ts
+++ b/src/hooks/useSessionFileChanges.ts
@@ -1,0 +1,33 @@
+/**
+ * Per-session file-change records (Review panel / dirty-chip data source).
+ *
+ * Writers: the host-event layer (`session://tool` batch apply via ctx) and
+ * journal hydration (`host.hydrate.applyOpenResult` + Review seeding).
+ * Readers: chat stage, resources aside, and the dirty-chip summary — all
+ * through `changesFor`, which owns the empty-list fallback.
+ *
+ * Extracted from AppWorkbench (WP: knowledge hiding — the host only routes
+ * writers and readers; the record shape and fallback are this hook's business).
+ */
+import { useCallback, useState } from "react";
+import {
+  EMPTY_SESSION_FILE_CHANGES,
+  type SessionFileChange,
+} from "@/lib/sessionChanges";
+
+export function useSessionFileChanges() {
+  const [sessionChangesById, setSessionChangesById] = useState<
+    Record<string, SessionFileChange[]>
+  >({});
+
+  /** Changes recorded for a session; empty list when none recorded. */
+  const changesFor = useCallback(
+    (sessionId: string | null | undefined): SessionFileChange[] =>
+      sessionId
+        ? (sessionChangesById[sessionId] ?? EMPTY_SESSION_FILE_CHANGES)
+        : EMPTY_SESSION_FILE_CHANGES,
+    [sessionChangesById],
+  );
+
+  return { sessionChangesById, setSessionChangesById, changesFor };
+}

--- a/src/lib/errorBannerActions.test.ts
+++ b/src/lib/errorBannerActions.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import {
+  ERROR_BANNER_SETTINGS_ROUTE,
+  isErrorBannerDismissOnly,
+} from "./errorBannerActions";
+import type { ErrorDeckActionId } from "@/lib/errorDeck";
+
+describe("ERROR_BANNER_SETTINGS_ROUTE", () => {
+  it("routes every settings-type action to a section", () => {
+    expect(ERROR_BANNER_SETTINGS_ROUTE.open_runtime).toEqual({
+      section: "runtime",
+    });
+    expect(ERROR_BANNER_SETTINGS_ROUTE.open_network).toEqual({
+      section: "runtime",
+      tab: "network",
+    });
+    expect(ERROR_BANNER_SETTINGS_ROUTE.open_permissions).toEqual({
+      section: "general",
+      tab: "permissions",
+    });
+    expect(ERROR_BANNER_SETTINGS_ROUTE.open_providers?.section).toBe(
+      "account",
+    );
+    expect(ERROR_BANNER_SETTINGS_ROUTE.open_extensions?.section).toBe(
+      "extensions",
+    );
+    expect(ERROR_BANNER_SETTINGS_ROUTE.upgrade_cli?.section).toBe("runtime");
+  });
+
+  it("does not route verb-type actions (host handles those)", () => {
+    const verbs: ErrorDeckActionId[] = [
+      "reconnect",
+      "open_doctor",
+      "open_mcp",
+      "trust_project",
+      "relocate_project",
+      "add_project",
+      "cancel_turn",
+      "dismiss",
+      "keep_waiting",
+    ];
+    for (const id of verbs) {
+      expect(ERROR_BANNER_SETTINGS_ROUTE[id]).toBeUndefined();
+    }
+  });
+});
+
+describe("isErrorBannerDismissOnly", () => {
+  it("covers dismiss and the stream-stall keep-waiting prompt", () => {
+    expect(isErrorBannerDismissOnly("dismiss")).toBe(true);
+    expect(isErrorBannerDismissOnly("keep_waiting")).toBe(true);
+    expect(isErrorBannerDismissOnly("reconnect")).toBe(false);
+    expect(isErrorBannerDismissOnly("cancel_turn")).toBe(false);
+  });
+});

--- a/src/lib/errorBannerActions.ts
+++ b/src/lib/errorBannerActions.ts
@@ -1,0 +1,41 @@
+/**
+ * Routing table for error-banner primary actions (ErrorDeckActionId →
+ * settings navigation target). Pure data so the host dispatcher stays a
+ * lookup + grouped verbs instead of a 16-case switch.
+ *
+ * Actions that are NOT settings navigation (reconnect, doctor, mcp modal,
+ * project verbs, turn control) stay in the host callback — they are real
+ * side effects, not routes.
+ */
+import type { ErrorDeckActionId } from "@/lib/errorDeck";
+import type { SettingsSectionId } from "@/lib/settingsCatalog";
+
+export type SettingsRoute = {
+  section: SettingsSectionId;
+  /** Optional anchor/tab inside the section. */
+  tab?: string | null;
+};
+
+/**
+ * Settings-navigation routes for banner action ids. Ids missing from this
+ * map are handled by the host's verb cases (reconnect / doctor / mcp /
+ * project verbs / turn control / dismiss).
+ */
+export const ERROR_BANNER_SETTINGS_ROUTE: Partial<
+  Record<ErrorDeckActionId, SettingsRoute>
+> = {
+  open_runtime: { section: "runtime" },
+  upgrade_cli: { section: "runtime" },
+  open_network: { section: "runtime", tab: "network" },
+  open_account: { section: "account" },
+  // Providers live under account / extensions path — account is the
+  // login+key surface; extensions holds MCP. Prefer account for keys.
+  open_providers: { section: "account" },
+  open_permissions: { section: "general", tab: "permissions" },
+  open_extensions: { section: "extensions" },
+};
+
+/** True when the action id only clears the banner (no side effect). */
+export function isErrorBannerDismissOnly(id: ErrorDeckActionId): boolean {
+  return id === "dismiss" || id === "keep_waiting";
+}


### PR DESCRIPTION
## Summary
`runErrorBannerAction` was a 16-case switch in AppWorkbench where **7 cases were pure Settings navigation** differing only in `(section, tab)`. Extracted that routing into [`src/lib/errorBannerActions.ts`](src/lib/errorBannerActions.ts) as a typed lookup table (`ERROR_BANNER_SETTINGS_ROUTE`, typed against `SettingsSectionId`) + `isErrorBannerDismissOnly`, with tests. The host callback shrinks to lookup + grouped verbs (transport, modal opens, project verbs, turn control).

**Fixes a real stale-closure bug** the dispatcher carried: the deps array listed `ensureConnected` (never called in the body) but **omitted `retryAgentConnect`** (called for the reconnect case) — the Reconnect button could invoke a stale connect closure after connection state changed. Deps now match the body exactly.

## Type of change
- [x] Bug fix
- [ ] New feature
- [x] Refactor / chore

## Checklist
- [x] `pnpm typecheck` / `pnpm test` (645 files incl. 3 new routing-table tests) / `lint` / gates / self-test / `build:ui` — all green
- [x] No Rust change
- [x] User-facing strings — CHANGELOG entry only (en + zh) for the reconnect fix
- [x] No secrets included

**Stacked on #1160 → #1161** (host extraction series).