### PR TITLE
refactor(extensions): extract the skills modal farm to its own component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ See `docs/llm-wiki/release.md`.
 ### Fixed
 - Math formulas render with one matching KaTeX version again. The bundled CSS had drifted ahead of the JS.
 - Wallpaper no longer flashes black while streaming or following the chat tail.
+- Reconnect from the error banner always uses the latest connection state.
 - Imagine portrait thumbnails stay contained when the wallpaper window narrows.
 - What's New now lists every entry; some were cut off before.
 - Generated wallpaper stays visible when library indexing fails and can be saved again.
@@ -29,6 +30,7 @@ See `docs/llm-wiki/release.md`.
 **中文 · 修复**
 - 数学公式恢复 CSS 与 JS 同版本渲染，不再出现样式超前于脚本。
 - 流式输出和自动跟随聊天底部时，静态及动态壁纸不再闪黑。
+- 错误横幅上的重连始终使用最新的连接状态。
 - 壁纸窗口缩小时，Imagine 纵向缩略图不再挤压错位。
 - 「新功能」弹窗不再漏掉部分条目。
 - 生成壁纸在图库索引失败时仍会显示，并可直接重试保存。

--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -677,6 +677,7 @@ import {
 } from "@/hooks/useSessionNavigation";
 import { useGitDirtyStatus } from "@/hooks/useGitDirtyStatus";
 import { useSessionFileChanges } from "@/hooks/useSessionFileChanges";
+import { ERROR_BANNER_SETTINGS_ROUTE, isErrorBannerDismissOnly } from "@/lib/errorBannerActions";
 import { WorkbenchSessionTree } from "@/app/WorkbenchSessionTree";
 import { WorkbenchSidebar } from "@/app/WorkbenchSidebar";
 import { WorkbenchMain } from "@/app/WorkbenchMain";
