### PR TITLE
fix(account): restore saved accounts list in the user menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ See `docs/llm-wiki/release.md`.
 - 输入框上的分支 chip 可在当前目录切换 git 分支。仅远程存在的分支会建本地跟踪分支；已在其他 worktree 检出的则切到那个 worktree。
 
 ### Fixed
+- The user menu lists every saved official account and remaining quota again.
 - Math formulas render with one matching KaTeX version again. The bundled CSS had drifted ahead of the JS.
 - Wallpaper no longer flashes black while streaming or following the chat tail.
 - Reconnect from the error banner always uses the latest connection state.
@@ -28,6 +29,7 @@ See `docs/llm-wiki/release.md`.
 - Generated wallpaper stays visible when library indexing fails and can be saved again.
 
 **中文 · 修复**
+- 用户菜单再次列出本机已保存的官方账号及各自剩余额度。
 - 数学公式恢复 CSS 与 JS 同版本渲染，不再出现样式超前于脚本。
 - 流式输出和自动跟随聊天底部时，静态及动态壁纸不再闪黑。
 - 错误横幅上的重连始终使用最新的连接状态。

--- a/docs/llm-wiki/account.md
+++ b/docs/llm-wiki/account.md
@@ -7,7 +7,7 @@ Product rules for **official login, membership, quota, and usage** in Grok App.
 1. Sign in with the **same** Grok Build CLI auth (`grok login`), not a parallel OAuth stack.
 2. Show account + membership at two depths:
    - **Sidebar footer identity**: avatar + display name + **compact remain** (SuperGrok remaining `%`, or DeepSeek / balance-capable custom `total CURRENCY`). Whole row opens the user menu. Signed-out / unsupported custom has no remain chip. Settings gear stays on the right.
-   - **User menu sheet** (identity click): **full quota or provider-balance card at the top** (plan + reset + bar / balance + refresh), then what's new, tour, theme, login/logout. Switch accounts in Settings → Account.
+   - **User menu sheet** (identity click): **full quota or provider-balance card at the top** (plan + reset + bar / balance + refresh), then **saved official accounts** with honest remaining % (click another → `account_switch`; click active → Settings → Account), then what's new, tour, theme, login/logout. Settings → Account keeps the full switcher / remove / rename UI.
    - **Settings → Account**: full profile, subscription, quota, token activity heatmap, recent session call logs, CLI path, Doctor.
 3. Never log tokens, API keys, or `auth.json` secrets (redact).
 

--- a/src/app/WorkbenchSidebar.tsx
+++ b/src/app/WorkbenchSidebar.tsx
@@ -190,13 +190,16 @@ export function WorkbenchSidebar(props: WorkbenchSidebarProps) {
     loadProviderBalance,
     applyThemeChoice,
     onSettings,
+    onAccountSettings,
     onTutorial,
     onLogin,
     onLogout,
+    savedAccounts,
+    activeAccountId,
+    accountQuotas,
+    onSwitchAccount,
     onUserMenuOpened,
   } = props;
-  // Account deep-link stays on Settings gear / Account section (no footer pin).
-  void props.onAccountSettings;
 
   const providerSupportsBalance =
     !!activeCustomProvider &&
@@ -424,6 +427,7 @@ export function WorkbenchSidebar(props: WorkbenchSidebarProps) {
               closeImmediately={closeImmediately}
               theme={theme}
               themePreference={themePreference}
+              locale={locale}
               account={account}
               activeProvider={activeCustomProvider}
               accountBusy={accountBusy}
@@ -453,6 +457,11 @@ export function WorkbenchSidebar(props: WorkbenchSidebarProps) {
                     }
                   : null
               }
