### PR TITLE
fix(chat): stop pin-snap flash; keep wallpaper frost stable while streaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ See `docs/llm-wiki/release.md`.
 - 输入框上的分支 chip 可在当前目录切换 git 分支。仅远程存在的分支会建本地跟踪分支；已在其他 worktree 检出的则切到那个 worktree。
 
 ### Fixed
+- Slow trackpad scrolling up from the chat tail no longer snaps back or flashes.
+- Wallpaper frost stays stable while streaming on macOS.
 - The user menu lists every saved official account and remaining quota again.
 - Math formulas render with one matching KaTeX version again. The bundled CSS had drifted ahead of the JS.
 - Wallpaper no longer flashes black while streaming or following the chat tail.
@@ -29,6 +31,8 @@ See `docs/llm-wiki/release.md`.
 - Generated wallpaper stays visible when library indexing fails and can be saved again.
 
 **中文 · 修复**
+- 从聊天底部慢慢上滑时，不再被弹回底部或闪一下。
+- 流式输出时壁纸霜化层保持稳定，不再随 stream-perf 重建。
 - 用户菜单再次列出本机已保存的官方账号及各自剩余额度。
 - 数学公式恢复 CSS 与 JS 同版本渲染，不再出现样式超前于脚本。
 - 流式输出和自动跟随聊天底部时，静态及动态壁纸不再闪黑。

--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -15,6 +15,10 @@ import { usePetCompanion } from "@/hooks/usePetCompanion";
 import { useFloatingMenu } from "@/lib/floatingMenu";
 import { restoreSessionGate } from "@/lib/sessionGateRestore";
 import { DEFAULT_WALLPAPER_FOCUS } from "@/lib/themeSkin";