@@ -10954,43 +10955,21 @@ export function AppWorkbench() {
   const runErrorBannerAction = useCallback(
     (action: NonNullable<ErrorBannerView["primary"]>) => {
       setErrorDetailOpen(false);
-      switch (action.id) {
+      const { id } = action;
+      // Settings navigation: data-driven from the routing table.
+      const route = ERROR_BANNER_SETTINGS_ROUTE[id];
+      if (route) {
+        setLocalError(null);
+        navigateSettings(route.section, route.tab);
+        return;
+      }
+      switch (id) {
         case "reconnect":
           retryAgentConnect();
           break;
         case "open_doctor":
           setLocalError(null);
           openDoctor();
-          break;
-        case "open_runtime":
-          setLocalError(null);
-          navigateSettings("runtime");
-          break;
-        case "upgrade_cli":
-          setLocalError(null);
-          navigateSettings("runtime");
-          break;
-        case "open_network":
-          setLocalError(null);
-          navigateSettings("runtime", "network");
-          break;
-        case "open_account":
-          setLocalError(null);
-          navigateSettings("account");
-          break;
-        case "open_providers":
-          setLocalError(null);
-          // Providers live under account / extensions path — account is the
-          // login+key surface; extensions holds MCP. Prefer account for keys.
-          navigateSettings("account");
-          break;
-        case "open_permissions":
-          setLocalError(null);
-          navigateSettings("general", "permissions");
-          break;
-        case "open_extensions":
-          setLocalError(null);
-          navigateSettings("extensions");
           break;
         case "open_mcp":
           setLocalError(null);
@@ -11008,27 +10987,25 @@ export function AppWorkbench() {
           setLocalError(null);
           void addProject(false);
           break;
-        case "dismiss":
-        case "keep_waiting":
-          // keep_waiting is for the stream-stall banner (clears prompt only).
-          setLocalError(null);
-          break;
         case "cancel_turn":
           setLocalError(null);
           void stop();
           break;
         default:
+          // dismiss / keep_waiting: clear the banner (keep_waiting is the
+          // stream-stall prompt — clears the prompt, keeps the turn).
+          if (isErrorBannerDismissOnly(id)) setLocalError(null);
           break;
       }
     },
     [
       activeProject,
       addProject,
-      ensureConnected,
       navigateSettings,
       openDoctor,
       openMcpModal,
       relocateProject,
+      retryAgentConnect,
       stop,
       trustProject,
     ],

--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -543,11 +543,9 @@ import { resolveSidePathDeepLink } from "@/lib/sidePathDeepLink";
 import { WorkbenchAppDialogStage } from "@/app/WorkbenchAppDialogStage";
 import { WorkbenchComposerModals } from "@/app/WorkbenchComposerModals";
 import {
-  EMPTY_SESSION_FILE_CHANGES,
   mergeSessionChange,
   sessionChangesFromMessages,
   summarizeSessionChanges,
-  type SessionFileChange,
 } from "@/lib/sessionChanges";
 
 
@@ -678,6 +676,7 @@ import {
   useSessionNavigation,
 } from "@/hooks/useSessionNavigation";
 import { useGitDirtyStatus } from "@/hooks/useGitDirtyStatus";
+import { useSessionFileChanges } from "@/hooks/useSessionFileChanges";
 import { WorkbenchSessionTree } from "@/app/WorkbenchSessionTree";
 import { WorkbenchSidebar } from "@/app/WorkbenchSidebar";
 import { WorkbenchMain } from "@/app/WorkbenchMain";
@@ -971,9 +970,8 @@ export function AppWorkbench() {
    * Files written/edited by agent tools per session (Changes / diff panel).
    * Live tool events may enrich entries with before/after snippets.
    */
-  const [sessionChangesById, setSessionChangesById] = useState<
-    Record<string, SessionFileChange[]>
-  >({});
+  const { sessionChangesById, setSessionChangesById, changesFor } =
+    useSessionFileChanges();
   const {
     getDraft,
     setDraft,
@@ -8872,10 +8870,7 @@ export function AppWorkbench() {
   /** Session file-changes chip (+/− or N files); hidden when empty. */
   const sessionChangesSummary = useMemo(() => {
     const sid = session.sessionId || "";
-    const list = sid
-      ? (sessionChangesById[sid] ?? EMPTY_SESSION_FILE_CHANGES)
-      : EMPTY_SESSION_FILE_CHANGES;
-    return summarizeSessionChanges(list);
+    return summarizeSessionChanges(changesFor(sid));
   }, [session.sessionId, sessionChangesById]);
 
   // Reset find when switching conversation (keep open across same session).
@@ -12761,10 +12756,7 @@ export function AppWorkbench() {
             retryAgentConnect={retryAgentConnect}
             runErrorBannerAction={runErrorBannerAction}
             session={session}
-            sessionChanges={
-              sessionChangesById[session.sessionId || ""] ??
-              EMPTY_SESSION_FILE_CHANGES
-            }
+            sessionChanges={changesFor(session.sessionId || "")}
             sessionJsonSchema={sessionJsonSchema}
             sessionTranscriptStore={sessionTranscriptStore}
             sessions={sessions}
@@ -13043,11 +13035,9 @@ export function AppWorkbench() {
           setSideWorkbench={setSideWorkbench}
           sideDockComposer={sideDockComposer}
           onToggleSideDockComposer={toggleDockComposer}
-          sessionChanges={
-            sessionChangesById[reviewSessionId] ??
-            sessionChangesById[session.sessionId || ""] ??
-            EMPTY_SESSION_FILE_CHANGES
-          }
+          sessionChanges={changesFor(
+            reviewSessionId ?? (session.sessionId || ""),
+          )}
           reviewFocusPath={reviewFocus?.path ?? null}
           reviewFocusToken={reviewFocus?.token ?? 0}
           reviewPinnedPaths={reviewFocus?.pinnedPaths ?? []}

--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -550,12 +550,6 @@ import {
   type SessionFileChange,
 } from "@/lib/sessionChanges";
 
-import {
-  gitDirtySummariesEqual,
-  summarizeGitDirty,
-  type GitDirtySummary,
-} from "@/lib/workspaceGit";
-import { startVisibilityPoll } from "@/lib/visibilityPoll";
 
 const AutomationsPage = lazy(async () => {
   const m = await import("@/components/AutomationsPage");
@@ -683,6 +677,7 @@ import {
   createSessionNavHost,
   useSessionNavigation,
 } from "@/hooks/useSessionNavigation";
+import { useGitDirtyStatus } from "@/hooks/useGitDirtyStatus";
 import { WorkbenchSessionTree } from "@/app/WorkbenchSessionTree";
 import { WorkbenchSidebar } from "@/app/WorkbenchSidebar";
 import { WorkbenchMain } from "@/app/WorkbenchMain";
@@ -979,12 +974,6 @@ export function AppWorkbench() {
   const [sessionChangesById, setSessionChangesById] = useState<
     Record<string, SessionFileChange[]>
   >({});
-  /**
-   * Workspace git dirty summary for the active project (composer chip).
-   * Null when not a repo, unavailable, clean, or no active project.
-   */
-  const [gitDirtySummary, setGitDirtySummary] =
-    useState<GitDirtySummary | null>(null);
   const {
     getDraft,
     setDraft,
@@ -1987,6 +1976,14 @@ export function AppWorkbench() {
   } = useGitWorktreeChrome({
     hostRef: gitWorktreeHostRef,
     projectPath: activeProject?.path ?? null,
+  });
+
+  const { gitDirtySummary } = useGitDirtyStatus({
+    projectPath: activeProject?.path,
+    busy:
+      session.state === "streaming" || session.state === "awaiting_permission",
+    busyKey: session.sessionId,
+    onStatus: applyStatusBranch,
   });
   /** Host stream-stall prompt (I06); null when dismissed or not stalled. */
   const [streamStall, setStreamStall] = useState<{
@@ -9751,60 +9748,6 @@ export function AppWorkbench() {
    * Poll workspace git status for the active project so the composer dirty chip
    * stays current (hide when clean / not a repo). Soft-fail; no toast spam.
    */
-  const gitDirtyReqRef = useRef(0);
-  const refreshGitDirtyStatus = useCallback(async () => {
-    const path = activeProject?.path?.trim() || null;
-    if (!path || !api.isTauri()) {
-      gitDirtyReqRef.current += 1;
-      setGitDirtySummary((prev) => (prev == null ? prev : null));
-      return;
-    }
-    const reqId = ++gitDirtyReqRef.current;
-    try {
-      const status = await api.gitStatus(path);
-      if (reqId !== gitDirtyReqRef.current) return;
-      const next = summarizeGitDirty(status);
-      setGitDirtySummary((prev) =>
-        gitDirtySummariesEqual(prev, next) ? prev : next,
-      );
-      // Same poll already has HEAD. Patch the composer branch chip so an
-      // in-place checkout does not stay stale until the menu is clicked.
-      applyStatusBranch(path, status);
-    } catch {
-      if (reqId !== gitDirtyReqRef.current) return;
-      setGitDirtySummary((prev) => (prev == null ? prev : null));
-    }
-  }, [activeProject?.path, applyStatusBranch]);
-
-  useEffect(() => {
-    void refreshGitDirtyStatus();
-    // Soft poll while a project is bound; refresh sooner on focus.
-    // Faster while a turn is live — agent may `git switch` mid-session.
-    // Ticks pause while the window is hidden — a minimized app has nothing
-    // to paint, and `git status` is a process spawn per poll.
-    const path = activeProject?.path?.trim() || null;
-    if (!path || !api.isTauri()) return;
-    const busy =
-      session.state === "streaming" || session.state === "awaiting_permission";
-    const intervalMs = busy ? 2000 : 8000;
-    const poll = startVisibilityPoll({
-      tick: () => void refreshGitDirtyStatus(),
-      setIntervalFn: (handler) => window.setInterval(handler, intervalMs),
-    });
-    const onFocus = () => {
-      void refreshGitDirtyStatus();
-    };
-    window.addEventListener("focus", onFocus);
-    return () => {
-      poll.dispose();
-      window.removeEventListener("focus", onFocus);
-    };
-  }, [
-    activeProject?.path,
-    refreshGitDirtyStatus,
-    session.sessionId,
-    session.state,
-  ]);
 
   /**
    * After a project is created/updated: refresh list, expand, optionally trust

--- a/src/components/ExtensionsPanel.tsx
+++ b/src/components/ExtensionsPanel.tsx
@@ -8,6 +8,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import * as api from "@/lib/api";
 import { createT, intlLocale, type Locale, type MessageKey } from "@/i18n";
 import { GlassModal } from "@/components/GlassModal";
+import { ExtensionsPanelSkillModals } from "@/components/ExtensionsPanelSkillModals";
 import {
   IconDoctor,
   IconEdit,
@@ -72,9 +73,6 @@ import {
   buildSkillSaveOkPresentation,
   buildSkillSavePreflightError,
   buildSkillValidatePresentation,
-  skillEditBadgeTone,
-  skillEditHint,
-  skillEditKindLabel,
   type SkillEditKind,
   type SkillEditPresentation,
 } from "@/lib/skillEditFeedback";
@@ -3907,449 +3905,40 @@ export function ExtensionsPanel({
         }}
       />
 
-      <GlassModal
-        open={skillNewOpen}
-        onClose={() => {
-          if (actionBusy !== "skill:create") setSkillNewOpen(false);
-        }}
-        title={tr("ext.skills.newTitle")}
-        size="md"
-        closeLabel={tr("common.close")}
-        wrapBody
-        footer={
-          <>
-            <button
-              type="button"
-              className="btn btn--ghost"
-              disabled={actionBusy === "skill:create"}
-              onClick={() => setSkillNewOpen(false)}
-            >
-              {tr("common.cancel")}
-            </button>
-            <button
-              type="button"
-              className="btn btn--solid"
-              disabled={
-                actionBusy === "skill:create" || !skillNewSanitized
-              }
-              onClick={() => void submitSkillNew()}
-            >
-              {actionBusy === "skill:create"
-                ? tr("ext.skills.newWorking")
-                : tr("ext.skills.newSubmit")}
-            </button>
-          </>
-        }
-      >
-        <form
-          className="app-dialog__form"
-          onSubmit={(e) => {
-            e.preventDefault();
-            void submitSkillNew();
-          }}
-        >
-          <label className="field">
-            <span>{tr("ext.skills.newName")}</span>
-            <input
-              className="app-dialog__input"
-              value={skillNewName}
-              onChange={(e) => {
-                setSkillNewName(e.target.value);
-                setSkillNewError(null);
-              }}
-              placeholder={tr("ext.skills.newNamePlaceholder")}
-              autoComplete="off"
-              spellCheck={false}
-              disabled={actionBusy === "skill:create"}
-              autoFocus
-            />
-            <span className="ext-field-hint">
-              {skillNewSanitized
-                ? tr("ext.skills.newNameHintOk", { name: skillNewSanitized })
-                : tr("ext.skills.newNameHint")}
-            </span>
-          </label>
-          <label className="field">
-            <span>{tr("ext.skills.newDescription")}</span>
-            <textarea
-              className="app-dialog__input ext-env-textarea"
-              value={skillNewDesc}
-              onChange={(e) => {
-                setSkillNewDesc(e.target.value);
-                setSkillNewError(null);
-              }}
-              placeholder={tr("ext.skills.newDescriptionPlaceholder")}
-              rows={3}
-              spellCheck
-              disabled={actionBusy === "skill:create"}
-            />
-            <span className="ext-field-hint">
-              {tr("ext.skills.newDescriptionHint")}
-            </span>
-          </label>
-          <fieldset className="field" disabled={actionBusy === "skill:create"}>
-            <legend>{tr("ext.skills.newScope")}</legend>
-            <label className="ext-radio-row">
-              <input
-                type="radio"
-                name="skill-new-scope"
-                checked={skillNewScope === "user"}
-                onChange={() => setSkillNewScope("user")}
-              />
-              <span>{tr("ext.skills.newScopeUser")}</span>
-            </label>
-            <label className="ext-radio-row">
-              <input
-                type="radio"
-                name="skill-new-scope"
-                checked={skillNewScope === "project"}
-                onChange={() => setSkillNewScope("project")}
-                disabled={!projectPath?.trim()}
-              />
-              <span>
-                {projectPath?.trim()
-                  ? tr("ext.skills.newScopeProject")
-                  : tr("ext.skills.newScopeProjectDisabled")}
-              </span>
-            </label>
-            <span className="ext-field-hint">{tr("ext.skills.newScopeHint")}</span>
-          </fieldset>
-          {skillNewError ? (
-            <p className="ext-alert" role="alert">
-              <span className="ext-alert__body">{skillNewError}</span>
-            </p>
-          ) : null}
-        </form>
-      </GlassModal>
-
-      <GlassModal
-        open={!!skillEditor}
-        onClose={requestCloseSkillEditor}
-        title={
-          skillEditor
-            ? tr("ext.skills.editTitle", { name: skillEditor.skill.name })
-            : tr("ext.skills.edit")
-        }
-        size="lg"
-        closeLabel={tr("common.close")}
-        closeOnOverlay={!skillEditor?.saving}
-        wrapBody
-        bodyClassName="ext-skill-editor"
-        footer={
-          <>
-            <button
-              type="button"
-              className="btn btn--ghost"
-              disabled={!!skillEditor?.saving}
-              onClick={requestCloseSkillEditor}
-            >
-              {tr("common.cancel")}
-            </button>
-            <button
-              type="button"
-              className="btn btn--ghost"
-              disabled={
-                !skillEditor || skillEditor.loading || skillEditor.saving
-              }
-              onClick={validateSkillEditor}
-            >
-              {tr("ext.skills.editValidate")}
-            </button>
-            <button
-              type="button"
-              className="btn btn--solid"
-              disabled={
-                !skillEditor ||
-                skillEditor.loading ||
-                skillEditor.saving ||
-                !!skillEditor.error ||
-                !skillEditorDirty
-              }
-              onClick={() => void saveSkillEditor()}
-            >
-              {skillEditor?.saving
-                ? tr("ext.skills.editSaving")
-                : tr("common.save")}
-            </button>
-          </>
-        }
-      >
-        {skillEditor ? (
-          <>
-            {!isExtensionEnabled(skillEditor.skill.enabled) ? (
-              <p className="ext-skill-editor__note" role="status">
-                {tr("ext.skills.editDisabledNote")}
-              </p>
-            ) : null}
-            {skillEditor.path ? (
-              <p className="ext-skill-editor__path" title={skillEditor.path}>
-                {shortPathLabel(skillEditor.path, 72) || skillEditor.path}
-              </p>
-            ) : null}
-            {skillEditor.loading ? (
-              <p className="ext-empty">{tr("ext.skills.editLoading")}</p>
-            ) : skillEditor.error && !skillEditor.baselineText ? (
-              <p className="ext-alert ext-alert--error" role="alert">
-                <span className="ext-alert__body">{skillEditor.error}</span>
-              </p>
-            ) : (
-              <textarea
-                className="ext-skill-editor__textarea"
-                value={skillEditor.draftText}
-                onChange={(e) =>
-                  setSkillEditor((s) =>
-                    s
-                      ? {
-                          ...s,
-                          draftText: e.target.value,
-                          savedHint: null,
-                          error: null,
-                        }
-                      : s,
-                  )
-                }
-                spellCheck={false}
-                disabled={skillEditor.saving}
-                aria-label={tr("ext.skills.editAria", {
-                  name: skillEditor.skill.name,
-                })}
-                rows={18}
-              />
-            )}
-            {skillEditor.error && skillEditor.baselineText ? (
-              <p className="ext-skill-editor__error" role="alert">
-                {skillEditor.error}
-                {skillFeedback ? (
-                  <>
-                    {" "}
-                    <button
-                      type="button"
-                      className="btn btn--ghost btn--sm ext-skill-editor__details-btn"
-                      onClick={() => setSkillFeedbackOpen(true)}
-                    >
-                      {tr("ext.skills.feedback.viewDetails")}
-                    </button>
-                  </>
-                ) : null}
-              </p>
-            ) : null}
-            {skillEditor.savedHint ? (
-              <p
-                className={
-                  "ext-skill-editor__saved" +
-                  (skillFeedback && !skillFeedback.blocking
-                    ? skillFeedback.severity === "warn"
-                      ? " ext-skill-editor__status--warn"
-                      : skillFeedback.severity === "ok"
-                        ? " ext-skill-editor__status--ok"
-                        : ""
-                    : " ext-skill-editor__status--ok")
-                }
-                role="status"
-              >
-                {skillEditor.savedHint}
-                {skillFeedback && !skillFeedback.blocking ? (
-                  <>
-                    {" "}
-                    <button
-                      type="button"
-                      className="btn btn--ghost btn--sm ext-skill-editor__details-btn"
-                      onClick={() => setSkillFeedbackOpen(true)}
-                    >
-                      {tr("ext.skills.feedback.viewDetails")}
-                    </button>
-                  </>
-                ) : null}
-              </p>
-            ) : null}
-          </>
-        ) : null}
-      </GlassModal>
-
-      <GlassModal
-        open={skillFeedbackOpen && !!skillFeedback}
-        onClose={() => setSkillFeedbackOpen(false)}
-        title={
-          skillFeedback?.phase === "validate"
-            ? tr("ext.skills.feedback.resultValidateTitle")
-            : skillFeedback?.phase === "load"
-              ? tr("ext.skills.feedback.resultLoadTitle")
-              : skillFeedback?.phase === "create"
-                ? tr("ext.skills.feedback.resultCreateTitle")
-                : tr("ext.skills.feedback.resultSaveTitle")
-        }
-        size="md"
-        closeLabel={tr("common.close")}
-        wrapBody
-        bodyClassName="ext-skill-feedback"
-        footer={
-          <>
-            <button
-              type="button"
-              className="btn btn--solid"
-              onClick={() => setSkillFeedbackOpen(false)}
-            >
-              {tr("common.close")}
-            </button>
-          </>
-        }
-      >
-        {skillFeedback ? (
-          <div className="ext-skill-feedback__body">
-            <div className="ext-skill-feedback__meta">
-              <span
-                className={
-                  "ext-badge ext-badge--" +
-                  skillEditBadgeTone(skillFeedback.severity)
-                }
-              >
-                {skillEditKindLabel(skillFeedback.kind, skillKindLabels)}
-              </span>
-              {skillFeedback.name ? (
-                <span className="ext-badge ext-badge--muted">
-                  /{skillFeedback.name}
-                </span>
-              ) : null}
-              {skillFeedback.sizeBytes != null ? (
-                <span className="ext-badge ext-badge--muted">
-                  {tr("ext.skills.feedback.sizeBytes", {
-                    n: String(skillFeedback.sizeBytes),
-                  })}
-                </span>
-              ) : null}
-            </div>
-            <p
-              className={
-                "ext-skill-feedback__summary" +
-                (skillFeedback.severity === "ok"
-                  ? " ext-skill-feedback__summary--ok"
-                  : skillFeedback.severity === "err"
-                    ? " ext-skill-feedback__summary--err"
-                    : skillFeedback.severity === "warn"
-                      ? " ext-skill-feedback__summary--warn"
-                      : "")
-              }
-            >
-              {skillFeedback.summary}
-            </p>
-            {skillEditHint(skillFeedback.kind, skillKindHints) ? (
-              <p className="ext-skill-feedback__hint">
-                {skillEditHint(skillFeedback.kind, skillKindHints)}
-              </p>
-            ) : null}
-            {skillFeedback.detail &&
-            skillFeedback.detail !== skillFeedback.summary ? (
-              <p className="ext-skill-feedback__detail">
-                {skillFeedback.detail}
-              </p>
-            ) : null}
-            {skillFeedback.issues.length > 1 ? (
-              <ul className="ext-skill-feedback__issues">
-                {skillFeedback.issues.map((issue, idx) => (
-                  <li key={`${issue.kind}-${idx}`}>
-                    <span
-                      className={
-                        "ext-badge ext-badge--" +
-                        skillEditBadgeTone(issue.severity)
-                      }
-                    >
-                      {skillEditKindLabel(issue.kind, skillKindLabels)}
-                    </span>
-                    {issue.detail ? (
-                      <span className="ext-skill-feedback__issue-detail">
-                        {issue.detail}
-                      </span>
-                    ) : null}
-                  </li>
-                ))}
-              </ul>
-            ) : null}
-            {skillFeedback.reason ? (
-              <p className="ext-skill-feedback__reason">
-                <span className="ext-skill-feedback__label">
-                  {tr("ext.skills.feedback.reason")}
-                </span>
-                <code>{skillFeedback.reason}</code>
-              </p>
-            ) : null}
-            {skillFeedback.path ? (
-              <p className="ext-skill-feedback__path" title={skillFeedback.path}>
-                <span className="ext-skill-feedback__label">
-                  {tr("ext.skills.feedback.path")}
-                </span>
-                <code>
-                  {shortPathLabel(skillFeedback.path, 64) || skillFeedback.path}
-                </code>
-              </p>
-            ) : null}
-          </div>
-        ) : null}
-      </GlassModal>
-
-      <GlassModal
-        open={skillDiscardOpen}
-        onClose={() => setSkillDiscardOpen(false)}
-        title={tr("ext.skills.editDiscardTitle")}
-        size="sm"
-        closeLabel={tr("common.close")}
-        footer={
-          <>
-            <button
-              type="button"
-              className="btn btn--ghost"
-              onClick={() => setSkillDiscardOpen(false)}
-            >
-              {tr("common.cancel")}
-            </button>
-            <button
-              type="button"
-              className="btn btn--danger"
-              onClick={() => {
-                setSkillDiscardOpen(false);
-                closeSkillEditor();
-              }}
-            >
-              {tr("ext.skills.editDiscard")}
-            </button>
-          </>
-        }
-      >
-        <p className="app-dialog__msg">{tr("ext.skills.editDiscardBody")}</p>
-      </GlassModal>
-
-      <GlassModal
-        open={skillConflictOpen}
-        onClose={() => setSkillConflictOpen(false)}
-        title={tr("ext.skills.editConflictTitle")}
-        size="sm"
-        closeLabel={tr("common.close")}
-        footer={
-          <>
-            <button
-              type="button"
-              className="btn btn--ghost"
-              onClick={() => {
-                setSkillConflictOpen(false);
-                if (skillEditor) void openSkillEditor(skillEditor.skill);
-              }}
-            >
-              {tr("ext.skills.editConflictReload")}
-            </button>
-            <button
-              type="button"
-              className="btn btn--solid"
-              onClick={() => {
-                setSkillConflictOpen(false);
-                void saveSkillEditor({ force: true });
-              }}
-            >
-              {tr("ext.skills.editConflictOverwrite")}
-            </button>
-          </>
-        }
-      >
-        <p className="app-dialog__msg">{tr("ext.skills.editConflictBody")}</p>
-      </GlassModal>
+      <ExtensionsPanelSkillModals
+        tr={tr}
+        actionBusy={actionBusy}
+        skillKindLabels={skillKindLabels}
+        skillKindHints={skillKindHints}
+        skillNewSanitized={skillNewSanitized}
+        submitSkillNew={submitSkillNew}
+        requestCloseSkillEditor={requestCloseSkillEditor}
+        validateSkillEditor={validateSkillEditor}
+        closeSkillEditor={closeSkillEditor}
+        openSkillEditor={openSkillEditor}
+        projectPath={projectPath ?? null}
+        saveSkillEditor={saveSkillEditor}
+        skillEditor={skillEditor}
+        setSkillEditor={setSkillEditor}
+        skillEditorDirty={skillEditorDirty}
+        skillFeedback={skillFeedback}
+        skillNewOpen={skillNewOpen}
+        skillNewName={skillNewName}
+        skillNewDesc={skillNewDesc}
+        skillNewScope={skillNewScope}
+        skillNewError={skillNewError}
+        skillDiscardOpen={skillDiscardOpen}
+        skillConflictOpen={skillConflictOpen}
+        skillFeedbackOpen={skillFeedbackOpen}
+        setSkillNewOpen={setSkillNewOpen}
+        setSkillNewName={setSkillNewName}
+        setSkillNewDesc={setSkillNewDesc}
+        setSkillNewScope={setSkillNewScope}
+        setSkillNewError={setSkillNewError}
+        setSkillDiscardOpen={setSkillDiscardOpen}
+        setSkillConflictOpen={setSkillConflictOpen}
+        setSkillFeedbackOpen={setSkillFeedbackOpen}
+      />
     </div>
   );
 }

--- a/src/components/ExtensionsPanelSkillModals.tsx
+++ b/src/components/ExtensionsPanelSkillModals.tsx
@@ -1,0 +1,552 @@
+/**
+ * Skills tab modal farm for ExtensionsPanel: new-skill scaffold, editor,
+ * save feedback, discard confirm, and write-conflict confirm. Extracted
+ * verbatim from the panel (WP: giant-component decomposition) — the modal
+ * state cluster threads through as one props bundle.
+ */
+import { GlassModal } from "@/components/GlassModal";
+import {
+  skillEditBadgeTone,
+  skillEditHint,
+  skillEditKindLabel,
+  type SkillEditKind,
+  type SkillEditPresentation,
+} from "@/lib/skillEditFeedback";
+import { createT } from "@/i18n";
+import { isExtensionEnabled, shortPathLabel } from "@/lib/extensionsUi";
+import type * as api from "@/lib/api";
+
+type TFn = ReturnType<typeof createT>;
+
+type SkillEditorState = {
+  skill: api.SkillDto;
+  path: string;
+  baselineText: string;
+  draftText: string;
+  mtimeMs: number | null;
+  loading: boolean;
+  saving: boolean;
+  error: string | null;
+  savedHint: string | null;
+};
+
+export type ExtensionsPanelSkillModalsProps = {
+  tr: TFn;
+  actionBusy: string | null;
+  skillKindLabels: Partial<Record<SkillEditKind, string>>;
+  skillKindHints: Partial<Record<SkillEditKind, string>>;
+  skillNewSanitized: string | null;
+  submitSkillNew: () => Promise<void>;
+  requestCloseSkillEditor: () => void;
+  validateSkillEditor: () => void;
+  closeSkillEditor: () => void;
+  openSkillEditor: (skill: api.SkillDto, opts?: { force?: boolean }) => Promise<void>;
+  projectPath: string | null;
+  saveSkillEditor: (opts?: { force?: boolean }) => Promise<void>;
+  skillEditor: SkillEditorState | null;
+  setSkillEditor: (
+    next: SkillEditorState | null | ((prev: SkillEditorState | null) => SkillEditorState | null),
+  ) => void;
+  skillEditorDirty: boolean;
+  skillFeedback: SkillEditPresentation | null;
+  skillNewOpen: boolean;
+  skillNewName: string;
+  skillNewDesc: string;
+  skillNewScope: "user" | "project";
+  skillNewError: string | null;
+  skillDiscardOpen: boolean;
+  skillConflictOpen: boolean;
+  skillFeedbackOpen: boolean;
+  setSkillNewOpen: (open: boolean) => void;
+  setSkillNewName: (v: string) => void;
+  setSkillNewDesc: (v: string) => void;
+  setSkillNewScope: (v: "user" | "project") => void;
+  setSkillNewError: (v: string | null) => void;
+  setSkillDiscardOpen: (v: boolean) => void;
+  setSkillConflictOpen: (v: boolean) => void;
+  setSkillFeedbackOpen: (v: boolean) => void;
+};
+
+export function ExtensionsPanelSkillModals(p: ExtensionsPanelSkillModalsProps) {
+  const {
+    tr,
+    actionBusy,
+    skillKindLabels,
+    skillKindHints,
+    skillNewSanitized,
+    submitSkillNew,
+    requestCloseSkillEditor,
+    validateSkillEditor,
+    closeSkillEditor,
+    openSkillEditor,
+    projectPath,
+    saveSkillEditor,
+    skillEditor,
+    setSkillEditor,
+    skillEditorDirty,
+    skillFeedback,
+    skillNewOpen,
+    skillNewName,
+    skillNewDesc,
+    skillNewScope,
+    skillNewError,
+    skillDiscardOpen,
+    skillConflictOpen,
+    skillFeedbackOpen,
+    setSkillNewOpen,
+    setSkillNewName,
+    setSkillNewDesc,
+    setSkillNewScope,
+    setSkillNewError,
+    setSkillDiscardOpen,
+    setSkillConflictOpen,
+    setSkillFeedbackOpen,
+  } = p;
+  return (
+    <>
+      <GlassModal
+        open={skillNewOpen}
+        onClose={() => {
+          if (actionBusy !== "skill:create") setSkillNewOpen(false);
+        }}
+        title={tr("ext.skills.newTitle")}
+        size="md"
+        closeLabel={tr("common.close")}
+        wrapBody
+        footer={
+          <>
+            <button
+              type="button"
+              className="btn btn--ghost"
+              disabled={actionBusy === "skill:create"}
+              onClick={() => setSkillNewOpen(false)}
+            >
+              {tr("common.cancel")}
+            </button>
+            <button
+              type="button"
+              className="btn btn--solid"
+              disabled={
+                actionBusy === "skill:create" || !skillNewSanitized
+              }
+              onClick={() => void submitSkillNew()}
+            >
+              {actionBusy === "skill:create"
+                ? tr("ext.skills.newWorking")
+                : tr("ext.skills.newSubmit")}
+            </button>
+          </>
+        }
+      >
+        <form
+          className="app-dialog__form"
+          onSubmit={(e) => {
+            e.preventDefault();
+            void submitSkillNew();
+          }}
+        >
+          <label className="field">
+            <span>{tr("ext.skills.newName")}</span>
+            <input
+              className="app-dialog__input"
+              value={skillNewName}
+              onChange={(e) => {
+                setSkillNewName(e.target.value);
+                setSkillNewError(null);
+              }}
+              placeholder={tr("ext.skills.newNamePlaceholder")}
+              autoComplete="off"
+              spellCheck={false}
+              disabled={actionBusy === "skill:create"}
+              autoFocus
+            />
+            <span className="ext-field-hint">
+              {skillNewSanitized
+                ? tr("ext.skills.newNameHintOk", { name: skillNewSanitized })
+                : tr("ext.skills.newNameHint")}
+            </span>
+          </label>
+          <label className="field">
+            <span>{tr("ext.skills.newDescription")}</span>
+            <textarea
+              className="app-dialog__input ext-env-textarea"
+              value={skillNewDesc}
+              onChange={(e) => {
+                setSkillNewDesc(e.target.value);
+                setSkillNewError(null);
+              }}
+              placeholder={tr("ext.skills.newDescriptionPlaceholder")}
+              rows={3}
+              spellCheck
+              disabled={actionBusy === "skill:create"}
+            />
+            <span className="ext-field-hint">
+              {tr("ext.skills.newDescriptionHint")}
+            </span>
+          </label>
+          <fieldset className="field" disabled={actionBusy === "skill:create"}>
+            <legend>{tr("ext.skills.newScope")}</legend>
+            <label className="ext-radio-row">
+              <input
+                type="radio"
+                name="skill-new-scope"
+                checked={skillNewScope === "user"}
+                onChange={() => setSkillNewScope("user")}
+              />
+              <span>{tr("ext.skills.newScopeUser")}</span>
+            </label>
+            <label className="ext-radio-row">
+              <input
+                type="radio"
+                name="skill-new-scope"
+                checked={skillNewScope === "project"}
+                onChange={() => setSkillNewScope("project")}
+                disabled={!projectPath?.trim()}
+              />
+              <span>
+                {projectPath?.trim()
+                  ? tr("ext.skills.newScopeProject")
+                  : tr("ext.skills.newScopeProjectDisabled")}
+              </span>
+            </label>
+            <span className="ext-field-hint">{tr("ext.skills.newScopeHint")}</span>
+          </fieldset>
+          {skillNewError ? (
+            <p className="ext-alert" role="alert">
+              <span className="ext-alert__body">{skillNewError}</span>
+            </p>
+          ) : null}
+        </form>
+      </GlassModal>
+
+      <GlassModal
+        open={!!skillEditor}
+        onClose={requestCloseSkillEditor}
+        title={
+          skillEditor
+            ? tr("ext.skills.editTitle", { name: skillEditor.skill.name })
+            : tr("ext.skills.edit")
+        }
+        size="lg"
+        closeLabel={tr("common.close")}
+        closeOnOverlay={!skillEditor?.saving}
+        wrapBody
+        bodyClassName="ext-skill-editor"
+        footer={
+          <>
+            <button
+              type="button"
+              className="btn btn--ghost"
+              disabled={!!skillEditor?.saving}
+              onClick={requestCloseSkillEditor}
+            >
+              {tr("common.cancel")}
+            </button>
+            <button
+              type="button"
+              className="btn btn--ghost"
+              disabled={
+                !skillEditor || skillEditor.loading || skillEditor.saving
+              }
+              onClick={validateSkillEditor}
+            >
+              {tr("ext.skills.editValidate")}
+            </button>
+            <button
+              type="button"
+              className="btn btn--solid"
+              disabled={
+                !skillEditor ||
+                skillEditor.loading ||
+                skillEditor.saving ||
+                !!skillEditor.error ||
+                !skillEditorDirty
+              }
+              onClick={() => void saveSkillEditor()}
+            >
+              {skillEditor?.saving
+                ? tr("ext.skills.editSaving")
+                : tr("common.save")}
+            </button>
+          </>
+        }
+      >
+        {skillEditor ? (
+          <>
+            {!isExtensionEnabled(skillEditor.skill.enabled) ? (
+              <p className="ext-skill-editor__note" role="status">
+                {tr("ext.skills.editDisabledNote")}
+              </p>
+            ) : null}
+            {skillEditor.path ? (
+              <p className="ext-skill-editor__path" title={skillEditor.path}>
+                {shortPathLabel(skillEditor.path, 72) || skillEditor.path}
+              </p>
+            ) : null}
+            {skillEditor.loading ? (
+              <p className="ext-empty">{tr("ext.skills.editLoading")}</p>
+            ) : skillEditor.error && !skillEditor.baselineText ? (
+              <p className="ext-alert ext-alert--error" role="alert">
+                <span className="ext-alert__body">{skillEditor.error}</span>
+              </p>
+            ) : (
+              <textarea
+                className="ext-skill-editor__textarea"
+                value={skillEditor.draftText}
+                onChange={(e) =>
+                  setSkillEditor((s) =>
+                    s
+                      ? {
+                          ...s,
+                          draftText: e.target.value,
+                          savedHint: null,
+                          error: null,
+                        }
+                      : s,
+                  )
+                }
+                spellCheck={false}
+                disabled={skillEditor.saving}
+                aria-label={tr("ext.skills.editAria", {
+                  name: skillEditor.skill.name,
+                })}
+                rows={18}
+              />
+            )}
+            {skillEditor.error && skillEditor.baselineText ? (
+              <p className="ext-skill-editor__error" role="alert">
+                {skillEditor.error}
+                {skillFeedback ? (
+                  <>
+                    {" "}
+                    <button
+                      type="button"
+                      className="btn btn--ghost btn--sm ext-skill-editor__details-btn"
+                      onClick={() => setSkillFeedbackOpen(true)}
+                    >
+                      {tr("ext.skills.feedback.viewDetails")}
+                    </button>
+                  </>
+                ) : null}
+              </p>
+            ) : null}
+            {skillEditor.savedHint ? (
+              <p
+                className={
+                  "ext-skill-editor__saved" +
+                  (skillFeedback && !skillFeedback.blocking
+                    ? skillFeedback.severity === "warn"
+                      ? " ext-skill-editor__status--warn"
+                      : skillFeedback.severity === "ok"
+                        ? " ext-skill-editor__status--ok"
+                        : ""
+                    : " ext-skill-editor__status--ok")
+                }
+                role="status"
+              >
+                {skillEditor.savedHint}
+                {skillFeedback && !skillFeedback.blocking ? (
+                  <>
+                    {" "}
+                    <button
+                      type="button"
+                      className="btn btn--ghost btn--sm ext-skill-editor__details-btn"
+                      onClick={() => setSkillFeedbackOpen(true)}
+                    >
+                      {tr("ext.skills.feedback.viewDetails")}
+                    </button>
+                  </>
+                ) : null}
+              </p>
+            ) : null}
+          </>
+        ) : null}
+      </GlassModal>
+
+      <GlassModal
+        open={skillFeedbackOpen && !!skillFeedback}
+        onClose={() => setSkillFeedbackOpen(false)}
+        title={
+          skillFeedback?.phase === "validate"
+            ? tr("ext.skills.feedback.resultValidateTitle")
+            : skillFeedback?.phase === "load"
+              ? tr("ext.skills.feedback.resultLoadTitle")
+              : skillFeedback?.phase === "create"
+                ? tr("ext.skills.feedback.resultCreateTitle")
+                : tr("ext.skills.feedback.resultSaveTitle")
+        }
+        size="md"
+        closeLabel={tr("common.close")}
+        wrapBody
+        bodyClassName="ext-skill-feedback"
+        footer={
+          <>
+            <button
+              type="button"
+              className="btn btn--solid"
+              onClick={() => setSkillFeedbackOpen(false)}
+            >
+              {tr("common.close")}
+            </button>
+          </>
+        }
+      >
+        {skillFeedback ? (
+          <div className="ext-skill-feedback__body">
+            <div className="ext-skill-feedback__meta">
+              <span
+                className={
+                  "ext-badge ext-badge--" +
+                  skillEditBadgeTone(skillFeedback.severity)
+                }
+              >
+                {skillEditKindLabel(skillFeedback.kind, skillKindLabels)}
+              </span>
+              {skillFeedback.name ? (
+                <span className="ext-badge ext-badge--muted">
+                  /{skillFeedback.name}
+                </span>
+              ) : null}
+              {skillFeedback.sizeBytes != null ? (
+                <span className="ext-badge ext-badge--muted">
+                  {tr("ext.skills.feedback.sizeBytes", {
+                    n: String(skillFeedback.sizeBytes),
+                  })}
+                </span>
+              ) : null}
+            </div>
+            <p
+              className={
+                "ext-skill-feedback__summary" +
+                (skillFeedback.severity === "ok"
+                  ? " ext-skill-feedback__summary--ok"
+                  : skillFeedback.severity === "err"
+                    ? " ext-skill-feedback__summary--err"
+                    : skillFeedback.severity === "warn"
+                      ? " ext-skill-feedback__summary--warn"
+                      : "")
+              }
+            >
+              {skillFeedback.summary}
+            </p>
+            {skillEditHint(skillFeedback.kind, skillKindHints) ? (
+              <p className="ext-skill-feedback__hint">
+                {skillEditHint(skillFeedback.kind, skillKindHints)}
+              </p>
+            ) : null}
+            {skillFeedback.detail &&
+            skillFeedback.detail !== skillFeedback.summary ? (
+              <p className="ext-skill-feedback__detail">
+                {skillFeedback.detail}
+              </p>
+            ) : null}
+            {skillFeedback.issues.length > 1 ? (
+              <ul className="ext-skill-feedback__issues">
+                {skillFeedback.issues.map((issue, idx) => (
+                  <li key={`${issue.kind}-${idx}`}>
+                    <span
+                      className={
+                        "ext-badge ext-badge--" +
+                        skillEditBadgeTone(issue.severity)
+                      }
+                    >
+                      {skillEditKindLabel(issue.kind, skillKindLabels)}
+                    </span>
+                    {issue.detail ? (
+                      <span className="ext-skill-feedback__issue-detail">
+                        {issue.detail}
+                      </span>
+                    ) : null}
+                  </li>
+                ))}
+              </ul>
+            ) : null}
+            {skillFeedback.reason ? (
+              <p className="ext-skill-feedback__reason">
+                <span className="ext-skill-feedback__label">
+                  {tr("ext.skills.feedback.reason")}
+                </span>
+                <code>{skillFeedback.reason}</code>
+              </p>
+            ) : null}
+            {skillFeedback.path ? (
+              <p className="ext-skill-feedback__path" title={skillFeedback.path}>
+                <span className="ext-skill-feedback__label">
+                  {tr("ext.skills.feedback.path")}
+                </span>
+                <code>
+                  {shortPathLabel(skillFeedback.path, 64) || skillFeedback.path}
+                </code>
+              </p>
+            ) : null}
+          </div>
+        ) : null}
+      </GlassModal>
+
+      <GlassModal
+        open={skillDiscardOpen}
+        onClose={() => setSkillDiscardOpen(false)}
+        title={tr("ext.skills.editDiscardTitle")}
+        size="sm"
+        closeLabel={tr("common.close")}
+        footer={
+          <>
+            <button
+              type="button"
+              className="btn btn--ghost"
+              onClick={() => setSkillDiscardOpen(false)}
+            >
+              {tr("common.cancel")}
+            </button>
+            <button
+              type="button"
+              className="btn btn--danger"
+              onClick={() => {
+                setSkillDiscardOpen(false);
+                closeSkillEditor();
+              }}
+            >
+              {tr("ext.skills.editDiscard")}
+            </button>
+          </>
+        }
+      >
+        <p className="app-dialog__msg">{tr("ext.skills.editDiscardBody")}</p>
+      </GlassModal>
+
+      <GlassModal
+        open={skillConflictOpen}
+        onClose={() => setSkillConflictOpen(false)}
+        title={tr("ext.skills.editConflictTitle")}
+        size="sm"
+        closeLabel={tr("common.close")}
+        footer={
+          <>
+            <button
+              type="button"
+              className="btn btn--ghost"
+              onClick={() => {
+                setSkillConflictOpen(false);
+                if (skillEditor) void openSkillEditor(skillEditor.skill);
+              }}
+            >
+              {tr("ext.skills.editConflictReload")}
+            </button>
+            <button
+              type="button"
+              className="btn btn--solid"
+              onClick={() => {
+                setSkillConflictOpen(false);
+                void saveSkillEditor({ force: true });
+              }}
+            >
+              {tr("ext.skills.editConflictOverwrite")}
+            </button>
+          </>
+        }
+      >
+        <p className="app-dialog__msg">{tr("ext.skills.editConflictBody")}</p>
+      </GlassModal>
+    </>
+  );
+}

--- a/src/components/ProvidersPanel.tsx
+++ b/src/components/ProvidersPanel.tsx
@@ -12,6 +12,19 @@ import {
   type MouseEvent,
 } from "react";
 import * as api from "@/lib/api";
+import {
+  asFormModel,
+  toFormEfforts,
+  ccSwitchStatusKey,
+  emptyForm,
+  effortsFromProvider,
+  formFromPreset,
+  hostOf,
+  modelsFromProvider,
+  type FormState,
+  type RightMode,
+  type Selection,
+} from "@/lib/providerForm";
 import { createT, type Locale, type MessageKey } from "@/i18n";
 import { Select } from "@/components/Select";
 import { GlassModal } from "@/components/GlassModal";
@@ -52,7 +65,6 @@ import {
 } from "@/lib/providerRouteHonesty";
 import {
   PROVIDER_PRESETS,
-  alignGrokPresetEfforts,
   applyPresetEndpoint,
   defaultCustomChannelEfforts,
   matchPresetEndpoint,
@@ -95,45 +107,6 @@ export interface ProvidersPanelProps {
   ) => void;
 }
 
-type FormEffort = {
-  id: string;
-  name: string;
-  isDefault: boolean;
-};
-
-type FormModel = {
-  /** Upstream request body model id. */
-  id: string;
-  /** Display name shown on composer chip / menu. */
-  name: string;
-  contextWindow?: number | null;
-  supportsVision?: boolean;
-  supportsVideo?: boolean;
-  efforts?: FormEffort[];
-};
-
-function toFormEfforts(
-  list?: Array<{ id: string; name?: string; isDefault?: boolean }>,
-): FormEffort[] | undefined {
-  if (!list?.length) return list ? [] : undefined;
-  return list.map((e) => ({
-    id: e.id,
-    name: e.name?.trim() || e.id,
-    isDefault: !!e.isDefault,
-  }));
-}
-
-function asFormModel(m: api.ProviderModelEntry): FormModel {
-  return {
-    id: m.id,
-    name: m.name,
-    contextWindow: m.contextWindow ?? null,
-    supportsVision: m.supportsVision,
-    supportsVideo: m.supportsVideo,
-    efforts: toFormEfforts(m.efforts),
-  };
-}
-
 function FieldHelp({ label, tip }: { label: string; tip: string }) {
   return (
     <span className="prov-field__label">
@@ -155,162 +128,6 @@ function FieldHelp({ label, tip }: { label: string; tip: string }) {
       ) : null}
     </span>
   );
-}
-
-type FormState = {
-  id: string;
-  name: string;
-  baseUrl: string;
-  /** When true, host keeps baseUrl as-is (no auto `/v1`). */
-  baseUrlFullPath: boolean;
-  apiKey: string;
-  apiBackend: string;
-  providerMode: "generic" | "grok_build_proxy";
-  models: FormModel[];
-  efforts: FormEffort[];
-  /** Extra rules appended to the system prompt on this channel. */
-  appendPrompt: string;
-  /** Explicit: this relay accepts image pixels. */
-  supportsVision: boolean;
-  /** External signup URL for “Get API Key” (from preset). */
-  apiKeyUrl: string | null;
-  extraHeaders: { name: string; value: string }[];
-  /** Prefill / keep per-channel context_window. Null = omit on create. */
-  contextWindow: number | null;
-};
-
-type RightMode = "empty" | "pick" | "create" | "edit" | "official";
-type Selection = null | "official" | string;
-
-const emptyForm = (): FormState => ({
-  id: "",
-  name: "",
-  baseUrl: "",
-  baseUrlFullPath: false,
-  apiKey: "",
-  apiBackend: "responses",
-  providerMode: "generic",
-  appendPrompt: "",
-  supportsVision: false,
-  models: [],
-  efforts: defaultCustomChannelEfforts().map((e) => ({
-    id: e.id,
-    name: e.name || e.id,
-    isDefault: !!e.isDefault,
-  })),
-  apiKeyUrl: null,
-  extraHeaders: [],
-  contextWindow: null,
-});
-
-function modelsFromProvider(p: api.CustomProvider): FormModel[] {
-  if (p.models?.length) {
-    return p.models.map((m) => ({
-      id: m.id,
-      name: m.name?.trim() || m.id,
-      contextWindow: m.contextWindow ?? null,
-      supportsVision: m.supportsVision,
-      supportsVideo: m.supportsVideo,
-      efforts: m.efforts?.map((e) => ({
-        id: e.id,
-        name: e.name?.trim() || e.id,
-        isDefault: !!e.isDefault,
-      })),
-    }));
-  }
-  const id = p.model?.trim() ?? "";
-  if (!id) return [];
-  return [{ id, name: id }];
-}
-
-function effortsFromProvider(p: api.CustomProvider): FormEffort[] {
-  const aligned = alignGrokPresetEfforts({
-    providerId: p.id,
-    baseUrl: p.baseUrl,
-    efforts: p.efforts,
-  });
-  const source = aligned ?? p.efforts;
-  if (source?.length) {
-    return source.map((e) => ({
-      id: e.id,
-      name: e.name?.trim() || e.id,
-      isDefault: !!e.isDefault,
-    }));
-  }
-  return defaultCustomChannelEfforts().map((e) => ({
-    id: e.id,
-    name: e.name || e.id,
-    isDefault: !!e.isDefault,
-  }));
-}
-
-function formFromPreset(preset: ProviderPreset, endpointId?: string): FormState {
-  const applied = applyPresetEndpoint(
-    preset,
-    endpointId ?? preset.defaultEndpointId,
-  );
-  return {
-    id: preset.suggestedId,
-    name: preset.name,
-    baseUrl: applied.baseUrl,
-    // Most presets ship with `/v1`; Volcengine Ark / Zhipu roots are already complete.
-    baseUrlFullPath: applied.baseUrlFullPath,
-    apiKey: "",
-    apiBackend: preset.apiBackend,
-    providerMode: "generic",
-    // Presets carry no channel rules — opt-in per provider.
-    appendPrompt: "",
-    supportsVision: !!preset.supportsVision,
-    models: preset.models.map((m) => ({
-      id: m.id,
-      name: m.name || m.id,
-      contextWindow: m.contextWindow ?? preset.contextWindow ?? null,
-      supportsVision: m.supportsVision ?? preset.supportsVision,
-      supportsVideo: m.supportsVideo,
-      efforts: (m.efforts?.length ? m.efforts : preset.efforts).map((e) => ({
-        id: e.id,
-        name: e.name || e.id,
-        isDefault: !!e.isDefault,
-      })),
-    })),
-    efforts: preset.efforts.map((e) => ({
-      id: e.id,
-      name: e.name || e.id,
-      isDefault: !!e.isDefault,
-    })),
-    apiKeyUrl: applied.apiKeyUrl,
-    extraHeaders: [],
-    contextWindow:
-      preset.contextWindow && preset.contextWindow > 0
-        ? preset.contextWindow
-        : null,
-  };
-}
-
-function hostOf(url: string): string {
-  try {
-    return new URL(url).host || url;
-  } catch {
-    return url;
-  }
-}
-
-function ccSwitchStatusKey(status: string): MessageKey {
-  switch (status) {
-    case "importable":
-      return "prov.ccSwitch.status.importable";
-    case "official":
-      return "prov.ccSwitch.status.official";
-    case "missing_key":
-      return "prov.ccSwitch.status.missing_key";
-    case "proxy_managed":
-      return "prov.ccSwitch.status.proxy_managed";
-    case "exists":
-      return "prov.ccSwitch.status.exists";
-    case "invalid":
-    default:
-      return "prov.ccSwitch.status.invalid";
-  }
 }
 
 export function ProvidersPanel({

--- a/src/hooks/useGitDirtyStatus.test.ts
+++ b/src/hooks/useGitDirtyStatus.test.ts
@@ -1,0 +1,74 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useGitDirtyStatus } from "./useGitDirtyStatus";
+
+vi.mock("@/lib/api", () => ({
+  isTauri: () => true,
+  gitStatus: vi.fn(),
+}));
+
+import * as api from "@/lib/api";
+
+const gitStatusMock = vi.mocked(api.gitStatus);
+
+function dirtyFile(path: string) {
+  return { path };
+}
+
+describe("useGitDirtyStatus", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("summarizes dirty files for the bound project", async () => {
+    gitStatusMock.mockResolvedValue({
+      available: true,
+      files: [dirtyFile("src/a.ts"), dirtyFile("src/b.ts")],
+    } as Awaited<ReturnType<typeof api.gitStatus>>);
+    const { result } = renderHook(() =>
+      useGitDirtyStatus({ projectPath: "/repo", busy: false }),
+    );
+    await vi.waitFor(() => {
+      expect(result.current.gitDirtySummary).not.toBeNull();
+    });
+    expect(result.current.gitDirtySummary?.count).toBe(2);
+    expect(result.current.gitDirtySummary?.label).toContain("2");
+  });
+
+  it("clears to null when no project is bound", async () => {
+    const { result } = renderHook(() =>
+      useGitDirtyStatus({ projectPath: null, busy: false }),
+    );
+    await vi.waitFor(() => {
+      expect(result.current.gitDirtySummary).toBeNull();
+    });
+    expect(gitStatusMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps null on soft-fail (repo missing) instead of erroring", async () => {
+    gitStatusMock.mockRejectedValue(new Error("not a repo"));
+    const { result } = renderHook(() =>
+      useGitDirtyStatus({ projectPath: "/repo", busy: false }),
+    );
+    await vi.waitFor(() => {
+      expect(result.current.gitDirtySummary).toBeNull();
+    });
+  });
+
+  it("forwards the raw status to onStatus (branch chip patch)", async () => {
+    const raw = { available: true, files: [dirtyFile("x.ts")] } as Awaited<
+      ReturnType<typeof api.gitStatus>
+    >;
+    gitStatusMock.mockResolvedValue(raw);
+    const onStatus = vi.fn();
+    renderHook(() =>
+      useGitDirtyStatus({ projectPath: "/repo", busy: false, onStatus }),
+    );
+    await vi.waitFor(() => {
+      expect(onStatus).toHaveBeenCalledWith("/repo", raw);
+    });
+  });
+});

--- a/src/hooks/useGitDirtyStatus.ts
+++ b/src/hooks/useGitDirtyStatus.ts
@@ -1,0 +1,92 @@
+/**
+ * Workspace git dirty summary for the active project (composer chip).
+ * Owns its polling lifecycle: soft poll while a project is bound, faster
+ * while a turn is live, refresh on window focus, paused while hidden.
+ *
+ * Extracted from AppWorkbench (WP: knowledge hiding — the host only needs
+ * the summary value; the poll cadence is this hook's business).
+ */
+import { useCallback, useEffect, useRef, useState } from "react";
+import * as api from "@/lib/api";
+import { startVisibilityPoll } from "@/lib/visibilityPoll";
+import {
+  gitDirtySummariesEqual,
+  summarizeGitDirty,
+  type GitDirtySummary,
+} from "@/lib/workspaceGit";
+
+export type GitStatusBranchPatch = (
+  path: string,
+  status: Awaited<ReturnType<typeof api.gitStatus>>,
+) => void;
+
+export function useGitDirtyStatus(opts: {
+  /** Absolute path of the active project; null when none. */
+  projectPath: string | null | undefined;
+  /** True while a turn is streaming / awaiting permission (faster poll). */
+  busy: boolean;
+  /**
+   * Side-channel: the same poll already fetched HEAD, so the composer
+   * branch chip can be patched without another spawn.
+   */
+  onStatus?: GitStatusBranchPatch;
+  /** Change key for busy (e.g. session id) to re-arm the poll cadence. */
+  busyKey?: string | number | null;
+}) {
+  const { projectPath, busy, onStatus, busyKey } = opts;
+  const onStatusRef = useRef(onStatus);
+  onStatusRef.current = onStatus;
+
+  /** Null when not a repo, unavailable, clean, or no active project. */
+  const [gitDirtySummary, setGitDirtySummary] = useState<GitDirtySummary | null>(
+    null,
+  );
+  const reqRef = useRef(0);
+
+  const refresh = useCallback(async () => {
+    const path = projectPath?.trim() || null;
+    if (!path || !api.isTauri()) {
+      reqRef.current += 1;
+      setGitDirtySummary((prev) => (prev == null ? prev : null));
+      return;
+    }
+    const reqId = ++reqRef.current;
+    try {
+      const status = await api.gitStatus(path);
+      if (reqId !== reqRef.current) return;
+      const next = summarizeGitDirty(status);
+      setGitDirtySummary((prev) =>
+        gitDirtySummariesEqual(prev, next) ? prev : next,
+      );
+      onStatusRef.current?.(path, status);
+    } catch {
+      if (reqId !== reqRef.current) return;
+      setGitDirtySummary((prev) => (prev == null ? prev : null));
+    }
+  }, [projectPath]);
+
+  useEffect(() => {
+    void refresh();
+    // Soft poll while a project is bound; refresh sooner on focus.
+    // Faster while a turn is live — agent may `git switch` mid-session.
+    // Ticks pause while the window is hidden — a minimized app has nothing
+    // to paint, and `git status` is a process spawn per poll.
+    const path = projectPath?.trim() || null;
+    if (!path || !api.isTauri()) return;
+    const intervalMs = busy ? 2000 : 8000;
+    const poll = startVisibilityPoll({
+      tick: () => void refresh(),
+      setIntervalFn: (handler) => window.setInterval(handler, intervalMs),
+    });
+    const onFocus = () => {
+      void refresh();
+    };
+    window.addEventListener("focus", onFocus);
+    return () => {
+      poll.dispose();
+      window.removeEventListener("focus", onFocus);
+    };
+  }, [projectPath, refresh, busy, busyKey]);
+
+  return { gitDirtySummary, refreshGitDirtyStatus: refresh };
+}

--- a/src/hooks/useSessionFileChanges.test.ts
+++ b/src/hooks/useSessionFileChanges.test.ts
@@ -1,0 +1,62 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { useSessionFileChanges } from "./useSessionFileChanges";
+import type { SessionFileChange } from "@/lib/sessionChanges";
+
+function change(path: string): SessionFileChange {
+  return {
+    toolCallId: "tc",
+    toolKind: "write",
+    status: "completed",
+    path,
+    name: path,
+    before: undefined,
+    after: "x",
+    updatedAt: "2026-09-10T00:00:00Z",
+  };
+}
+
+describe("useSessionFileChanges", () => {
+  it("returns an empty list for unknown sessions", () => {
+    const { result } = renderHook(() => useSessionFileChanges());
+    expect(result.current.changesFor("nope")).toEqual([]);
+  });
+
+  it("returns an empty list for null / empty session ids", () => {
+    const { result } = renderHook(() => useSessionFileChanges());
+    expect(result.current.changesFor(null)).toEqual([]);
+    expect(result.current.changesFor("")).toEqual([]);
+  });
+
+  it("returns recorded changes per session id", () => {
+    const { result } = renderHook(() => useSessionFileChanges());
+    act(() => {
+      result.current.setSessionChangesById((prev) => ({
+        ...prev,
+        "s1": [change("a.ts")],
+        "s2": [change("b.ts"), change("c.ts")],
+      }));
+    });
+    expect(result.current.changesFor("s1")).toHaveLength(1);
+    expect(result.current.changesFor("s2")).toHaveLength(2);
+    expect(result.current.changesFor("s3")).toEqual([]);
+  });
+
+  it("keeps other sessions intact when one is updated", () => {
+    const { result } = renderHook(() => useSessionFileChanges());
+    act(() => {
+      result.current.setSessionChangesById(() => ({ s1: [change("a.ts")] }));
+    });
+    act(() => {
+      result.current.setSessionChangesById((prev) => ({
+        ...prev,
+        s2: [change("b.ts")],
+      }));
+    });
+    expect(result.current.changesFor("s1")).toHaveLength(1);
+    expect(result.current.changesFor("s2")).toHaveLength(1);
+  });
+});

--- a/src/hooks/useSessionFileChanges.ts
+++ b/src/hooks/useSessionFileChanges.ts
@@ -1,0 +1,33 @@
+/**
+ * Per-session file-change records (Review panel / dirty-chip data source).
+ *
+ * Writers: the host-event layer (`session://tool` batch apply via ctx) and
+ * journal hydration (`host.hydrate.applyOpenResult` + Review seeding).
+ * Readers: chat stage, resources aside, and the dirty-chip summary — all
+ * through `changesFor`, which owns the empty-list fallback.
+ *
+ * Extracted from AppWorkbench (WP: knowledge hiding — the host only routes
+ * writers and readers; the record shape and fallback are this hook's business).
+ */
+import { useCallback, useState } from "react";
+import {
+  EMPTY_SESSION_FILE_CHANGES,
+  type SessionFileChange,
+} from "@/lib/sessionChanges";
+
+export function useSessionFileChanges() {
+  const [sessionChangesById, setSessionChangesById] = useState<
+    Record<string, SessionFileChange[]>
+  >({});
+
+  /** Changes recorded for a session; empty list when none recorded. */
+  const changesFor = useCallback(
+    (sessionId: string | null | undefined): SessionFileChange[] =>
+      sessionId
+        ? (sessionChangesById[sessionId] ?? EMPTY_SESSION_FILE_CHANGES)
+        : EMPTY_SESSION_FILE_CHANGES,
+    [sessionChangesById],
+  );
+
+  return { sessionChangesById, setSessionChangesById, changesFor };
+}

--- a/src/lib/errorBannerActions.test.ts
+++ b/src/lib/errorBannerActions.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import {
+  ERROR_BANNER_SETTINGS_ROUTE,
+  isErrorBannerDismissOnly,
+} from "./errorBannerActions";
+import type { ErrorDeckActionId } from "@/lib/errorDeck";
+
+describe("ERROR_BANNER_SETTINGS_ROUTE", () => {
+  it("routes every settings-type action to a section", () => {
+    expect(ERROR_BANNER_SETTINGS_ROUTE.open_runtime).toEqual({
+      section: "runtime",
+    });
+    expect(ERROR_BANNER_SETTINGS_ROUTE.open_network).toEqual({
+      section: "runtime",
+      tab: "network",
+    });
+    expect(ERROR_BANNER_SETTINGS_ROUTE.open_permissions).toEqual({
+      section: "general",
+      tab: "permissions",
+    });
+    expect(ERROR_BANNER_SETTINGS_ROUTE.open_providers?.section).toBe(
+      "account",
+    );
+    expect(ERROR_BANNER_SETTINGS_ROUTE.open_extensions?.section).toBe(
+      "extensions",
+    );
+    expect(ERROR_BANNER_SETTINGS_ROUTE.upgrade_cli?.section).toBe("runtime");
+  });
+
+  it("does not route verb-type actions (host handles those)", () => {
+    const verbs: ErrorDeckActionId[] = [
+      "reconnect",
+      "open_doctor",
+      "open_mcp",
+      "trust_project",
+      "relocate_project",
+      "add_project",
+      "cancel_turn",
+      "dismiss",
+      "keep_waiting",
+    ];
+    for (const id of verbs) {
+      expect(ERROR_BANNER_SETTINGS_ROUTE[id]).toBeUndefined();
+    }
+  });
+});
+
+describe("isErrorBannerDismissOnly", () => {
+  it("covers dismiss and the stream-stall keep-waiting prompt", () => {
+    expect(isErrorBannerDismissOnly("dismiss")).toBe(true);
+    expect(isErrorBannerDismissOnly("keep_waiting")).toBe(true);
+    expect(isErrorBannerDismissOnly("reconnect")).toBe(false);
+    expect(isErrorBannerDismissOnly("cancel_turn")).toBe(false);
+  });
+});

--- a/src/lib/errorBannerActions.ts
+++ b/src/lib/errorBannerActions.ts
@@ -1,0 +1,41 @@
+/**
+ * Routing table for error-banner primary actions (ErrorDeckActionId →
+ * settings navigation target). Pure data so the host dispatcher stays a
+ * lookup + grouped verbs instead of a 16-case switch.
+ *
+ * Actions that are NOT settings navigation (reconnect, doctor, mcp modal,
+ * project verbs, turn control) stay in the host callback — they are real
+ * side effects, not routes.
+ */
+import type { ErrorDeckActionId } from "@/lib/errorDeck";
+import type { SettingsSectionId } from "@/lib/settingsCatalog";
+
+export type SettingsRoute = {
+  section: SettingsSectionId;
+  /** Optional anchor/tab inside the section. */
+  tab?: string | null;
+};
+
+/**
+ * Settings-navigation routes for banner action ids. Ids missing from this
+ * map are handled by the host's verb cases (reconnect / doctor / mcp /
+ * project verbs / turn control / dismiss).
+ */
+export const ERROR_BANNER_SETTINGS_ROUTE: Partial<
+  Record<ErrorDeckActionId, SettingsRoute>
+> = {
+  open_runtime: { section: "runtime" },
+  upgrade_cli: { section: "runtime" },
+  open_network: { section: "runtime", tab: "network" },
+  open_account: { section: "account" },
+  // Providers live under account / extensions path — account is the
+  // login+key surface; extensions holds MCP. Prefer account for keys.
+  open_providers: { section: "account" },
+  open_permissions: { section: "general", tab: "permissions" },
+  open_extensions: { section: "extensions" },
+};
+
+/** True when the action id only clears the banner (no side effect). */
+export function isErrorBannerDismissOnly(id: ErrorDeckActionId): boolean {
+  return id === "dismiss" || id === "keep_waiting";
+}

--- a/src/lib/providerForm.test.ts
+++ b/src/lib/providerForm.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import {
+  asFormModel,
+  ccSwitchStatusKey,
+  emptyForm,
+  formFromPreset,
+  hostOf,
+  modelsFromProvider,
+  toFormEfforts,
+} from "./providerForm";
+import { PROVIDER_PRESETS } from "@/lib/providerPresets";
+
+describe("toFormEfforts", () => {
+  it("maps entries and trims empty names to ids", () => {
+    const out = toFormEfforts([
+      { id: "high", name: "  " },
+      { id: "low", name: "Low", isDefault: true },
+    ]);
+    expect(out).toEqual([
+      { id: "high", name: "high", isDefault: false },
+      { id: "low", name: "Low", isDefault: true },
+    ]);
+  });
+
+  it("keeps undefined for absent lists and [] for empty ones", () => {
+    expect(toFormEfforts(undefined)).toBeUndefined();
+    expect(toFormEfforts([])).toEqual([]);
+  });
+});
+
+describe("asFormModel", () => {
+  it("normalizes contextWindow null and passes flags through", () => {
+    const out = asFormModel({
+      id: "m1",
+      name: "M1",
+      contextWindow: undefined,
+      supportsVision: true,
+      supportsVideo: false,
+    } as Parameters<typeof asFormModel>[0]);
+    expect(out.contextWindow).toBeNull();
+    expect(out.supportsVision).toBe(true);
+    expect(out.efforts).toBeUndefined();
+  });
+});
+
+describe("modelsFromProvider", () => {
+  it("uses explicit models when present", () => {
+    const out = modelsFromProvider({
+      id: "p",
+      models: [{ id: "a" }, { id: "b", name: "B" }],
+    } as Parameters<typeof modelsFromProvider>[0]);
+    expect(out.map((m) => m.id)).toEqual(["a", "b"]);
+    expect(out[1]?.name).toBe("B");
+  });
+
+  it("falls back to the legacy single model field", () => {
+    const out = modelsFromProvider({
+      id: "p",
+      model: "legacy-id",
+    } as Parameters<typeof modelsFromProvider>[0]);
+    expect(out).toEqual([{ id: "legacy-id", name: "legacy-id" }]);
+  });
+
+  it("returns empty when the provider has no model at all", () => {
+    const out = modelsFromProvider({ id: "p" } as Parameters<
+      typeof modelsFromProvider
+    >[0]);
+    expect(out).toEqual([]);
+  });
+});
+
+describe("emptyForm", () => {
+  it("seeds default custom-channel efforts and neutral defaults", () => {
+    const f = emptyForm();
+    expect(f.id).toBe("");
+    expect(f.providerMode).toBe("generic");
+    expect(f.apiBackend).toBe("responses");
+    expect(f.efforts.length).toBeGreaterThan(0);
+    expect(f.models).toEqual([]);
+  });
+});
+
+describe("formFromPreset", () => {
+  it("builds a form from a real preset with its default endpoint", () => {
+    const preset = PROVIDER_PRESETS[0];
+    const f = formFromPreset(preset);
+    expect(f.id).toBe(preset.suggestedId);
+    expect(f.name).toBe(preset.name);
+    expect(f.baseUrl).toContain("http");
+    expect(f.apiKey).toBe("");
+    expect(f.models.length).toBe(preset.models.length);
+  });
+});
+
+describe("hostOf", () => {
+  it("extracts the host of valid urls and passes junk through", () => {
+    expect(hostOf("https://api.example.com/v1")).toBe("api.example.com");
+    expect(hostOf("not a url")).toBe("not a url");
+  });
+});
+
+describe("ccSwitchStatusKey", () => {
+  it("maps every known status and falls back to invalid", () => {
+    expect(ccSwitchStatusKey("importable")).toBe("prov.ccSwitch.status.importable");
+    expect(ccSwitchStatusKey("official")).toBe("prov.ccSwitch.status.official");
+    expect(ccSwitchStatusKey("missing_key")).toBe("prov.ccSwitch.status.missing_key");
+    expect(ccSwitchStatusKey("proxy_managed")).toBe("prov.ccSwitch.status.proxy_managed");
+    expect(ccSwitchStatusKey("exists")).toBe("prov.ccSwitch.status.exists");
+    expect(ccSwitchStatusKey("whatever")).toBe("prov.ccSwitch.status.invalid");
+  });
+});

--- a/src/lib/providerForm.ts
+++ b/src/lib/providerForm.ts
@@ -1,0 +1,210 @@
+/**
+ * Custom-provider form mapping: ProviderModelEntry / CustomProvider /
+ * ProviderPreset → the panel's FormState, plus small label helpers.
+ * Pure functions extracted from ProvidersPanel so the mapping is testable
+ * without rendering the panel.
+ */
+import * as api from "@/lib/api";
+import type { MessageKey } from "@/i18n";
+import {
+  alignGrokPresetEfforts,
+  applyPresetEndpoint,
+  defaultCustomChannelEfforts,
+  type ProviderPreset,
+} from "@/lib/providerPresets";
+
+export type FormEffort = {
+  id: string;
+  name: string;
+  isDefault: boolean;
+};
+
+export type FormModel = {
+  /** Upstream request body model id. */
+  id: string;
+  /** Display name shown on composer chip / menu. */
+  name: string;
+  contextWindow?: number | null;
+  supportsVision?: boolean;
+  supportsVideo?: boolean;
+  efforts?: FormEffort[];
+};
+
+export function toFormEfforts(
+  list?: Array<{ id: string; name?: string; isDefault?: boolean }>,
+): FormEffort[] | undefined {
+  if (!list?.length) return list ? [] : undefined;
+  return list.map((e) => ({
+    id: e.id,
+    name: e.name?.trim() || e.id,
+    isDefault: !!e.isDefault,
+  }));
+}
+
+export function asFormModel(m: api.ProviderModelEntry): FormModel {
+  return {
+    id: m.id,
+    name: m.name,
+    contextWindow: m.contextWindow ?? null,
+    supportsVision: m.supportsVision,
+    supportsVideo: m.supportsVideo,
+    efforts: toFormEfforts(m.efforts),
+  };
+}
+
+export type FormState = {
+  id: string;
+  name: string;
+  baseUrl: string;
+  /** When true, host keeps baseUrl as-is (no auto `/v1`). */
+  baseUrlFullPath: boolean;
+  apiKey: string;
+  apiBackend: string;
+  providerMode: "generic" | "grok_build_proxy";
+  models: FormModel[];
+  efforts: FormEffort[];
+  /** Extra rules appended to the system prompt on this channel. */
+  appendPrompt: string;
+  /** Explicit: this relay accepts image pixels. */
+  supportsVision: boolean;
+  /** External signup URL for “Get API Key” (from preset). */
+  apiKeyUrl: string | null;
+  extraHeaders: { name: string; value: string }[];
+  /** Prefill / keep per-channel context_window. Null = omit on create. */
+  contextWindow: number | null;
+};
+
+export type RightMode = "empty" | "pick" | "create" | "edit" | "official";
+export type Selection = null | "official" | string;
+
+export const emptyForm = (): FormState => ({
+  id: "",
+  name: "",
+  baseUrl: "",
+  baseUrlFullPath: false,
+  apiKey: "",
+  apiBackend: "responses",
+  providerMode: "generic",
+  appendPrompt: "",
+  supportsVision: false,
+  models: [],
+  efforts: defaultCustomChannelEfforts().map((e) => ({
+    id: e.id,
+    name: e.name || e.id,
+    isDefault: !!e.isDefault,
+  })),
+  apiKeyUrl: null,
+  extraHeaders: [],
+  contextWindow: null,
+});
+
+export function modelsFromProvider(p: api.CustomProvider): FormModel[] {
+  if (p.models?.length) {
+    return p.models.map((m) => ({
+      id: m.id,
+      name: m.name?.trim() || m.id,
+      contextWindow: m.contextWindow ?? null,
+      supportsVision: m.supportsVision,
+      supportsVideo: m.supportsVideo,
+      efforts: m.efforts?.map((e) => ({
+        id: e.id,
+        name: e.name?.trim() || e.id,
+        isDefault: !!e.isDefault,
+      })),
+    }));
+  }
+  const id = p.model?.trim() ?? "";
+  if (!id) return [];
+  return [{ id, name: id }];
+}
+
+export function effortsFromProvider(p: api.CustomProvider): FormEffort[] {
+  const aligned = alignGrokPresetEfforts({
+    providerId: p.id,
+    baseUrl: p.baseUrl,
+    efforts: p.efforts,
+  });
+  const source = aligned ?? p.efforts;
+  if (source?.length) {
+    return source.map((e) => ({
+      id: e.id,
+      name: e.name?.trim() || e.id,
+      isDefault: !!e.isDefault,
+    }));
+  }
+  return defaultCustomChannelEfforts().map((e) => ({
+    id: e.id,
+    name: e.name || e.id,
+    isDefault: !!e.isDefault,
+  }));
+}
+
+export function formFromPreset(preset: ProviderPreset, endpointId?: string): FormState {
+  const applied = applyPresetEndpoint(
+    preset,
+    endpointId ?? preset.defaultEndpointId,
+  );
+  return {
+    id: preset.suggestedId,
+    name: preset.name,
+    baseUrl: applied.baseUrl,
+    // Most presets ship with `/v1`; Volcengine Ark / Zhipu roots are already complete.
+    baseUrlFullPath: applied.baseUrlFullPath,
+    apiKey: "",
+    apiBackend: preset.apiBackend,
+    providerMode: "generic",
+    // Presets carry no channel rules — opt-in per provider.
+    appendPrompt: "",
+    supportsVision: !!preset.supportsVision,
+    models: preset.models.map((m) => ({
+      id: m.id,
+      name: m.name || m.id,
+      contextWindow: m.contextWindow ?? preset.contextWindow ?? null,
+      supportsVision: m.supportsVision ?? preset.supportsVision,
+      supportsVideo: m.supportsVideo,
+      efforts: (m.efforts?.length ? m.efforts : preset.efforts).map((e) => ({
+        id: e.id,
+        name: e.name || e.id,
+        isDefault: !!e.isDefault,
+      })),
+    })),
+    efforts: preset.efforts.map((e) => ({
+      id: e.id,
+      name: e.name || e.id,
+      isDefault: !!e.isDefault,
+    })),
+    apiKeyUrl: applied.apiKeyUrl,
+    extraHeaders: [],
+    contextWindow:
+      preset.contextWindow && preset.contextWindow > 0
+        ? preset.contextWindow
+        : null,
+  };
+}
+
+export function hostOf(url: string): string {
+  try {
+    return new URL(url).host || url;
+  } catch {
+    return url;
+  }
+}
+
+export function ccSwitchStatusKey(status: string): MessageKey {
+  switch (status) {
+    case "importable":
+      return "prov.ccSwitch.status.importable";
+    case "official":
+      return "prov.ccSwitch.status.official";
+    case "missing_key":
+      return "prov.ccSwitch.status.missing_key";
+    case "proxy_managed":
+      return "prov.ccSwitch.status.proxy_managed";
+    case "exists":
+      return "prov.ccSwitch.status.exists";
+    case "invalid":
+    default:
+      return "prov.ccSwitch.status.invalid";
+  }
+}
+


### PR DESCRIPTION
## Summary
`ExtensionsPanel` renders **17 GlassModals inline**. This moves the five Skills-tab modals — new-skill scaffold, editor, save feedback, discard confirm, write-conflict confirm (~440 lines of JSX) — verbatim into [`ExtensionsPanelSkillModals.tsx`](src/components/ExtensionsPanelSkillModals.tsx), with one typed props bundle threading the skill state cluster (new/editor/feedback state, editor verbs, kind labels/hints).

**The three extensions-surface guard tests pass unchanged** — the tab surface and the plugins/MCP modals stay in the panel, so the surface-div→first-GlassModal adjacency the guards assert is intact. The plugins/MCP modal farm is the follow-up tranche.

`ExtensionsPanel`: 4,391 → **3,980 lines**. Part of the giant-component decomposition series (#1163 was the first tranche: the form-mapping layer).

## Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Refactor / chore

## Checklist
- [x] `pnpm typecheck` / `pnpm test` (646 files incl. the 3 guard suites) / `lint` / gates / self-test / `build:ui` — all green
- [x] No Rust change
- [x] No user-facing strings / no visual change (JSX moved verbatim)
- [x] No secrets included