+              savedAccounts={savedAccounts}
+              activeAccountId={activeAccountId}
+              accountQuotas={accountQuotas}
+              onSwitchAccount={onSwitchAccount}
+              onAccountSettings={onAccountSettings}
               labels={{
                 whatsNew: tr("whatsNew.menu"),
                 tutorial: tr("tutorial.menu"),
@@ -463,6 +472,10 @@ export function WorkbenchSidebar(props: WorkbenchSidebarProps) {
                 themeEditor: tr("user.themeEditor"),
                 login: tr("account.login"),
                 logout: tr("account.logout"),
+                remaining: tr("account.quotaRemaining"),
+                profileActive: tr("account.profileActive"),
+                switchTo: tr("account.switchTo"),
+                resetsAt: tr("account.resetsAt"),
               }}
               onWhatsNew={() => requestWhatsNewOpen()}
               onTutorial={onTutorial}

--- a/src/components/UserMenu.test.tsx
+++ b/src/components/UserMenu.test.tsx
@@ -164,3 +164,87 @@ it("clears an open account menu when the sidebar collapses", async () => {
   view.rerender(<Harness collapsed={false} />);
   expect(document.querySelector(".user-menu__pop--portal")).toBeNull();
 });
+
+it("lists saved official accounts with remaining quota and switches on click", async () => {
+  const onSwitchAccount = vi.fn();
+  const onAccountSettings = vi.fn();
+  const account = {
+    profile: {
+      signedIn: true,
+      name: "Alice",
+      email: "alice@x.ai",
+      userId: "u1",
+    },
+    channel: "official_oauth" as const,
+    billing: {
+      plan: "SuperGrok",
+      usedPercent: 40,
+      remainingPercent: 60,
+      resetsAt: null,
+      fetchedAt: null,
+    },
+  };
+  render(
+    <UserMenu
+      open
+      onClose={() => undefined}
+      theme="dark"
+      themePreference="dark"
+      labels={{
+        ...labels,
+        remaining: "remaining",
+        profileActive: "Active",
+        switchTo: "Switch to",
+        resetsAt: "Resets",
+      }}
+      account={account as never}
+      activeProvider={null}
+      accountBusy={false}
+      savedAccounts={[
+        {
+          id: "a1",
+          email: "alice@x.ai",
+          displayName: "Alice",
+          label: "Alice",
+          updatedAt: "",
+        },
+        {
+          id: "a2",
+          email: "bob@x.ai",
+          displayName: "Bob",
+          label: "Bob",
+          updatedAt: "",
+        },
+      ]}
+      activeAccountId="a1"
+      accountQuotas={{
+        a2: {
+          remainingPercent: 25,
+          usedPercent: 75,
+          resetsAt: null,
+          available: true,
+        },
+      }}
+      onSwitchAccount={onSwitchAccount}
+      onAccountSettings={onAccountSettings}
+      onTheme={() => undefined}
+      onLogin={() => undefined}
+      onLogout={() => undefined}
+    >
+      <button type="button">Account</button>
+    </UserMenu>,
+  );
+
+  await waitFor(() =>
+    expect(screen.getByTestId("user-menu-accounts")).toBeTruthy(),
+  );
+  expect(screen.getByRole("menuitem", { name: "Alice, Active" })).toBeTruthy();
+  expect(screen.getByRole("menuitem", { name: "Switch to: Bob" })).toBeTruthy();
+  expect(screen.getByText("25% remaining")).toBeTruthy();
+
+  fireEvent.click(screen.getByRole("menuitem", { name: "Switch to: Bob" }));
+  expect(onSwitchAccount).toHaveBeenCalledWith("a2");
+
+  fireEvent.click(screen.getByRole("menuitem", { name: "Alice, Active" }));
+  expect(onAccountSettings).toHaveBeenCalled();
+});

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -1,6 +1,7 @@
 /**
  * Personal center — compact upward menu.
- * Optional quota / provider-balance header sits above what's new · theme · auth.
+ * Optional quota / provider-balance header, then saved official accounts,
+ * then what's new · theme · auth.
  */
 
 import {
@@ -21,13 +22,24 @@ import {
   IconThemeMoon,
   IconThemeSun,
 } from "@/components/icons";
+import { GrokLogo } from "@/components/GrokLogo";
 import type { Theme, ThemePreference } from "@/lib/theme";
 import {
   FLOATING_MENU_Z_INDEX,
   useFloatingMenu,
 } from "@/lib/floatingMenu";
 import { OPEN_PRESENCE_MS, useOpenPresence } from "@/lib/openPresence";
-import type { AccountStatus, CustomProvider } from "@/lib/api";
+import type { AccountStatus, CustomProvider, SavedAccount } from "@/lib/api";
+import { formatQuotaResetTime } from "@/lib/accountUi";
+import {
+  formatQuotaRemainLabel,
+  resolveQuotaPercents,
+} from "@/lib/accountQuotaHonesty";
+import {
+  mergeAccountQuota,
+  switcherDisplayName,
+  type SwitcherQuota,
+} from "@/lib/accountSwitcherQuota";
 
 export type UserMenuOfficialQuota = {
   plan: string;
@@ -56,6 +68,8 @@ export interface UserMenuProps {
   theme: Theme;
   /** Preference driving the theme submenu selection. */
   themePreference: ThemePreference;
+  /** App locale so per-account reset clocks follow Settings. */
+  locale?: string;
   labels: {
     /** Optional what's-new entry (account menu, above the tour). */
     whatsNew?: string;
@@ -69,6 +83,14 @@ export interface UserMenuProps {
     themeEditor?: string;
     login: string;
     logout: string;
+    /** Suffix after remain %, e.g. "remaining". */
+    remaining?: string;
+    /** Active-account badge, e.g. "Active". */
+    profileActive?: string;
+    /** Aria prefix when switching, e.g. "Switch to this account". */
+    switchTo?: string;
+    /** Prefix before reset time, e.g. "Resets". */
+    resetsAt?: string;
   };
   account: AccountStatus | null;
   activeProvider: CustomProvider | null;
@@ -77,6 +99,13 @@ export interface UserMenuProps {
   officialQuota?: UserMenuOfficialQuota | null;
   /** DeepSeek (etc.) balance card at the top of the sheet. */
   providerBalance?: UserMenuProviderBalance | null;
+  /** Saved official account snapshots for in-menu switch. */
+  savedAccounts?: SavedAccount[];
+  activeAccountId?: string | null;
+  accountQuotas?: Record<string, SwitcherQuota>;
+  onSwitchAccount?: (id: string) => void;
+  /** Active row opens Settings → Account. */
+  onAccountSettings?: () => void;
   /** Re-open the current version's update notes. */
   onWhatsNew?: () => void;
   /** Open optional in-app product tour */
@@ -132,12 +161,18 @@ export function UserMenu({
   onClose,
   theme,
   themePreference,
+  locale = "en",
   labels,
   account,
   activeProvider,
   accountBusy,
   officialQuota = null,
   providerBalance = null,
+  savedAccounts = [],
+  activeAccountId = null,
+  accountQuotas = {},
+  onSwitchAccount,
+  onAccountSettings,
   onWhatsNew,
   onTutorial,
   onTheme,
@@ -231,7 +266,7 @@ export function UserMenu({
     width: 0,
     fitContent: false,
     matchTriggerWidth: true,
-    estHeight: 220,
+    estHeight: savedAccounts.length > 1 ? 360 : 260,
     gap: 6,
     // CSS owns transform (rise from the footer). Do not apply placeAbove -100%.
     anchorTransform: false,
@@ -244,6 +279,13 @@ export function UserMenu({
 
   const isCustomProvider = activeProvider != null;
   const signedIn = !isCustomProvider && !!account?.profile?.signedIn;
+  const profile = account?.profile ?? null;
+  const livePercents = resolveQuotaPercents(account?.billing ?? null);
+  const showSavedOfficialAccounts = signedIn && savedAccounts.length > 0;
+  const remainingWord = labels.remaining ?? "remaining";
+  const profileActiveLabel = labels.profileActive ?? "Active";
+  const switchToLabel = labels.switchTo ?? "Switch to this account";
+  const resetsAtLabel = labels.resetsAt ?? "Resets";
 
   const themeLabel = (pref: ThemePreference) => {
     if (pref === "system") return labels.themeSystem;
@@ -414,6 +456,133 @@ export function UserMenu({
             ) : null}
 
             {officialQuota || providerBalance ? (
+              <div className="user-menu__sep" role="separator" />
+            ) : null}
+
+            {showSavedOfficialAccounts ? (
+              <div className="user-menu__accounts" data-testid="user-menu-accounts">
+                {savedAccounts.map((saved) => {
+                  const active = saved.id === activeAccountId;
+                  const rowName = switcherDisplayName(saved);
+                  const q = mergeAccountQuota(
+                    saved.id,
+                    saved.email,
+                    accountQuotas,
+                    {
+                      id: activeAccountId,
+                      email: profile?.email,
+                      remaining: livePercents.remainingPercent,
+                      used: livePercents.usedPercent,
+                      resetsAt: account?.billing?.resetsAt ?? null,
+                    },
+                  );
+                  const rowRemain = q?.remainingPercent ?? null;
+                  const rowUsed = q?.usedPercent ?? null;
+                  const rowReset = formatQuotaResetTime(q?.resetsAt, locale);
+                  const rowRemainLabel = formatQuotaRemainLabel(rowRemain);
+                  const low = rowRemain != null && rowRemain <= 10;
+                  return (
+                    <button
+                      key={saved.id}
+                      type="button"
+                      className={
+                        "user-menu__account" +
+                        (active ? " is-active" : "") +
+                        (low ? " is-low" : "")
+                      }
+                      role="menuitem"
+                      disabled={accountBusy}
+                      aria-current={active ? "true" : undefined}
+                      aria-label={
+                        active
+                          ? `${rowName}, ${profileActiveLabel}`
+                          : `${switchToLabel}: ${rowName}`
+                      }
+                      onClick={() => {
+                        if (active) {
+                          onClose();
+                          onAccountSettings?.();
+                          return;
+                        }
+                        if (!onSwitchAccount) return;
+                        onClose();
+                        onSwitchAccount(saved.id);
+                      }}
+                    >
+                      <div className="user-menu__account-top">
+                        <div
+                          className="account-avatar account-avatar--sm"
+                          aria-hidden
+                        >
+                          {active && signedIn ? (
+                            <GrokLogo size={17} />
+                          ) : (
+                            rowName.slice(0, 1).toUpperCase()
+                          )}
+                        </div>
+                        <div className="user-menu__account-text">
+                          <div className="user-menu__account-name-row">
+                            <div className="user-menu__account-id">
+                              <div className="user-menu__account-name">
+                                {rowName}
+                              </div>
+                              {active ? (
+                                <span className="user-menu__current">
+                                  {profileActiveLabel}
+                                </span>
+                              ) : null}
+                            </div>
+                            {rowReset ? (
+                              <span className="user-menu__quota-reset">
+                                {resetsAtLabel} {rowReset}
+                              </span>
+                            ) : null}
+                          </div>
+                          <div className="user-menu__quota">
+                            <div className="user-menu__quota-row">
+                              <span className="user-menu__tier">
+                                {active
+                                  ? (officialQuota?.plan ?? "Grok Build")
+                                  : saved.email && saved.email !== rowName
+                                    ? saved.email
+                                    : "\u00a0"}
+                              </span>
+                              <span className="user-menu__remain">
+                                {rowRemainLabel
+                                  ? `${rowRemainLabel} ${remainingWord}`
+                                  : "—"}
+                              </span>
+                            </div>
+                            {rowRemainLabel ? (
+                              <div
+                                className="account-quota-bar account-quota-bar--sm"
+                                aria-hidden
+                              >
+                                <div
+                                  className={
+                                    "account-quota-bar__fill" +
+                                    (rowUsed != null && rowUsed >= 90
+                                      ? " is-danger"
+                                      : rowUsed != null && rowUsed >= 70
+                                        ? " is-warn"
+                                        : "")
+                                  }
+                                  style={{
+                                    width: `${Math.min(100, rowUsed ?? 0)}%`,
+                                  }}
+                                />
+                              </div>
+                            ) : null}
+                          </div>
+                        </div>
+                      </div>
+                    </button>
+                  );
+                })}
+              </div>
+            ) : null}
+
+            {showSavedOfficialAccounts ? (
               <div className="user-menu__sep" role="separator" />
             ) : null}
 


### PR DESCRIPTION
## Summary
- Restore the multi-account list in the sidebar user menu (honest remaining % per saved official account).
- Keep the current-account quota / provider-balance card at the top.
- Click active row → Settings → Account; click another → `account_switch`.
- Update `docs/llm-wiki/account.md` Goals to match Multi-account.

Fixes #1142 (regression vs v0.2.33 / #621 / #625).

## Type of change
- [x] Bug fix

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm exec vitest run src/components/UserMenu.test.tsx src/app/WorkbenchSidebar.footer.test.tsx src/lib/whatsNew.test.ts`