+import {
+  setStreamPerfActive,
+  shouldSyncStreamPerfDataset,
+} from "@/lib/streamRenderPolicy";
 import { formatRelativeTime } from "@/lib/accountUi";
 import { loadConfirmExternalLinksPref } from "@/lib/externalLinkPref";
 import {
@@ -5509,13 +5513,21 @@ export function AppWorkbench() {
   const lastUserMessageId = transcriptMeta.lastUserId;
 
   // Streaming perf mode — shrink browse overscan on integrated GPU Retina.
-  // Do not zero the flag in the update cleanup (that flashes 1→0→1).
-  // Turn it off after paint so it does not restyle in the same frame as settle.
+  // Module flag drives JS readers; html data-stream-perf is only for CSS that
+  // is already gated off wallpaper. Flipping html attrs while wallpaper frost
+  // is active invalidates the macOS blur compositor (#1158).
   useEffect(() => {
     const on =
       session.state === "streaming" ||
       session.state === "awaiting_permission" ||
       transcriptMeta.hasStreamingAssistant;
+    setStreamPerfActive(on);
+    const wallpaperActive =
+      document.documentElement.getAttribute("data-wallpaper") === "1";
+    if (!shouldSyncStreamPerfDataset({ wallpaperActive })) {
+      delete document.documentElement.dataset.streamPerf;
+      return;
+    }
     if (on) {
       document.documentElement.dataset.streamPerf = "1";
       return;
@@ -5527,7 +5539,8 @@ export function AppWorkbench() {
   }, [session.state, transcriptMeta.hasStreamingAssistant]);
   useEffect(() => {
     return () => {
-      document.documentElement.dataset.streamPerf = "0";
+      setStreamPerfActive(false);
+      delete document.documentElement.dataset.streamPerf;
     };
   }, []);
 

--- a/src/hooks/useChatMessageVirtualizer.test.tsx
+++ b/src/hooks/useChatMessageVirtualizer.test.tsx
@@ -283,6 +283,25 @@ describe("useChatMessageVirtualizer touch freeze", () => {
     expect(viewport.dataset.scrolling).toBe("1");
   });
 
+  it("keeps scrolling UI after wheel + scroll while still pinned (#1159)", () => {
+    // Trackpad leave-bottom: wheel sets scrolling, then the native scroll
+    // event runs recomputeNow. That must NOT clear scrollingRef or pin-snap
+    // will yank the viewport back to the tail on sub-10px steps. Advance past
+    // the hover-restore debounce so a false clear would already have dropped
+    // data-scrolling.
+    const { viewport } = mount({ pinned: true });
+    act(() => {
+      viewport.dispatchEvent(new Event("wheel"));
+      viewport.dispatchEvent(new Event("scroll"));
+      vi.advanceTimersByTime(16);
+    });
+    expect(viewport.dataset.scrolling).toBe("1");
+    act(() => {
+      vi.advanceTimersByTime(250);
+    });
+    expect(viewport.dataset.scrolling).toBe("1");
+  });
+
   it("clears contact on the last touchend, not pointercancel", () => {
     const { viewport } = mount({ pinned: true });
     act(() => {

--- a/src/hooks/useChatMessageVirtualizer.ts
+++ b/src/hooks/useChatMessageVirtualizer.ts
@@ -57,7 +57,10 @@ import {
   nextChatRichBand,
 } from "@/lib/chatRowPaintPolicy";
 import { scrollPerfDebug } from "@/lib/scrollPerfDebug";
-import { resolveStreamOverscanScale } from "@/lib/streamRenderPolicy";
+import {
+  isStreamPerfActive,
+  resolveStreamOverscanScale,
+} from "@/lib/streamRenderPolicy";
 import {
   cancelFrameSchedule,
   emptyFrameSchedule,
@@ -354,15 +357,11 @@ export function useChatMessageVirtualizer(
       return;
     }
 
-    // Programmatic stick follow arrives as a native scroll event. If we left
-    // scrollingRef set, the streaming tail would freeze as shells and
-    // height commits would be dropped. Only clear when there is no contact:
-    // Chromium pointercancel on a touch pan is not a lift.
-    if (pin && scrollingRef.current && !fingerDownRef.current) {
-      scrollingRef.current = false;
-      pendingAnchorOffsetRef.current = 0;
-      setScrollingUi(false);
-    }
+    // Do NOT clear scrollingRef here while pinned. Trackpad leave-bottom
+    // arrives as wheel → scroll without fingerDown; clearing would let
+    // pin-snap yank sub-10px escapes back to the tail (#1159). Programmatic
+    // pin-follow never sets scrollingRef (see onScroll programmaticPinFollow),
+    // so streaming height commits stay unblocked.
 
     // A synchronous scrollTop write below must land with its compensating
     // paddingTop in the same commit — a deferred (transition) commit would
@@ -402,10 +401,7 @@ export function useChatMessageVirtualizer(
         viewportHeight: el.clientHeight,
         pinToBottom: pin,
         rowCount: count,
-        scale: resolveStreamOverscanScale(
-          typeof document !== "undefined" &&
-            document.documentElement.dataset.streamPerf === "1",
-        ),
+        scale: resolveStreamOverscanScale(isStreamPerfActive()),
       }),
       pinToBottom: pin,
       forceIndices: forceRef.current,
@@ -657,6 +653,14 @@ export function useChatMessageVirtualizer(
     const endContact = () => {
       if (!fingerDownRef.current) return;
       fingerDownRef.current = false;
+      // Touch/pen lift while pinned: release the scroll freeze so streaming
+      // height commits resume. Trackpad wheel never sets fingerDown, so this
+      // does not reintroduce the #1159 pin-snap yank on leave-bottom.
+      if (isPinnedRef.current) {
+        scrollingRef.current = false;
+        pendingAnchorOffsetRef.current = 0;
+        setScrollingUi(false);
+      }
       scheduleOnFrame(scrollFrameRef.current, () =>
         recomputeNow({ sampleVelocity: true }),
       );

--- a/src/lib/streamRenderPolicy.test.ts
+++ b/src/lib/streamRenderPolicy.test.ts
@@ -1,12 +1,15 @@
 import { describe, expect, it } from "vitest";
 import {
   CHAT_VIRTUALIZE_THRESHOLD_PERF,
+  isStreamPerfActive,
   resolveStreamFlushMs,
   resolveStreamMarkdownParseMs,
   resolveStreamOverscanScale,
   resolveMarkdownPaintSource,
   resolveTranscriptContentNotifyMs,
+  setStreamPerfActive,
   shouldPlayWallpaperVideo,
+  shouldSyncStreamPerfDataset,
   shouldUsePlainStreamBody,
   STREAM_COALESCE_FLUSH_MS,
   STREAM_MARKDOWN_PARSE_MS,
@@ -83,5 +86,19 @@ describe("streamRenderPolicy", () => {
     expect(shouldPlayWallpaperVideo({})).toBe(true);
     expect(shouldPlayWallpaperVideo({ visibilityState: "visible" })).toBe(true);
     expect(shouldPlayWallpaperVideo({ visibilityState: "hidden" })).toBe(false);
+  });
+
+  it("tracks stream-perf in a module flag for overscan without requiring html attrs (#1158)", () => {
+    setStreamPerfActive(false);
+    expect(isStreamPerfActive()).toBe(false);
+    setStreamPerfActive(true);
+    expect(isStreamPerfActive()).toBe(true);
+    setStreamPerfActive(false);
+    expect(isStreamPerfActive()).toBe(false);
+  });
+
+  it("skips html data-stream-perf sync while wallpaper is active (#1158)", () => {
+    expect(shouldSyncStreamPerfDataset({ wallpaperActive: true })).toBe(false);
+    expect(shouldSyncStreamPerfDataset({ wallpaperActive: false })).toBe(true);
   });
 });

--- a/src/lib/streamRenderPolicy.ts
+++ b/src/lib/streamRenderPolicy.ts
@@ -132,3 +132,25 @@ export function shouldPlayWallpaperVideo(opts: {
 }): boolean {
   return (opts.visibilityState ?? "visible") !== "hidden";
 }
+
+/**
+ * Module-level stream-perf flag for JS readers (virtual overscan, etc.).
+ * Prefer this over `document.documentElement.dataset.streamPerf` so wallpaper
+ * sessions can skip flipping html attributes that invalidate macOS blur layers.
+ */
+let streamPerfActive = false;
+
+export function setStreamPerfActive(on: boolean): void {
+  streamPerfActive = on;
+}
+
+export function isStreamPerfActive(): boolean {
+  return streamPerfActive;
+}
+
+/** When wallpaper frost is active, skip syncing `data-stream-perf` onto `<html>`. */
+export function shouldSyncStreamPerfDataset(opts: {
+  wallpaperActive: boolean;
+}): boolean {
+  return !opts.wallpaperActive;
+}


### PR DESCRIPTION
## Summary
- **#1159**: Trackpad leave-bottom no longer clears \`scrollingRef\` on pinned recompute, so pin-snap cannot yank sub-10px escapes (flash + wrong position).
- Touch/pen lift while pinned still releases the scroll freeze so streaming height commits resume.
- **#1158**: Stream overscan reads a module flag; with wallpaper active we skip flipping \`html[data-stream-perf]\` so macOS frost blur layers stay stable.

## Type of change
- [x] Bug fix

## Test plan
- [x] \`pnpm typecheck\`
- [x] \`pnpm exec vitest run src/hooks/useChatMessageVirtualizer.test.tsx src/lib/streamRenderPolicy.test.ts src/styles/skins.streamPerf.test.ts\`
- [ ] Manual: macOS + wallpaper, stream a long answer — background should not jump
- [ ] Manual: scroll to bottom, slowly wheel up — no flash / snap back