### PR TITLE
refactor(extensions): extract the plugins and MCP modal farms

### DIFF
--- a/src/components/ExtensionsPanel.tsx
+++ b/src/components/ExtensionsPanel.tsx
@@ -7,8 +7,9 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import * as api from "@/lib/api";
 import { createT, intlLocale, type Locale, type MessageKey } from "@/i18n";
-import { GlassModal } from "@/components/GlassModal";
 import { ExtensionsPanelSkillModals } from "@/components/ExtensionsPanelSkillModals";
+import { ExtensionsPanelPluginsModals } from "@/components/ExtensionsPanelPluginsModals";
+import { ExtensionsPanelMcpModals } from "@/components/ExtensionsPanelMcpModals";
 import {
   IconDoctor,
   IconEdit,
@@ -28,7 +29,6 @@ import {
   mergeInspectErrors,
   normalizePluginInstallSource,
   pluginRowKey,
-  shortPathLabel,
   skillMetaLine,
   skillSourceTone,
   sortMcpByName,
@@ -39,10 +39,6 @@ import {
   buildPluginValidateExceptionPresentation,
   buildPluginValidatePreflightError,
   buildPluginValidatePresentation,
-  formatPluginValidateMessages,
-  pluginValidateBadgeTone,
-  pluginValidateHint,
-  pluginValidateKindLabel,
   type PluginValidateKind,
   type PluginValidatePresentation,
 } from "@/lib/pluginValidate";
@@ -52,7 +48,6 @@ import {
   mcpAuthGuidanceKey,
   mcpStatusBadgeMod,
   mcpStatusLabelKey,
-  redactMcpText,
   type McpServerStatus,
   type McpStatusIndex,
 } from "@/lib/mcpStatus";
@@ -61,7 +56,6 @@ import {
   mcpOauthActionLabelKey,
   type McpOauthAction,
 } from "@/lib/mcpOauth";
-import { McpOauthWizard } from "@/components/McpOauthWizard";
 import {
   isSkillEditable,
   resolveSkillMdPath,
@@ -84,8 +78,6 @@ import {
   ExtensionsBuildExtras,
   type ExtAgentsTabActions,
 } from "@/components/ExtensionsBuildExtras";
-import { PluginPathInstallCard } from "@/components/PluginPathInstallCard";
-import { PluginMcpAuthWizard } from "@/components/PluginMcpAuthWizard";
 import {
   ExtensionsHooksPanel,
   type ExtHooksTabActions,
@@ -101,7 +93,6 @@ import {
   X_API_INSTALL_SOURCE,
   isChatCutInstalled,
   isXApiInstalled,
-  pluginDisplayName,
   resolveExtensionsTabId,
 } from "@/lib/pluginRecommended";
 import {
@@ -2892,1019 +2883,106 @@ export function ExtensionsPanel({
       )}
       </div>
 
-      <GlassModal
-        open={!!recommendedInstall}
-        onClose={() => {
-          const busy =
-            actionBusy === "install:chatcut" || actionBusy === "install:x-api";
-          if (!busy) setRecommendedInstall(null);
-        }}
-        title={
-          recommendedInstall === "x-api"
-            ? tr("ext.plugins.recommended.xApiInstallTitle")
-            : tr("ext.plugins.recommended.installTitle")
-        }
-        size="sm"
-        closeLabel={tr("common.close")}
-        footer={
-          <>
-            <button
-              type="button"
-              className="btn btn--ghost"
-              disabled={
-                actionBusy === "install:chatcut" ||
-                actionBusy === "install:x-api"
-              }
-              onClick={() => setRecommendedInstall(null)}
-            >
-              {tr("common.cancel")}
-            </button>
-            <button
-              type="button"
-              className="btn btn--solid"
-              disabled={
-                actionBusy === "install:chatcut" ||
-                actionBusy === "install:x-api" ||
-                cliMissing ||
-                !recommendedInstall
-              }
-              onClick={() => {
-                if (recommendedInstall) void installRecommended(recommendedInstall);
-              }}
-            >
-              {actionBusy === "install:chatcut" ||
-              actionBusy === "install:x-api"
-                ? tr("ext.plugins.installing")
-                : tr("ext.plugins.recommended.install")}
-            </button>
-          </>
-        }
-      >
-        <p className="app-dialog__msg">
-          {recommendedInstall === "x-api"
-            ? tr("ext.plugins.recommended.xApiInstallConfirm", {
-                source: X_API_INSTALL_SOURCE,
-              })
-            : tr("ext.plugins.recommended.installConfirm", {
-                source: CHATCUT_CODEX_INSTALL_SOURCE,
-              })}
-        </p>
-        <p className="ext-field-hint">{tr("ext.market.installTrustNote")}</p>
-      </GlassModal>
-
-      <PluginMcpAuthWizard
-        open={!!pluginAuthServer}
+      <ExtensionsPanelPluginsModals
+        projectPath={projectPath ?? null}
+        cliFound={cliFound}
+        onOpenRuntime={() => onOpenRuntime?.()}
+        cliMissing={cliMissing}
+        plugins={plugins}
+        recommendedInstall={recommendedInstall}
+        setRecommendedInstall={setRecommendedInstall}
+        installRecommended={installRecommended}
+        installAvailableDirect={installAvailableDirect}
+        installSource={installSource}
+        pathInstallOpen={pathInstallOpen}
+        setPathInstallOpen={setPathInstallOpen}
+        pathInstallError={pathInstallError}
+        setPathInstallError={setPathInstallError}
+        setPathValidate={setPathValidate}
+        setInstallSource={setInstallSource}
+        openPathInstall={openPathInstall}
+        browsePluginFolder={browsePluginFolder}
+        pathInstallInputRef={pathInstallInputRef}
+        pathValidate={pathValidate}
+        validatePathInstall={validatePathInstall}
+        requestPathInstall={requestPathInstall}
+        installConfirmSource={installConfirmSource}
+        setInstallConfirmSource={setInstallConfirmSource}
+        confirmPathInstall={confirmPathInstall}
+        detailCard={detailCard}
+        setDetailCard={setDetailCard}
+        menuPlugin={menuPlugin}
+        setMenuPlugin={setMenuPlugin}
+        setDetailsModel={setDetailsModel}
+        setDetailRawAvailable={setDetailRawAvailable}
+        setDetailRawInstalled={setDetailRawInstalled}
+        showDetails={showDetails}
+        setDetailsOpen={setDetailsOpen}
+        detailsOpen={detailsOpen}
+        detailsTitle={detailsTitle}
+        detailsBody={detailsBody}
+        detailsLoading={detailsLoading}
+        detailsModel={detailsModel}
+        detailRawAvailable={detailRawAvailable}
+        detailRawInstalled={detailRawInstalled}
+        togglePlugin={togglePlugin}
+        badgeLabel={badgeLabel}
+        metaByName={metaByName}
+        uninstallTarget={uninstallTarget}
+        setUninstallTarget={setUninstallTarget}
+        confirmUninstall={confirmUninstall}
+        sourcesModalOpen={sourcesModalOpen}
+        setSourcesModalOpen={setSourcesModalOpen}
+        validateModal={validateModal}
+        setValidateModal={setValidateModal}
+        pluginValidateKindLabels={pluginValidateKindLabels}
+        pluginValidateKindHints={pluginValidateKindHints}
+        setPluginAuthStatus={setPluginAuthStatus}
+        pluginAuthServer={pluginAuthServer}
+        setPluginAuthServer={setPluginAuthServer}
+        refresh={refresh}
+        tr={tr}
         locale={locale}
-        serverName={pluginAuthServer ?? ""}
-        onClose={() => setPluginAuthServer(null)}
-        onChanged={(st) => {
-          setPluginAuthStatus((prev) => ({ ...prev, [st.server]: st }));
-        }}
+        actionBusy={actionBusy}
       />
 
-      <GlassModal
-        open={pathInstallOpen}
-        onClose={() => setPathInstallOpen(false)}
-        title={tr("ext.plugins.advancedInstall")}
-        size="lg"
-        closeLabel={tr("common.close")}
-        wrapBody
-        initialFocus={() => pathInstallInputRef.current}
-      >
-        <PluginPathInstallCard
-          locale={locale}
-          source={installSource}
-          onSourceChange={(next) => {
-            setInstallSource(next);
-            setPathInstallError(null);
-            setPathValidate(null);
-          }}
-          disabled={!!actionBusy || cliMissing}
-          installing={actionBusy === "install"}
-          validating={actionBusy === "validate-path"}
-          formError={pathInstallError}
-          validatePresentation={pathValidate}
-          kindLabels={pluginValidateKindLabels}
-          kindHints={pluginValidateKindHints}
-          onBrowse={() => void browsePluginFolder()}
-          onValidate={() => void validatePathInstall()}
-          onInstall={requestPathInstall}
-          inputRef={pathInstallInputRef}
-        />
-      </GlassModal>
-
-      <GlassModal
-        open={!!installConfirmSource}
-        onClose={() => {
-          if (actionBusy === "install") return;
-          setInstallConfirmSource(null);
-          setPathInstallOpen(true);
-        }}
-        title={tr("ext.plugins.installConfirmTitle")}
-        size="sm"
-        closeLabel={tr("common.close")}
-        footer={
-          <>
-            <button
-              type="button"
-              className="btn btn--ghost"
-              disabled={actionBusy === "install"}
-              onClick={() => {
-                setInstallConfirmSource(null);
-                setPathInstallOpen(true);
-              }}
-            >
-              {tr("common.cancel")}
-            </button>
-            <button
-              type="button"
-              className="btn btn--solid"
-              disabled={actionBusy === "install" || cliMissing}
-              onClick={() => void confirmPathInstall()}
-            >
-              {actionBusy === "install"
-                ? tr("ext.plugins.installing")
-                : tr("ext.plugins.install")}
-            </button>
-          </>
-        }
-      >
-        <p className="app-dialog__msg">
-          {tr("ext.plugins.installConfirm", {
-            source: installConfirmSource ?? "",
-          })}
-        </p>
-        <p className="ext-field-hint">{tr("ext.market.installTrustNote")}</p>
-      </GlassModal>
-
-      <GlassModal
-        open={!!detailCard}
-        onClose={() => {
-          setDetailCard(null);
-          setDetailRawAvailable(null);
-          setDetailRawInstalled(null);
-        }}
-        title={detailCard?.displayName ?? tr("ext.market.detailTitle")}
-        size="md"
-        closeLabel={tr("common.close")}
-        wrapBody
-        footer={
-          <>
-            <button
-              type="button"
-              className="btn btn--ghost"
-              onClick={() => {
-                setDetailCard(null);
-                setDetailRawAvailable(null);
-                setDetailRawInstalled(null);
-              }}
-            >
-              {tr("common.close")}
-            </button>
-            {detailRawAvailable && !detailCard?.installed ? (
-              <button
-                type="button"
-                className="btn btn--solid"
-                disabled={
-                  !!actionBusy ||
-                  cliMissing ||
-                  actionBusy === `inst:${detailRawAvailable.name}`
-                }
-                onClick={() => {
-                  const t = detailRawAvailable;
-                  setDetailCard(null);
-                  setDetailRawAvailable(null);
-                  void installAvailableDirect(t);
-                }}
-              >
-                {actionBusy === `inst:${detailRawAvailable.name}`
-                  ? tr("ext.market.installing")
-                  : tr("ext.market.install")}
-              </button>
-            ) : null}
-            {detailRawInstalled ? (
-              <button
-                type="button"
-                className="btn btn--solid"
-                onClick={() => {
-                  togglePlugin(detailRawInstalled);
-                  setDetailCard(null);
-                  setDetailRawInstalled(null);
-                }}
-              >
-                {detailRawInstalled.enabled
-                  ? tr("ext.plugins.disable")
-                  : tr("ext.plugins.enable")}
-              </button>
-            ) : null}
-          </>
-        }
-      >
-        {detailCard ? (
-          <div className="ext-market-detail">
-            <div
-              style={{
-                display: "flex",
-                gap: 14,
-                alignItems: "flex-start",
-                marginBottom: 12,
-              }}
-            >
-              <div className="ext-ref-featured__icon" aria-hidden>
-                {detailCard.iconUrl ? (
-                  <img src={detailCard.iconUrl} alt="" />
-                ) : (
-                  <span className="ext-ref-icon__glyph">
-                    {pluginInitials(detailCard.displayName)}
-                  </span>
-                )}
-              </div>
-              <div style={{ minWidth: 0, flex: 1 }}>
-                <div className="ext-ref-featured__title">
-                  {detailCard.displayName}
-                </div>
-                <div className="ext-ref-featured__desc">
-                  {detailCard.description || "—"}
-                </div>
-              </div>
-            </div>
-            {(() => {
-              const meta = metaByName.get(
-                detailCard.name.trim().toLowerCase(),
-              );
-              const clean: Array<[string, string]> = [];
-              clean.push([
-                tr("ext.market.field.marketplace"),
-                detailCard.marketplace?.trim() || "—",
-              ]);
-              clean.push([
-                tr("ext.market.field.version"),
-                String(detailCard.version || meta?.version || "—"),
-              ]);
-              if (meta?.category || detailCard.categoryLabel) {
-                clean.push([
-                  detailCard.categoryLabel || "Category",
-                  meta?.category || detailCard.categoryLabel || "—",
-                ]);
-              }
-              if (meta?.author) clean.push(["Author", meta.author]);
-              if (meta?.homepage) clean.push(["Homepage", meta.homepage]);
-              if (meta?.repository) clean.push(["Repository", meta.repository]);
-              if (meta?.license) clean.push(["License", meta.license]);
-              if (detailCard.providesLine) {
-                clean.push([
-                  tr("ext.market.componentsLabel"),
-                  detailCard.providesLine,
-                ]);
-              }
-              if (meta?.keywords && meta.keywords.length > 0) {
-                clean.push(["Keywords", meta.keywords.join(", ")]);
-              }
-              if (detailRawInstalled?.path) {
-                clean.push(["Path", detailRawInstalled.path]);
-              }
-              if (detailRawInstalled?.source) {
-                clean.push([
-                  tr("ext.market.field.source"),
-                  detailRawInstalled.source,
-                ]);
-              }
-              return (
-                <dl className="ext-market-detail__meta">
-                  {clean.map(([k, v]) => (
-                    <div key={k} className="ext-market-detail__row">
-                      <dt>{k}</dt>
-                      <dd title={v}>{v}</dd>
-                    </div>
-                  ))}
-                </dl>
-              );
-            })()}
-            {(() => {
-              const meta = metaByName.get(
-                detailCard.name.trim().toLowerCase(),
-              );
-              const long =
-                meta?.longDescription?.trim() ||
-                detailCard.description ||
-                "";
-              if (!long) return null;
-              return (
-                <p className="ext-field-hint" style={{ marginTop: 12 }}>
-                  {long}
-                </p>
-              );
-            })()}
-            {!detailCard.installed ? (
-              <p className="ext-field-hint" style={{ marginTop: 8 }}>
-                {tr("ext.market.installTrustNote")}
-              </p>
-            ) : null}
-          </div>
-        ) : null}
-      </GlassModal>
-
-      <GlassModal
-        open={!!menuPlugin}
-        onClose={() => setMenuPlugin(null)}
-        title={
-          pluginDisplayName(
-            menuPlugin,
-            tr("ext.plugins.recommended.chatcutName"),
-          )
-        }
-        size="sm"
-        closeLabel={tr("common.close")}
-        footer={
-          <button
-            type="button"
-            className="btn btn--ghost"
-            onClick={() => setMenuPlugin(null)}
-          >
-            {tr("common.close")}
-          </button>
-        }
-      >
-        {menuPlugin ? (
-          <div className="ext-ref-stack" style={{ gap: 8 }}>
-            <button
-              type="button"
-              className="btn btn--ghost"
-              style={{ justifyContent: "flex-start" }}
-              onClick={() => {
-                togglePlugin(menuPlugin);
-                setMenuPlugin(null);
-              }}
-            >
-              {menuPlugin.enabled
-                ? tr("ext.plugins.disable")
-                : tr("ext.plugins.enable")}
-            </button>
-            <button
-              type="button"
-              className="btn btn--ghost"
-              style={{ justifyContent: "flex-start" }}
-              onClick={() => {
-                void showDetails(menuPlugin);
-                setMenuPlugin(null);
-              }}
-            >
-              {tr("ext.plugins.details")}
-            </button>
-            <button
-              type="button"
-              className="btn btn--ghost ext-item__danger"
-              style={{ justifyContent: "flex-start" }}
-              onClick={() => {
-                setUninstallTarget(menuPlugin);
-                setMenuPlugin(null);
-              }}
-            >
-              {tr("ext.plugins.uninstall")}
-            </button>
-          </div>
-        ) : null}
-      </GlassModal>
-
-      <GlassModal
-        open={sourcesModalOpen}
-        onClose={() => setSourcesModalOpen(false)}
-        title={tr("ext.plugins.sourcesModalTitle")}
-        size="lg"
-        closeLabel={tr("common.close")}
-        wrapBody
-        footer={
-          <>
-            <button
-              type="button"
-              className="btn btn--ghost"
-              onClick={openPathInstall}
-            >
-              {tr("ext.plugins.advancedInstall")}
-            </button>
-            <button
-              type="button"
-              className="btn btn--ghost"
-              onClick={() => setSourcesModalOpen(false)}
-            >
-              {tr("common.close")}
-            </button>
-          </>
-        }
-      >
-        <p className="ext-ref-block__lead" style={{ marginBottom: 12 }}>
-          {tr("ext.plugins.sourcesModalLead")}
-        </p>
-        <div className="ext-ref-block" style={{ marginBottom: 16 }}>
-          <div className="ext-ref-block__head">
-            <h3 className="ext-ref-block__title">
-              {tr("ext.plugins.sourcesListTitle")}
-            </h3>
-          </div>
-          {/* Reuse market block for sources management only (non-embedded shows sources). */}
-          <ExtensionsBuildExtras
-            locale={locale}
-            projectPath={projectPath}
-            cliFound={cliFound && !cliMissing}
-            mode="market"
-            embedded
-            sourcesOnly
-            installedPlugins={plugins.map((p) => ({
-              name: p.name,
-              marketplace: p.marketplace,
-              path: p.path,
-              source: p.source,
-              repoKey: p.repoKey,
-            }))}
-            onOpenRuntime={onOpenRuntime}
-            onPluginsChanged={() => {
-              invalidatePluginsListCache();
-              void refresh({ forcePlugins: true });
-            }}
-          />
-        </div>
-      </GlassModal>
-
-      <GlassModal
-        open={!!uninstallTarget}
-        onClose={() => {
-          if (!actionBusy) setUninstallTarget(null);
-        }}
-        title={tr("ext.plugins.uninstallTitle")}
-        size="sm"
-        closeLabel={tr("common.close")}
-        footer={
-          <>
-            <button
-              type="button"
-              className="btn btn--ghost"
-              disabled={!!actionBusy}
-              onClick={() => setUninstallTarget(null)}
-            >
-              {tr("common.cancel")}
-            </button>
-            <button
-              type="button"
-              className="btn btn--danger"
-              disabled={!!actionBusy}
-              onClick={() => void confirmUninstall()}
-            >
-              {tr("ext.plugins.uninstall")}
-            </button>
-          </>
-        }
-      >
-        <p className="app-dialog__msg">
-          {tr("ext.plugins.uninstallConfirm", {
-            name: uninstallTarget?.name ?? "",
-          })}
-        </p>
-      </GlassModal>
-
-      <GlassModal
-        open={validateModal.open && !!validateModal.presentation}
-        onClose={() =>
-          setValidateModal((prev) => ({ ...prev, open: false }))
-        }
-        title={
-          validateModal.pluginName
-            ? tr("ext.plugins.validate.resultTitleNamed", {
-                name: validateModal.pluginName,
-              })
-            : tr("ext.plugins.validate.resultTitle")
-        }
-        size="lg"
-        closeLabel={tr("common.close")}
-        wrapBody
-        bodyClassName="ext-plugin-result-modal"
-        footer={
-          <button
-            type="button"
-            className="btn btn--solid"
-            onClick={() =>
-              setValidateModal((prev) => ({ ...prev, open: false }))
-            }
-          >
-            {tr("common.close")}
-          </button>
-        }
-      >
-        {validateModal.presentation ? (
-          <div className="ext-plugin-result">
-            <div className="ext-plugin-result__meta">
-              <span
-                className={
-                  "ext-badge ext-badge--" +
-                  pluginValidateBadgeTone(validateModal.presentation.severity)
-                }
-              >
-                {pluginValidateKindLabel(
-                  validateModal.presentation.kind,
-                  pluginValidateKindLabels,
-                )}
-              </span>
-              {validateModal.presentation.softFail ? (
-                <span className="ext-badge ext-badge--muted">
-                  {tr("ext.plugins.validate.softFail")}
-                </span>
-              ) : null}
-              {validateModal.presentation.ok ? (
-                <span className="ext-badge ext-badge--ok">
-                  {tr("ext.plugins.validateOk")}
-                </span>
-              ) : null}
-            </div>
-            <p
-              className={
-                "ext-plugin-result__summary" +
-                (validateModal.presentation.severity === "ok"
-                  ? " ext-plugin-result__summary--ok"
-                  : validateModal.presentation.severity === "err"
-                    ? " ext-plugin-result__summary--err"
-                    : " ext-plugin-result__summary--warn")
-              }
-            >
-              {validateModal.presentation.summary}
-            </p>
-            {pluginValidateHint(
-              validateModal.presentation.kind,
-              pluginValidateKindHints,
-            ) ? (
-              <p className="ext-plugin-result__hint">
-                {pluginValidateHint(
-                  validateModal.presentation.kind,
-                  pluginValidateKindHints,
-                )}
-              </p>
-            ) : null}
-            {validateModal.presentation.detail &&
-            validateModal.presentation.detail !==
-              validateModal.presentation.summary ? (
-              <pre className="ext-plugin-result__detail">
-                {validateModal.presentation.detail}
-              </pre>
-            ) : validateModal.presentation.messages.length > 1 ? (
-              <pre className="ext-plugin-result__detail">
-                {formatPluginValidateMessages(
-                  validateModal.presentation.messages,
-                )}
-              </pre>
-            ) : null}
-            {validateModal.presentation.reason ? (
-              <p className="ext-plugin-result__reason">
-                <span className="ext-plugin-result__label">
-                  {tr("ext.plugins.validate.reason")}
-                </span>
-                <code>{validateModal.presentation.reason}</code>
-              </p>
-            ) : null}
-            {validateModal.presentation.path ? (
-              <p
-                className="ext-plugin-result__path"
-                title={validateModal.presentation.path}
-              >
-                <span className="ext-plugin-result__label">
-                  {tr("ext.plugins.validate.path")}
-                </span>
-                <code>{validateModal.presentation.path}</code>
-              </p>
-            ) : null}
-          </div>
-        ) : null}
-      </GlassModal>
-
-      <GlassModal
-        open={detailsOpen}
-        onClose={() => {
-          setDetailsOpen(false);
-          setDetailsModel(null);
-        }}
-        title={tr("ext.plugins.detailsTitle", { name: detailsTitle })}
-        size="lg"
-        closeLabel={tr("common.close")}
-        wrapBody
-        footer={
-          <button
-            type="button"
-            className="btn btn--ghost"
-            onClick={() => {
-              setDetailsOpen(false);
-              setDetailsModel(null);
-            }}
-          >
-            {tr("common.close")}
-          </button>
-        }
-      >
-        {detailsModel ? (
-          <div className="ext-market-detail">
-            <dl className="ext-market-detail__meta">
-              <div className="ext-market-detail__row">
-                <dt>{tr("ext.market.field.marketplace")}</dt>
-                <dd>
-                  {detailsModel.marketplace?.trim() ||
-                    tr("ext.market.field.unknown")}
-                </dd>
-              </div>
-              <div className="ext-market-detail__row">
-                <dt>{tr("ext.market.field.version")}</dt>
-                <dd>
-                  {detailsModel.versionLabel
-                    ? `v${detailsModel.versionLabel}`
-                    : tr("ext.market.field.unknown")}
-                </dd>
-              </div>
-            </dl>
-            {detailsModel.badges.length > 0 ? (
-              <div
-                className="ext-component-badges ext-component-badges--detail"
-                aria-label={tr("ext.market.componentsLabel")}
-              >
-                {detailsModel.badges.map((b) => (
-                  <span
-                    key={b.kind}
-                    className={
-                      "ext-badge ext-badge--component ext-badge--component-" +
-                      b.kind
-                    }
-                  >
-                    {badgeLabel(b.kind, b.count)}
-                  </span>
-                ))}
-              </div>
-            ) : null}
-          </div>
-        ) : null}
-        {detailsLoading ? (
-          <p className="ext-empty">{tr("ext.plugins.detailsLoading")}</p>
-        ) : (
-          <pre className="ext-details-pre">{detailsBody}</pre>
-        )}
-      </GlassModal>
-
-      <GlassModal
-        open={addOpen}
-        onClose={() => {
-          if (actionBusy !== "mcp:add") setAddOpen(false);
-        }}
-        title={tr("ext.mcp.addTitle")}
-        size="md"
-        closeLabel={tr("common.close")}
-        wrapBody
-        footer={
-          <>
-            <button
-              type="button"
-              className="btn btn--ghost"
-              disabled={actionBusy === "mcp:add"}
-              onClick={() => setAddOpen(false)}
-            >
-              {tr("common.cancel")}
-            </button>
-            <button
-              type="button"
-              className="btn btn--solid"
-              disabled={
-                actionBusy === "mcp:add" ||
-                !addName.trim() ||
-                !addCommand.trim()
-              }
-              onClick={() => void submitAdd()}
-            >
-              {actionBusy === "mcp:add"
-                ? tr("ext.mcp.addWorking")
-                : tr("ext.mcp.addSubmit")}
-            </button>
-          </>
-        }
-      >
-        <form
-          className="app-dialog__form"
-          onSubmit={(e) => {
-            e.preventDefault();
-            void submitAdd();
-          }}
-        >
-          <label className="field">
-            <span>{tr("ext.mcp.name")}</span>
-            <input
-              className="app-dialog__input"
-              value={addName}
-              onChange={(e) => setAddName(e.target.value)}
-              placeholder={tr("ext.mcp.namePlaceholder")}
-              autoComplete="off"
-              spellCheck={false}
-              disabled={actionBusy === "mcp:add"}
-            />
-          </label>
-          <label className="field">
-            <span>{tr("ext.mcp.command")}</span>
-            <input
-              className="app-dialog__input"
-              value={addCommand}
-              onChange={(e) => setAddCommand(e.target.value)}
-              placeholder={tr("ext.mcp.commandPlaceholder")}
-              autoComplete="off"
-              spellCheck={false}
-              disabled={actionBusy === "mcp:add"}
-            />
-          </label>
-          <label className="field">
-            <span>{tr("ext.mcp.args")}</span>
-            <input
-              className="app-dialog__input"
-              value={addArgs}
-              onChange={(e) => setAddArgs(e.target.value)}
-              placeholder={tr("ext.mcp.argsPlaceholder")}
-              autoComplete="off"
-              spellCheck={false}
-              disabled={actionBusy === "mcp:add"}
-            />
-            <span className="ext-field-hint">{tr("ext.mcp.argsHint")}</span>
-          </label>
-          <label className="field">
-            <span>{tr("ext.mcp.env")}</span>
-            <textarea
-              className="app-dialog__input ext-env-textarea"
-              value={addEnv}
-              onChange={(e) => setAddEnv(e.target.value)}
-              placeholder={tr("ext.mcp.envPlaceholder")}
-              rows={3}
-              spellCheck={false}
-              disabled={actionBusy === "mcp:add"}
-            />
-            <span className="ext-field-hint">{tr("ext.mcp.envHint")}</span>
-          </label>
-        </form>
-      </GlassModal>
-
-      <GlassModal
-        open={!!removeTarget}
-        onClose={() => {
-          if (!actionBusy) setRemoveTarget(null);
-        }}
-        title={tr("ext.mcp.removeTitle")}
-        size="sm"
-        closeLabel={tr("common.close")}
-        footer={
-          <>
-            <button
-              type="button"
-              className="btn btn--ghost"
-              disabled={!!actionBusy}
-              onClick={() => setRemoveTarget(null)}
-            >
-              {tr("common.cancel")}
-            </button>
-            <button
-              type="button"
-              className="btn btn--danger"
-              disabled={!!actionBusy}
-              onClick={() => void confirmRemoveMcp()}
-            >
-              {tr("ext.mcp.remove")}
-            </button>
-          </>
-        }
-      >
-        <p className="app-dialog__msg">
-          {tr("ext.mcp.removeConfirm", {
-            name: removeTarget?.name ?? "",
-          })}
-        </p>
-      </GlassModal>
-
-      <GlassModal
-        open={doctorOpen}
-        onClose={() => {
-          if (!doctorLoading) setDoctorOpen(false);
-        }}
-        title={
-          doctorFocus
-            ? `${tr("ext.mcp.doctorTitle")} · ${doctorFocus}`
-            : tr("ext.mcp.doctorTitle")
-        }
-        size="lg"
-        closeLabel={tr("common.close")}
-        wrapBody
-        footer={
-          <>
-            <button
-              type="button"
-              className="btn btn--ghost"
-              disabled={doctorLoading}
-              onClick={() => void runDoctor(doctorFocus)}
-            >
-              <IconRefresh size={14} />
-              <span>{tr("ext.mcp.doctorRerun")}</span>
-            </button>
-            <button
-              type="button"
-              className="btn btn--ghost"
-              disabled={doctorLoading}
-              onClick={() => setDoctorOpen(false)}
-            >
-              {tr("common.close")}
-            </button>
-          </>
-        }
-      >
-        {doctorLoading && (
-          <p className="ext-empty">{tr("ext.mcp.doctorRunning")}</p>
-        )}
-        {!doctorLoading && doctorError && (
-          <div className="ext-alert ext-alert--error" role="alert">
-            <p className="ext-alert__body">{doctorError}</p>
-          </div>
-        )}
-        {!doctorLoading && doctorReport && (
-          <div className="ext-doctor">
-            <p className="ext-doctor__summary">
-              {tr("ext.mcp.doctorSummary", {
-                healthy: doctorReport.summary.healthy,
-                unhealthy: doctorReport.summary.unhealthy,
-                total: doctorReport.summary.total,
-              })}
-            </p>
-            {(doctorReport.sources?.length ?? 0) > 0 ? (
-              <div className="ext-doctor__sources">
-                <div className="ext-doctor__section-title">
-                  {tr("ext.mcp.doctorSources")}
-                </div>
-                <ul className="ext-doctor__source-list">
-                  {doctorReport.sources.map((src: any) => (
-                    <li key={src.path}>
-                      <code>{src.path}</code>
-                      <span className="ext-badge ext-badge--muted">
-                        {src.status}
-                        {src.serverCount != null
-                          ? ` · ${src.serverCount}`
-                          : ""}
-                      </span>
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            ) : null}
-            {(doctorReport.servers?.length ?? 0) === 0 ? (
-              <p className="ext-empty">
-                {redactMcpText(doctorReport.rawText)?.trim() ||
-                  tr("ext.mcp.doctorEmpty")}
-              </p>
-            ) : (
-              <ul className="ext-list ext-doctor__servers">
-                {doctorReport.servers.map((s: any) => {
-                  const st =
-                    lookupServerStatus(doctorReportStatusIndex, s.name) ??
-                    lookupServerStatus(doctorStatusIndex, s.name);
-                  const badgeMod = st
-                    ? mcpStatusBadgeMod(st.tone)
-                    : s.healthy
-                      ? "ok"
-                      : "fail";
-                  const label = st
-                    ? tr(mcpStatusLabelKey(st.tone) as MessageKey)
-                    : s.healthy
-                      ? tr("ext.mcp.doctorHealthy")
-                      : tr("ext.mcp.doctorUnhealthy");
-                  const guidanceKey = st
-                    ? mcpAuthGuidanceKey(st.tone)
-                    : null;
-                  const oauthAction = st
-                    ? classifyMcpOauthFromStatus(st)
-                    : null;
-                  return (
-                    <li
-                      key={s.name}
-                      className={
-                        "ext-item" + (s.healthy ? "" : " ext-item--off")
-                      }
-                    >
-                      <div className="ext-item__head">
-                        <strong className="ext-item__name">{s.name}</strong>
-                        <span
-                          className={
-                            "ext-mcp-status ext-mcp-status--" + badgeMod
-                          }
-                        >
-                          <span
-                            className="ext-mcp-status__lamp"
-                            aria-hidden
-                          />
-                          <span
-                            className={"ext-badge ext-badge--" + badgeMod}
-                          >
-                            {label}
-                          </span>
-                        </span>
-                        {s.transport ? (
-                          <span className="ext-badge ext-badge--muted">
-                            {s.transport}
-                          </span>
-                        ) : null}
-                      </div>
-                      {s.target ? (
-                        <p className="ext-item__desc" title={s.target}>
-                          {shortPathLabel(s.target, 72) || s.target}
-                        </p>
-                      ) : null}
-                      {st?.needsAuthRefresh && guidanceKey ? (
-                        <div className="ext-mcp-auth-row">
-                          <p className="ext-mcp-auth-hint">
-                            {tr(guidanceKey as MessageKey)}
-                          </p>
-                          <button
-                            type="button"
-                            className="btn btn--ghost btn--sm"
-                            onClick={() => openOauthWizard(oauthAction, st)}
-                          >
-                            {tr(
-                              (oauthAction
-                                ? mcpOauthActionLabelKey(oauthAction.kind)
-                                : "ext.mcp.auth.howToRefresh") as MessageKey,
-                            )}
-                          </button>
-                        </div>
-                      ) : null}
-                      {Array.isArray(s.checks) && s.checks.length > 0 ? (
-                        <ul className="ext-doctor__checks">
-                          {s.checks.map((c: any, i: any) => (
-                            <li
-                              key={`${s.name}:${c.label}:${i}`}
-                              className={
-                                "ext-doctor__check" +
-                                (c.passed ? " is-pass" : " is-fail")
-                              }
-                            >
-                              <span className="ext-doctor__check-label">
-                                {c.passed ? "✓" : "✗"} {c.label}
-                              </span>
-                              {c.detail ? (
-                                <span className="ext-doctor__check-detail">
-                                  {redactMcpText(c.detail)}
-                                </span>
-                              ) : null}
-                              {c.hint ? (
-                                <span className="ext-doctor__check-hint">
-                                  {tr("ext.mcp.doctorHint", {
-                                    hint: redactMcpText(c.hint),
-                                  })}
-                                </span>
-                              ) : null}
-                            </li>
-                          ))}
-                        </ul>
-                      ) : null}
-                    </li>
-                  );
-                })}
-              </ul>
-            )}
-            {doctorReport.rawText ? (
-              <pre className="ext-details-pre">
-                {redactMcpText(doctorReport.rawText)}
-              </pre>
-            ) : null}
-          </div>
-        )}
-      </GlassModal>
-
-      <McpOauthWizard
-        open={!!oauthWizardTarget}
+      <ExtensionsPanelMcpModals
+        addOpen={addOpen}
+        setAddOpen={setAddOpen}
+        addName={addName}
+        setAddName={setAddName}
+        addCommand={addCommand}
+        setAddCommand={setAddCommand}
+        addArgs={addArgs}
+        setAddArgs={setAddArgs}
+        addEnv={addEnv}
+        setAddEnv={setAddEnv}
+        submitAdd={submitAdd}
+        removeTarget={removeTarget}
+        setRemoveTarget={setRemoveTarget}
+        confirmRemoveMcp={confirmRemoveMcp}
+        doctorOpen={doctorOpen}
+        setDoctorOpen={setDoctorOpen}
+        runDoctor={runDoctor}
+        doctorStatusIndex={doctorStatusIndex}
+        setDoctorStatusIndex={setDoctorStatusIndex}
+        doctorReportStatusIndex={doctorReportStatusIndex}
+        doctorLoading={doctorLoading}
+        setDoctorLoading={setDoctorLoading}
+        doctorError={doctorError}
+        setDoctorError={setDoctorError}
+        doctorReport={doctorReport}
+        setDoctorReport={setDoctorReport}
+        doctorFocus={doctorFocus}
+        setDoctorFocus={setDoctorFocus}
+        setDoctorLastAt={setDoctorLastAt}
+        oauthWizardTarget={oauthWizardTarget}
+        setOauthWizardTarget={setOauthWizardTarget}
+        openOauthWizard={openOauthWizard}
+        tr={tr}
         locale={locale}
-        action={oauthWizardTarget?.action ?? null}
-        statusReason={oauthWizardTarget?.status.reason ?? null}
-        onClose={() => setOauthWizardTarget(null)}
-        onRefreshDoctor={async (serverName) => {
-          // Keep doctor modal closed when refreshing from wizard; still update index.
-          if (!api.isTauri()) {
-            return { report: null, error: tr("ext.needTauri") };
-          }
-          setDoctorLoading(true);
-          setDoctorError(null);
-          setDoctorFocus(serverName?.trim() || null);
-          try {
-            const report = await api.mcpDoctor(serverName?.trim() || null);
-            setDoctorReport(report);
-            setDoctorLastAt(Date.now());
-            const next = indexDoctorServerStatuses(report);
-            setDoctorStatusIndex((prev) => {
-              if (!serverName?.trim()) return next;
-              const merged = new Map(prev);
-              for (const [k, v] of next) merged.set(k, v);
-              return merged;
-            });
-            return { report, error: null };
-          } catch (e) {
-            const error = String(e);
-            setDoctorError(error);
-            return { report: null, error };
-          } finally {
-            setDoctorLoading(false);
-          }
-        }}
+        actionBusy={actionBusy}
       />
-
       <ExtensionsPanelSkillModals
         tr={tr}
         actionBusy={actionBusy}

--- a/src/components/ExtensionsPanelMcpModals.tsx
+++ b/src/components/ExtensionsPanelMcpModals.tsx
@@ -1,0 +1,485 @@
+/**
+ * MCP modal farm for ExtensionsPanel: server add form, remove confirm,
+ * doctor report, and the two OAuth wizards. Extracted verbatim from the
+ * panel (WP: giant-component decomposition).
+ */
+import * as api from "@/lib/api";
+import type { Locale, MessageKey } from "@/i18n";
+import { createT } from "@/i18n";
+import { GlassModal } from "@/components/GlassModal";
+import { shortPathLabel } from "@/lib/extensionsUi";
+import { IconRefresh } from "@/components/icons";
+import { McpOauthWizard } from "@/components/McpOauthWizard";
+import {
+  lookupServerStatus,
+  indexDoctorServerStatuses,
+  mcpStatusBadgeMod,
+  mcpStatusLabelKey,
+  mcpAuthGuidanceKey,
+  redactMcpText,
+  type McpStatusIndex,
+  type McpServerStatus,
+} from "@/lib/mcpStatus";
+import {
+  classifyMcpOauthFromStatus,
+  mcpOauthActionLabelKey,
+  type McpOauthAction,
+} from "@/lib/mcpOauth";
+
+type TFn = ReturnType<typeof createT>;
+
+export type ExtensionsPanelMcpModalsProps = {
+  addOpen: boolean;
+  setAddOpen: (v: boolean) => void;
+  addName: string;
+  setAddName: (v: string) => void;
+  addCommand: string;
+  setAddCommand: (v: string) => void;
+  addArgs: string;
+  setAddArgs: (v: string) => void;
+  addEnv: string;
+  setAddEnv: (v: string) => void;
+  submitAdd: () => Promise<void>;
+  removeTarget: api.McpDto | null;
+  setRemoveTarget: (v: api.McpDto | null) => void;
+  confirmRemoveMcp: () => Promise<void>;
+  doctorOpen: boolean;
+  setDoctorOpen: (v: boolean) => void;
+  runDoctor: (focus?: string | null) => void;
+  doctorStatusIndex: McpStatusIndex;
+  setDoctorStatusIndex: (
+    v:
+      | McpStatusIndex
+      | ((prev: McpStatusIndex) => McpStatusIndex),
+  ) => void;
+  // Panel keeps this as `any` (raw host report json).
+  doctorReport: any;
+  setDoctorReport: (v: any) => void;
+  doctorReportStatusIndex: McpStatusIndex;
+  doctorLoading: boolean;
+  setDoctorLoading: (v: boolean) => void;
+  doctorError: string | null;
+  setDoctorError: (v: string | null) => void;
+  doctorFocus: string | null;
+  setDoctorFocus: (v: string | null) => void;
+  setDoctorLastAt: (v: number | null) => void;
+  oauthWizardTarget: { action: McpOauthAction; status: McpServerStatus } | null;
+  setOauthWizardTarget: (
+    v: { action: McpOauthAction; status: McpServerStatus } | null,
+  ) => void;
+  openOauthWizard: (
+    action: McpOauthAction | null,
+    status: McpServerStatus,
+  ) => void;
+
+  tr: TFn;
+  locale: Locale;
+  actionBusy: string | null;
+};
+
+export function ExtensionsPanelMcpModals(p: ExtensionsPanelMcpModalsProps) {
+  const {
+    addOpen,
+    setAddOpen,
+    addName,
+    setAddName,
+    addCommand,
+    setAddCommand,
+    addArgs,
+    setAddArgs,
+    addEnv,
+    setAddEnv,
+    submitAdd,
+    removeTarget,
+    setRemoveTarget,
+    confirmRemoveMcp,
+    doctorOpen,
+    setDoctorOpen,
+    runDoctor,
+    doctorStatusIndex,
+    setDoctorStatusIndex,
+    doctorReportStatusIndex,
+    doctorLoading,
+    setDoctorLoading,
+    doctorError,
+    setDoctorError,
+    doctorReport,
+    setDoctorReport,
+    doctorFocus,
+    setDoctorFocus,
+    setDoctorLastAt,
+    oauthWizardTarget,
+    setOauthWizardTarget,
+    openOauthWizard,
+    tr,
+    locale,
+    actionBusy,
+  } = p;
+  return (
+    <>
+      <GlassModal
+        open={addOpen}
+        onClose={() => {
+          if (actionBusy !== "mcp:add") setAddOpen(false);
+        }}
+        title={tr("ext.mcp.addTitle")}
+        size="md"
+        closeLabel={tr("common.close")}
+        wrapBody
+        footer={
+          <>
+            <button
+              type="button"
+              className="btn btn--ghost"
+              disabled={actionBusy === "mcp:add"}
+              onClick={() => setAddOpen(false)}
+            >
+              {tr("common.cancel")}
+            </button>
+            <button
+              type="button"
+              className="btn btn--solid"
+              disabled={
+                actionBusy === "mcp:add" ||
+                !addName.trim() ||
+                !addCommand.trim()
+              }
+              onClick={() => void submitAdd()}
+            >
+              {actionBusy === "mcp:add"
+                ? tr("ext.mcp.addWorking")
+                : tr("ext.mcp.addSubmit")}
+            </button>
+          </>
+        }
+      >
+        <form
+          className="app-dialog__form"
+          onSubmit={(e) => {
+            e.preventDefault();
+            void submitAdd();
+          }}
+        >
+          <label className="field">
+            <span>{tr("ext.mcp.name")}</span>
+            <input
+              className="app-dialog__input"
+              value={addName}
+              onChange={(e) => setAddName(e.target.value)}
+              placeholder={tr("ext.mcp.namePlaceholder")}
+              autoComplete="off"
+              spellCheck={false}
+              disabled={actionBusy === "mcp:add"}
+            />
+          </label>
+          <label className="field">
+            <span>{tr("ext.mcp.command")}</span>
+            <input
+              className="app-dialog__input"
+              value={addCommand}
+              onChange={(e) => setAddCommand(e.target.value)}
+              placeholder={tr("ext.mcp.commandPlaceholder")}
+              autoComplete="off"
+              spellCheck={false}
+              disabled={actionBusy === "mcp:add"}
+            />
+          </label>
+          <label className="field">
+            <span>{tr("ext.mcp.args")}</span>
+            <input
+              className="app-dialog__input"
+              value={addArgs}
+              onChange={(e) => setAddArgs(e.target.value)}
+              placeholder={tr("ext.mcp.argsPlaceholder")}
+              autoComplete="off"
+              spellCheck={false}
+              disabled={actionBusy === "mcp:add"}
+            />
+            <span className="ext-field-hint">{tr("ext.mcp.argsHint")}</span>
+          </label>
+          <label className="field">
+            <span>{tr("ext.mcp.env")}</span>
+            <textarea
+              className="app-dialog__input ext-env-textarea"
+              value={addEnv}
+              onChange={(e) => setAddEnv(e.target.value)}
+              placeholder={tr("ext.mcp.envPlaceholder")}
+              rows={3}
+              spellCheck={false}
+              disabled={actionBusy === "mcp:add"}
+            />
+            <span className="ext-field-hint">{tr("ext.mcp.envHint")}</span>
+          </label>
+        </form>
+      </GlassModal>
+
+      <GlassModal
+        open={!!removeTarget}
+        onClose={() => {
+          if (!actionBusy) setRemoveTarget(null);
+        }}
+        title={tr("ext.mcp.removeTitle")}
+        size="sm"
+        closeLabel={tr("common.close")}
+        footer={
+          <>
+            <button
+              type="button"
+              className="btn btn--ghost"
+              disabled={!!actionBusy}
+              onClick={() => setRemoveTarget(null)}
+            >
+              {tr("common.cancel")}
+            </button>
+            <button
+              type="button"
+              className="btn btn--danger"
+              disabled={!!actionBusy}
+              onClick={() => void confirmRemoveMcp()}
+            >
+              {tr("ext.mcp.remove")}
+            </button>
+          </>
+        }
+      >
+        <p className="app-dialog__msg">
+          {tr("ext.mcp.removeConfirm", {
+            name: removeTarget?.name ?? "",
+          })}
+        </p>
+      </GlassModal>
+
+      <GlassModal
+        open={doctorOpen}
+        onClose={() => {
+          if (!doctorLoading) setDoctorOpen(false);
+        }}
+        title={
+          doctorFocus
+            ? `${tr("ext.mcp.doctorTitle")} · ${doctorFocus}`
+            : tr("ext.mcp.doctorTitle")
+        }
+        size="lg"
+        closeLabel={tr("common.close")}
+        wrapBody
+        footer={
+          <>
+            <button
+              type="button"
+              className="btn btn--ghost"
+              disabled={doctorLoading}
+              onClick={() => void runDoctor(doctorFocus)}
+            >
+              <IconRefresh size={14} />
+              <span>{tr("ext.mcp.doctorRerun")}</span>
+            </button>
+            <button
+              type="button"
+              className="btn btn--ghost"
+              disabled={doctorLoading}
+              onClick={() => setDoctorOpen(false)}
+            >
+              {tr("common.close")}
+            </button>
+          </>
+        }
+      >
+        {doctorLoading && (
+          <p className="ext-empty">{tr("ext.mcp.doctorRunning")}</p>
+        )}
+        {!doctorLoading && doctorError && (
+          <div className="ext-alert ext-alert--error" role="alert">
+            <p className="ext-alert__body">{doctorError}</p>
+          </div>
+        )}
+        {!doctorLoading && doctorReport && (
+          <div className="ext-doctor">
+            <p className="ext-doctor__summary">
+              {tr("ext.mcp.doctorSummary", {
+                healthy: doctorReport.summary.healthy,
+                unhealthy: doctorReport.summary.unhealthy,
+                total: doctorReport.summary.total,
+              })}
+            </p>
+            {(doctorReport.sources?.length ?? 0) > 0 ? (
+              <div className="ext-doctor__sources">
+                <div className="ext-doctor__section-title">
+                  {tr("ext.mcp.doctorSources")}
+                </div>
+                <ul className="ext-doctor__source-list">
+                  {doctorReport.sources.map((src: any) => (
+                    <li key={src.path}>
+                      <code>{src.path}</code>
+                      <span className="ext-badge ext-badge--muted">
+                        {src.status}
+                        {src.serverCount != null
+                          ? ` · ${src.serverCount}`
+                          : ""}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ) : null}
+            {(doctorReport.servers?.length ?? 0) === 0 ? (
+              <p className="ext-empty">
+                {redactMcpText(doctorReport.rawText)?.trim() ||
+                  tr("ext.mcp.doctorEmpty")}
+              </p>
+            ) : (
+              <ul className="ext-list ext-doctor__servers">
+                {doctorReport.servers.map((s: any) => {
+                  const st =
+                    lookupServerStatus(doctorReportStatusIndex, s.name) ??
+                    lookupServerStatus(doctorStatusIndex, s.name);
+                  const badgeMod = st
+                    ? mcpStatusBadgeMod(st.tone)
+                    : s.healthy
+                      ? "ok"
+                      : "fail";
+                  const label = st
+                    ? tr(mcpStatusLabelKey(st.tone) as MessageKey)
+                    : s.healthy
+                      ? tr("ext.mcp.doctorHealthy")
+                      : tr("ext.mcp.doctorUnhealthy");
+                  const guidanceKey = st
+                    ? mcpAuthGuidanceKey(st.tone)
+                    : null;
+                  const oauthAction = st
+                    ? classifyMcpOauthFromStatus(st)
+                    : null;
+                  return (
+                    <li
+                      key={s.name}
+                      className={
+                        "ext-item" + (s.healthy ? "" : " ext-item--off")
+                      }
+                    >
+                      <div className="ext-item__head">
+                        <strong className="ext-item__name">{s.name}</strong>
+                        <span
+                          className={
+                            "ext-mcp-status ext-mcp-status--" + badgeMod
+                          }
+                        >
+                          <span
+                            className="ext-mcp-status__lamp"
+                            aria-hidden
+                          />
+                          <span
+                            className={"ext-badge ext-badge--" + badgeMod}
+                          >
+                            {label}
+                          </span>
+                        </span>
+                        {s.transport ? (
+                          <span className="ext-badge ext-badge--muted">
+                            {s.transport}
+                          </span>
+                        ) : null}
+                      </div>
+                      {s.target ? (
+                        <p className="ext-item__desc" title={s.target}>
+                          {shortPathLabel(s.target, 72) || s.target}
+                        </p>
+                      ) : null}
+                      {st?.needsAuthRefresh && guidanceKey ? (
+                        <div className="ext-mcp-auth-row">
+                          <p className="ext-mcp-auth-hint">
+                            {tr(guidanceKey as MessageKey)}
+                          </p>
+                          <button
+                            type="button"
+                            className="btn btn--ghost btn--sm"
+                            onClick={() => openOauthWizard(oauthAction, st)}
+                          >
+                            {tr(
+                              (oauthAction
+                                ? mcpOauthActionLabelKey(oauthAction.kind)
+                                : "ext.mcp.auth.howToRefresh") as MessageKey,
+                            )}
+                          </button>
+                        </div>
+                      ) : null}
+                      {Array.isArray(s.checks) && s.checks.length > 0 ? (
+                        <ul className="ext-doctor__checks">
+                          {s.checks.map((c: any, i: any) => (
+                            <li
+                              key={`${s.name}:${c.label}:${i}`}
+                              className={
+                                "ext-doctor__check" +
+                                (c.passed ? " is-pass" : " is-fail")
+                              }
+                            >
+                              <span className="ext-doctor__check-label">
+                                {c.passed ? "✓" : "✗"} {c.label}
+                              </span>
+                              {c.detail ? (
+                                <span className="ext-doctor__check-detail">
+                                  {redactMcpText(c.detail)}
+                                </span>
+                              ) : null}
+                              {c.hint ? (
+                                <span className="ext-doctor__check-hint">
+                                  {tr("ext.mcp.doctorHint", {
+                                    hint: redactMcpText(c.hint),
+                                  })}
+                                </span>
+                              ) : null}
+                            </li>
+                          ))}
+                        </ul>
+                      ) : null}
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+            {doctorReport.rawText ? (
+              <pre className="ext-details-pre">
+                {redactMcpText(doctorReport.rawText)}
+              </pre>
+            ) : null}
+          </div>
+        )}
+      </GlassModal>
+
+      <McpOauthWizard
+        open={!!oauthWizardTarget}
+        locale={locale}
+        action={oauthWizardTarget?.action ?? null}
+        statusReason={oauthWizardTarget?.status.reason ?? null}
+        onClose={() => setOauthWizardTarget(null)}
+        onRefreshDoctor={async (serverName) => {
+          // Keep doctor modal closed when refreshing from wizard; still update index.
+          if (!api.isTauri()) {
+            return { report: null, error: tr("ext.needTauri") };
+          }
+          setDoctorLoading(true);
+          setDoctorError(null);
+          setDoctorFocus(serverName?.trim() || null);
+          try {
+            const report = await api.mcpDoctor(serverName?.trim() || null);
+            setDoctorReport(report);
+            setDoctorLastAt(Date.now());
+            const next = indexDoctorServerStatuses(report);
+            setDoctorStatusIndex((prev) => {
+              if (!serverName?.trim()) return next;
+              const merged = new Map(prev);
+              for (const [k, v] of next) merged.set(k, v);
+              return merged;
+            });
+            return { report, error: null };
+          } catch (e) {
+            const error = String(e);
+            setDoctorError(error);
+            return { report: null, error };
+          } finally {
+            setDoctorLoading(false);
+          }
+        }}
+      />
+
+    </>
+  );
+}

--- a/src/components/ExtensionsPanelPluginsModals.tsx
+++ b/src/components/ExtensionsPanelPluginsModals.tsx
@@ -1,0 +1,859 @@
+/**
+ * Plugins modal farm for ExtensionsPanel: recommended install, path
+ * install + validate, install confirm, plugin details + row menu,
+ * sources management, uninstall confirm, and validate result.
+ * Extracted verbatim from the panel (WP: giant-component decomposition).
+ */
+import * as api from "@/lib/api";
+import type { Locale } from "@/i18n";
+import { createT } from "@/i18n";
+import { GlassModal } from "@/components/GlassModal";
+import { PluginPathInstallCard } from "@/components/PluginPathInstallCard";
+import { ExtensionsBuildExtras } from "@/components/ExtensionsBuildExtras";
+import { PluginMcpAuthWizard } from "@/components/PluginMcpAuthWizard";
+import { pluginInitials, type PluginCardModel } from "@/lib/pluginCard";
+import {
+  formatPluginValidateMessages,
+  pluginValidateBadgeTone,
+  pluginValidateHint,
+  pluginValidateKindLabel,
+  type PluginValidatePresentation,
+} from "@/lib/pluginValidate";
+import { pluginDisplayName } from "@/lib/pluginRecommended";
+import { invalidatePluginsListCache } from "@/lib/pluginsListCache";
+import {
+  CHATCUT_CODEX_INSTALL_SOURCE,
+  X_API_INSTALL_SOURCE,
+} from "@/lib/pluginRecommended";
+import type {
+  AvailablePluginDetailModel,
+  AvailablePluginLike,
+  PluginComponentBadgeKind,
+} from "@/lib/pluginMarketplace";
+
+type TFn = ReturnType<typeof createT>;
+
+export type ExtensionsPanelPluginsModalsProps = {
+  projectPath: string | null;
+  cliFound: boolean;
+  onOpenRuntime: () => void;
+  cliMissing: boolean;
+  plugins: api.PluginDto[];
+  recommendedInstall: "chatcut" | "x-api" | null;
+  setRecommendedInstall: (v: "chatcut" | "x-api" | null) => void;
+  installRecommended: (kind: "chatcut" | "x-api") => Promise<void>;
+  installAvailableDirect: (target: AvailablePluginLike) => Promise<void>;
+  installSource: string;
+  pathInstallOpen: boolean;
+  setPathInstallOpen: (v: boolean) => void;
+  pathInstallError: string | null;
+  setPathInstallError: (v: string | null) => void;
+  setPathValidate: (v: PluginValidatePresentation | null) => void;
+  setInstallSource: (v: string) => void;
+  openPathInstall: () => void;
+  browsePluginFolder: () => Promise<void>;
+  pathInstallInputRef: React.RefObject<HTMLInputElement | null>;
+  pathValidate: PluginValidatePresentation | null;
+  validatePathInstall: () => Promise<void>;
+  requestPathInstall: () => void;
+  installConfirmSource: string | null;
+  setInstallConfirmSource: (v: string | null) => void;
+  confirmPathInstall: () => Promise<void>;
+  detailCard: PluginCardModel | null;
+  setDetailCard: (v: PluginCardModel | null) => void;
+  menuPlugin: api.PluginDto | null;
+  setMenuPlugin: (v: api.PluginDto | null) => void;
+  setDetailsModel: (v: AvailablePluginDetailModel | null) => void;
+  setDetailRawAvailable: (v: AvailablePluginLike | null) => void;
+  setDetailRawInstalled: (v: api.PluginDto | null) => void;
+  showDetails: (p: api.PluginDto) => Promise<void>;
+  setDetailsOpen: (v: boolean) => void;
+  detailsOpen: boolean;
+  detailsTitle: string;
+  detailsBody: string;
+  detailsLoading: boolean;
+  detailsModel: AvailablePluginDetailModel | null;
+  detailRawAvailable: AvailablePluginLike | null;
+  detailRawInstalled: api.PluginDto | null;
+  togglePlugin: (p: api.PluginDto) => void;
+  badgeLabel: (kind: PluginComponentBadgeKind, count?: number | null) => string;
+  metaByName: Map<
+    string,
+    {
+      displayName?: string | null;
+      description?: string | null;
+      longDescription?: string | null;
+      version?: string | null;
+      category?: string | null;
+      author?: string | null;
+      homepage?: string | null;
+      repository?: string | null;
+      license?: string | null;
+      logoUrl?: string | null;
+      keywords?: string[];
+    }
+  >;
+  uninstallTarget: api.PluginDto | null;
+  setUninstallTarget: (v: api.PluginDto | null) => void;
+  confirmUninstall: () => Promise<void>;
+  sourcesModalOpen: boolean;
+  setSourcesModalOpen: (v: boolean) => void;
+  validateModal: {
+    open: boolean;
+    presentation: PluginValidatePresentation | null;
+    pluginName: string | null;
+  };
+  setValidateModal: (
+    v:
+      | {
+          open: boolean;
+          presentation: PluginValidatePresentation | null;
+          pluginName: string | null;
+        }
+      | ((
+          prev: {
+            open: boolean;
+            presentation: PluginValidatePresentation | null;
+            pluginName: string | null;
+          },
+        ) => {
+          open: boolean;
+          presentation: PluginValidatePresentation | null;
+          pluginName: string | null;
+        }),
+  ) => void;
+  pluginValidateKindLabels: Record<string, string>;
+  pluginValidateKindHints: Record<string, string>;
+  setPluginAuthStatus: (
+    v:
+      | Record<string, api.PluginMcpAuthStatus>
+      | ((
+          prev: Record<string, api.PluginMcpAuthStatus>,
+        ) => Record<string, api.PluginMcpAuthStatus>),
+  ) => void;
+  pluginAuthServer: string | null;
+  setPluginAuthServer: (v: string | null) => void;
+  refresh: (opts?: { forcePlugins?: boolean }) => Promise<void>;
+
+  tr: TFn;
+  locale: Locale;
+  actionBusy: string | null;
+};
+
+export function ExtensionsPanelPluginsModals(p: ExtensionsPanelPluginsModalsProps) {
+  const {
+    projectPath,
+    cliFound,
+    onOpenRuntime,
+    cliMissing,
+    plugins,
+    recommendedInstall,
+    setRecommendedInstall,
+    installRecommended,
+    installAvailableDirect,
+    installSource,
+    pathInstallOpen,
+    setPathInstallOpen,
+    pathInstallError,
+    setPathInstallError,
+    setPathValidate,
+    setInstallSource,
+    openPathInstall,
+    browsePluginFolder,
+    pathInstallInputRef,
+    pathValidate,
+    validatePathInstall,
+    requestPathInstall,
+    installConfirmSource,
+    setInstallConfirmSource,
+    confirmPathInstall,
+    detailCard,
+    setDetailCard,
+    menuPlugin,
+    setMenuPlugin,
+    setDetailsModel,
+    setDetailRawAvailable,
+    setDetailRawInstalled,
+    showDetails,
+    setDetailsOpen,
+    detailsOpen,
+    detailsTitle,
+    detailsBody,
+    detailsLoading,
+    detailsModel,
+    detailRawAvailable,
+    detailRawInstalled,
+    togglePlugin,
+    badgeLabel,
+    metaByName,
+    uninstallTarget,
+    setUninstallTarget,
+    confirmUninstall,
+    sourcesModalOpen,
+    setSourcesModalOpen,
+    validateModal,
+    setValidateModal,
+    pluginValidateKindLabels,
+    pluginValidateKindHints,
+    setPluginAuthStatus,
+    pluginAuthServer,
+    setPluginAuthServer,
+    refresh,
+    tr,
+    locale,
+    actionBusy,
+  } = p;
+  return (
+    <>
+      <GlassModal
+        open={!!recommendedInstall}
+        onClose={() => {
+          const busy =
+            actionBusy === "install:chatcut" || actionBusy === "install:x-api";
+          if (!busy) setRecommendedInstall(null);
+        }}
+        title={
+          recommendedInstall === "x-api"
+            ? tr("ext.plugins.recommended.xApiInstallTitle")
+            : tr("ext.plugins.recommended.installTitle")
+        }
+        size="sm"
+        closeLabel={tr("common.close")}
+        footer={
+          <>
+            <button
+              type="button"
+              className="btn btn--ghost"
+              disabled={
+                actionBusy === "install:chatcut" ||
+                actionBusy === "install:x-api"
+              }
+              onClick={() => setRecommendedInstall(null)}
+            >
+              {tr("common.cancel")}
+            </button>
+            <button
+              type="button"
+              className="btn btn--solid"
+              disabled={
+                actionBusy === "install:chatcut" ||
+                actionBusy === "install:x-api" ||
+                cliMissing ||
+                !recommendedInstall
+              }
+              onClick={() => {
+                if (recommendedInstall) void installRecommended(recommendedInstall);
+              }}
+            >
+              {actionBusy === "install:chatcut" ||
+              actionBusy === "install:x-api"
+                ? tr("ext.plugins.installing")
+                : tr("ext.plugins.recommended.install")}
+            </button>
+          </>
+        }
+      >
+        <p className="app-dialog__msg">
+          {recommendedInstall === "x-api"
+            ? tr("ext.plugins.recommended.xApiInstallConfirm", {
+                source: X_API_INSTALL_SOURCE,
+              })
+            : tr("ext.plugins.recommended.installConfirm", {
+                source: CHATCUT_CODEX_INSTALL_SOURCE,
+              })}
+        </p>
+        <p className="ext-field-hint">{tr("ext.market.installTrustNote")}</p>
+      </GlassModal>
+
+      <PluginMcpAuthWizard
+        open={!!pluginAuthServer}
+        locale={locale}
+        serverName={pluginAuthServer ?? ""}
+        onClose={() => setPluginAuthServer(null)}
+        onChanged={(st) => {
+          setPluginAuthStatus((prev) => ({ ...prev, [st.server]: st }));
+        }}
+      />
+
+      <GlassModal
+        open={pathInstallOpen}
+        onClose={() => setPathInstallOpen(false)}
+        title={tr("ext.plugins.advancedInstall")}
+        size="lg"
+        closeLabel={tr("common.close")}
+        wrapBody
+        initialFocus={() => pathInstallInputRef.current}
+      >
+        <PluginPathInstallCard
+          locale={locale}
+          source={installSource}
+          onSourceChange={(next) => {
+            setInstallSource(next);
+            setPathInstallError(null);
+            setPathValidate(null);
+          }}
+          disabled={!!actionBusy || cliMissing}
+          installing={actionBusy === "install"}
+          validating={actionBusy === "validate-path"}
+          formError={pathInstallError}
+          validatePresentation={pathValidate}
+          kindLabels={pluginValidateKindLabels}
+          kindHints={pluginValidateKindHints}
+          onBrowse={() => void browsePluginFolder()}
+          onValidate={() => void validatePathInstall()}
+          onInstall={requestPathInstall}
+          inputRef={pathInstallInputRef}
+        />
+      </GlassModal>
+
+      <GlassModal
+        open={!!installConfirmSource}
+        onClose={() => {
+          if (actionBusy === "install") return;
+          setInstallConfirmSource(null);
+          setPathInstallOpen(true);
+        }}
+        title={tr("ext.plugins.installConfirmTitle")}
+        size="sm"
+        closeLabel={tr("common.close")}
+        footer={
+          <>
+            <button
+              type="button"
+              className="btn btn--ghost"
+              disabled={actionBusy === "install"}
+              onClick={() => {
+                setInstallConfirmSource(null);
+                setPathInstallOpen(true);
+              }}
+            >
+              {tr("common.cancel")}
+            </button>
+            <button
+              type="button"
+              className="btn btn--solid"
+              disabled={actionBusy === "install" || cliMissing}
+              onClick={() => void confirmPathInstall()}
+            >
+              {actionBusy === "install"
+                ? tr("ext.plugins.installing")
+                : tr("ext.plugins.install")}
+            </button>
+          </>
+        }
+      >
+        <p className="app-dialog__msg">
+          {tr("ext.plugins.installConfirm", {
+            source: installConfirmSource ?? "",
+          })}
+        </p>
+        <p className="ext-field-hint">{tr("ext.market.installTrustNote")}</p>
+      </GlassModal>
+
+      <GlassModal
+        open={!!detailCard}
+        onClose={() => {
+          setDetailCard(null);
+          setDetailRawAvailable(null);
+          setDetailRawInstalled(null);
+        }}
+        title={detailCard?.displayName ?? tr("ext.market.detailTitle")}
+        size="md"
+        closeLabel={tr("common.close")}
+        wrapBody
+        footer={
+          <>
+            <button
+              type="button"
+              className="btn btn--ghost"
+              onClick={() => {
+                setDetailCard(null);
+                setDetailRawAvailable(null);
+                setDetailRawInstalled(null);
+              }}
+            >
+              {tr("common.close")}
+            </button>
+            {detailRawAvailable && !detailCard?.installed ? (
+              <button
+                type="button"
+                className="btn btn--solid"
+                disabled={
+                  !!actionBusy ||
+                  cliMissing ||
+                  actionBusy === `inst:${detailRawAvailable.name}`
+                }
+                onClick={() => {
+                  const t = detailRawAvailable;
+                  setDetailCard(null);
+                  setDetailRawAvailable(null);
+                  void installAvailableDirect(t);
+                }}
+              >
+                {actionBusy === `inst:${detailRawAvailable.name}`
+                  ? tr("ext.market.installing")
+                  : tr("ext.market.install")}
+              </button>
+            ) : null}
+            {detailRawInstalled ? (
+              <button
+                type="button"
+                className="btn btn--solid"
+                onClick={() => {
+                  togglePlugin(detailRawInstalled);
+                  setDetailCard(null);
+                  setDetailRawInstalled(null);
+                }}
+              >
+                {detailRawInstalled.enabled
+                  ? tr("ext.plugins.disable")
+                  : tr("ext.plugins.enable")}
+              </button>
+            ) : null}
+          </>
+        }
+      >
+        {detailCard ? (
+          <div className="ext-market-detail">
+            <div
+              style={{
+                display: "flex",
+                gap: 14,
+                alignItems: "flex-start",
+                marginBottom: 12,
+              }}
+            >
+              <div className="ext-ref-featured__icon" aria-hidden>
+                {detailCard.iconUrl ? (
+                  <img src={detailCard.iconUrl} alt="" />
+                ) : (
+                  <span className="ext-ref-icon__glyph">
+                    {pluginInitials(detailCard.displayName)}
+                  </span>
+                )}
+              </div>
+              <div style={{ minWidth: 0, flex: 1 }}>
+                <div className="ext-ref-featured__title">
+                  {detailCard.displayName}
+                </div>
+                <div className="ext-ref-featured__desc">
+                  {detailCard.description || "—"}
+                </div>
+              </div>
+            </div>
+            {(() => {
+              const meta = metaByName.get(
+                detailCard.name.trim().toLowerCase(),
+              );
+              const clean: Array<[string, string]> = [];
+              clean.push([
+                tr("ext.market.field.marketplace"),
+                detailCard.marketplace?.trim() || "—",
+              ]);
+              clean.push([
+                tr("ext.market.field.version"),
+                String(detailCard.version || meta?.version || "—"),
+              ]);
+              if (meta?.category || detailCard.categoryLabel) {
+                clean.push([
+                  detailCard.categoryLabel || "Category",
+                  meta?.category || detailCard.categoryLabel || "—",
+                ]);
+              }
+              if (meta?.author) clean.push(["Author", meta.author]);
+              if (meta?.homepage) clean.push(["Homepage", meta.homepage]);
+              if (meta?.repository) clean.push(["Repository", meta.repository]);
+              if (meta?.license) clean.push(["License", meta.license]);
+              if (detailCard.providesLine) {
+                clean.push([
+                  tr("ext.market.componentsLabel"),
+                  detailCard.providesLine,
+                ]);
+              }
+              if (meta?.keywords && meta.keywords.length > 0) {
+                clean.push(["Keywords", meta.keywords.join(", ")]);
+              }
+              if (detailRawInstalled?.path) {
+                clean.push(["Path", detailRawInstalled.path]);
+              }
+              if (detailRawInstalled?.source) {
+                clean.push([
+                  tr("ext.market.field.source"),
+                  detailRawInstalled.source,
+                ]);
+              }
+              return (
+                <dl className="ext-market-detail__meta">
+                  {clean.map(([k, v]) => (
+                    <div key={k} className="ext-market-detail__row">
+                      <dt>{k}</dt>
+                      <dd title={v}>{v}</dd>
+                    </div>
+                  ))}
+                </dl>
+              );
+            })()}
+            {(() => {
+              const meta = metaByName.get(
+                detailCard.name.trim().toLowerCase(),
+              );
+              const long =
+                meta?.longDescription?.trim() ||
+                detailCard.description ||
+                "";
+              if (!long) return null;
+              return (
+                <p className="ext-field-hint" style={{ marginTop: 12 }}>
+                  {long}
+                </p>
+              );
+            })()}
+            {!detailCard.installed ? (
+              <p className="ext-field-hint" style={{ marginTop: 8 }}>
+                {tr("ext.market.installTrustNote")}
+              </p>
+            ) : null}
+          </div>
+        ) : null}
+      </GlassModal>
+
+      <GlassModal
+        open={!!menuPlugin}
+        onClose={() => setMenuPlugin(null)}
+        title={
+          pluginDisplayName(
+            menuPlugin,
+            tr("ext.plugins.recommended.chatcutName"),
+          )
+        }
+        size="sm"
+        closeLabel={tr("common.close")}
+        footer={
+          <button
+            type="button"
+            className="btn btn--ghost"
+            onClick={() => setMenuPlugin(null)}
+          >
+            {tr("common.close")}
+          </button>
+        }
+      >
+        {menuPlugin ? (
+          <div className="ext-ref-stack" style={{ gap: 8 }}>
+            <button
+              type="button"
+              className="btn btn--ghost"
+              style={{ justifyContent: "flex-start" }}
+              onClick={() => {
+                togglePlugin(menuPlugin);
+                setMenuPlugin(null);
+              }}
+            >
+              {menuPlugin.enabled
+                ? tr("ext.plugins.disable")
+                : tr("ext.plugins.enable")}
+            </button>
+            <button
+              type="button"
+              className="btn btn--ghost"
+              style={{ justifyContent: "flex-start" }}
+              onClick={() => {
+                void showDetails(menuPlugin);
+                setMenuPlugin(null);
+              }}
+            >
+              {tr("ext.plugins.details")}
+            </button>
+            <button
+              type="button"
+              className="btn btn--ghost ext-item__danger"
+              style={{ justifyContent: "flex-start" }}
+              onClick={() => {
+                setUninstallTarget(menuPlugin);
+                setMenuPlugin(null);
+              }}
+            >
+              {tr("ext.plugins.uninstall")}
+            </button>
+          </div>
+        ) : null}
+      </GlassModal>
+
+      <GlassModal
+        open={sourcesModalOpen}
+        onClose={() => setSourcesModalOpen(false)}
+        title={tr("ext.plugins.sourcesModalTitle")}
+        size="lg"
+        closeLabel={tr("common.close")}
+        wrapBody
+        footer={
+          <>
+            <button
+              type="button"
+              className="btn btn--ghost"
+              onClick={openPathInstall}
+            >
+              {tr("ext.plugins.advancedInstall")}
+            </button>
+            <button
+              type="button"
+              className="btn btn--ghost"
+              onClick={() => setSourcesModalOpen(false)}
+            >
+              {tr("common.close")}
+            </button>
+          </>
+        }
+      >
+        <p className="ext-ref-block__lead" style={{ marginBottom: 12 }}>
+          {tr("ext.plugins.sourcesModalLead")}
+        </p>
+        <div className="ext-ref-block" style={{ marginBottom: 16 }}>
+          <div className="ext-ref-block__head">
+            <h3 className="ext-ref-block__title">
+              {tr("ext.plugins.sourcesListTitle")}
+            </h3>
+          </div>
+          {/* Reuse market block for sources management only (non-embedded shows sources). */}
+          <ExtensionsBuildExtras
+            locale={locale}
+            projectPath={projectPath}
+            cliFound={cliFound && !cliMissing}
+            mode="market"
+            embedded
+            sourcesOnly
+            installedPlugins={plugins.map((p) => ({
+              name: p.name,
+              marketplace: p.marketplace,
+              path: p.path,
+              source: p.source,
+              repoKey: p.repoKey,
+            }))}
+            onOpenRuntime={onOpenRuntime}
+            onPluginsChanged={() => {
+              invalidatePluginsListCache();
+              void refresh({ forcePlugins: true });
+            }}
+          />
+        </div>
+      </GlassModal>
+
+      <GlassModal
+        open={!!uninstallTarget}
+        onClose={() => {
+          if (!actionBusy) setUninstallTarget(null);
+        }}
+        title={tr("ext.plugins.uninstallTitle")}
+        size="sm"
+        closeLabel={tr("common.close")}
+        footer={
+          <>
+            <button
+              type="button"
+              className="btn btn--ghost"
+              disabled={!!actionBusy}
+              onClick={() => setUninstallTarget(null)}
+            >
+              {tr("common.cancel")}
+            </button>
+            <button
+              type="button"
+              className="btn btn--danger"
+              disabled={!!actionBusy}
+              onClick={() => void confirmUninstall()}
+            >
+              {tr("ext.plugins.uninstall")}
+            </button>
+          </>
+        }
+      >
+        <p className="app-dialog__msg">
+          {tr("ext.plugins.uninstallConfirm", {
+            name: uninstallTarget?.name ?? "",
+          })}
+        </p>
+      </GlassModal>
+
+      <GlassModal
+        open={validateModal.open && !!validateModal.presentation}
+        onClose={() =>
+          setValidateModal((prev) => ({ ...prev, open: false }))
+        }
+        title={
+          validateModal.pluginName
+            ? tr("ext.plugins.validate.resultTitleNamed", {
+                name: validateModal.pluginName,
+              })
+            : tr("ext.plugins.validate.resultTitle")
+        }
+        size="lg"
+        closeLabel={tr("common.close")}
+        wrapBody
+        bodyClassName="ext-plugin-result-modal"
+        footer={
+          <button
+            type="button"
+            className="btn btn--solid"
+            onClick={() =>
+              setValidateModal((prev) => ({ ...prev, open: false }))
+            }
+          >
+            {tr("common.close")}
+          </button>
+        }
+      >
+        {validateModal.presentation ? (
+          <div className="ext-plugin-result">
+            <div className="ext-plugin-result__meta">
+              <span
+                className={
+                  "ext-badge ext-badge--" +
+                  pluginValidateBadgeTone(validateModal.presentation.severity)
+                }
+              >
+                {pluginValidateKindLabel(
+                  validateModal.presentation.kind,
+                  pluginValidateKindLabels,
+                )}
+              </span>
+              {validateModal.presentation.softFail ? (
+                <span className="ext-badge ext-badge--muted">
+                  {tr("ext.plugins.validate.softFail")}
+                </span>
+              ) : null}
+              {validateModal.presentation.ok ? (
+                <span className="ext-badge ext-badge--ok">
+                  {tr("ext.plugins.validateOk")}
+                </span>
+              ) : null}
+            </div>
+            <p
+              className={
+                "ext-plugin-result__summary" +
+                (validateModal.presentation.severity === "ok"
+                  ? " ext-plugin-result__summary--ok"
+                  : validateModal.presentation.severity === "err"
+                    ? " ext-plugin-result__summary--err"
+                    : " ext-plugin-result__summary--warn")
+              }
+            >
+              {validateModal.presentation.summary}
+            </p>
+            {pluginValidateHint(
+              validateModal.presentation.kind,
+              pluginValidateKindHints,
+            ) ? (
+              <p className="ext-plugin-result__hint">
+                {pluginValidateHint(
+                  validateModal.presentation.kind,
+                  pluginValidateKindHints,
+                )}
+              </p>
+            ) : null}
+            {validateModal.presentation.detail &&
+            validateModal.presentation.detail !==
+              validateModal.presentation.summary ? (
+              <pre className="ext-plugin-result__detail">
+                {validateModal.presentation.detail}
+              </pre>
+            ) : validateModal.presentation.messages.length > 1 ? (
+              <pre className="ext-plugin-result__detail">
+                {formatPluginValidateMessages(
+                  validateModal.presentation.messages,
+                )}
+              </pre>
+            ) : null}
+            {validateModal.presentation.reason ? (
+              <p className="ext-plugin-result__reason">
+                <span className="ext-plugin-result__label">
+                  {tr("ext.plugins.validate.reason")}
+                </span>
+                <code>{validateModal.presentation.reason}</code>
+              </p>
+            ) : null}
+            {validateModal.presentation.path ? (
+              <p
+                className="ext-plugin-result__path"
+                title={validateModal.presentation.path}
+              >
+                <span className="ext-plugin-result__label">
+                  {tr("ext.plugins.validate.path")}
+                </span>
+                <code>{validateModal.presentation.path}</code>
+              </p>
+            ) : null}
+          </div>
+        ) : null}
+      </GlassModal>
+
+      <GlassModal
+        open={detailsOpen}
+        onClose={() => {
+          setDetailsOpen(false);
+          setDetailsModel(null);
+        }}
+        title={tr("ext.plugins.detailsTitle", { name: detailsTitle })}
+        size="lg"
+        closeLabel={tr("common.close")}
+        wrapBody
+        footer={
+          <button
+            type="button"
+            className="btn btn--ghost"
+            onClick={() => {
+              setDetailsOpen(false);
+              setDetailsModel(null);
+            }}
+          >
+            {tr("common.close")}
+          </button>
+        }
+      >
+        {detailsModel ? (
+          <div className="ext-market-detail">
+            <dl className="ext-market-detail__meta">
+              <div className="ext-market-detail__row">
+                <dt>{tr("ext.market.field.marketplace")}</dt>
+                <dd>
+                  {detailsModel.marketplace?.trim() ||
+                    tr("ext.market.field.unknown")}
+                </dd>
+              </div>
+              <div className="ext-market-detail__row">
+                <dt>{tr("ext.market.field.version")}</dt>
+                <dd>
+                  {detailsModel.versionLabel
+                    ? `v${detailsModel.versionLabel}`
+                    : tr("ext.market.field.unknown")}
+                </dd>
+              </div>
+            </dl>
+            {detailsModel.badges.length > 0 ? (
+              <div
+                className="ext-component-badges ext-component-badges--detail"
+                aria-label={tr("ext.market.componentsLabel")}
+              >
+                {detailsModel.badges.map((b) => (
+                  <span
+                    key={b.kind}
+                    className={
+                      "ext-badge ext-badge--component ext-badge--component-" +
+                      b.kind
+                    }
+                  >
+                    {badgeLabel(b.kind, b.count)}
+                  </span>
+                ))}
+              </div>
+            ) : null}
+          </div>
+        ) : null}
+        {detailsLoading ? (
+          <p className="ext-empty">{tr("ext.plugins.detailsLoading")}</p>
+        ) : (
+          <pre className="ext-details-pre">{detailsBody}</pre>
+        )}
+      </GlassModal>
+    </>
+  );
+}

--- a/src/lib/extensionsSurface.guard.test.ts
+++ b/src/lib/extensionsSurface.guard.test.ts
@@ -8,7 +8,7 @@ describe("extensions settings surface guard", () => {
   it("wraps every extension tab in the shared opaque settings card", () => {
     const component = read("../components/ExtensionsPanel.tsx");
     const surface = component.match(
-      /<div className="settings-card ext-panel__surface">([\s\S]*?)\n\s*<\/div>\n\n\s*<GlassModal/,
+      /<div className="settings-card ext-panel__surface">([\s\S]*?)\n\s*<\/div>\n\n\s*<ExtensionsPanelPluginsModals/,
     )?.[1];
 
     expect(surface).toBeDefined();
@@ -19,11 +19,15 @@ describe("extensions settings surface guard", () => {
 
   it("keeps local-path plugin install on the plugins Discover + control", () => {
     const component = read("../components/ExtensionsPanel.tsx");
+    const modals = read("../components/ExtensionsPanelPluginsModals.tsx");
+    // Anchor stays on the panel's Discover surface; the card + wiring moved
+    // with the plugins modal farm (WP: giant-component decomposition).
     expect(component).toContain("settings-anchor-ext-plugins-install");
-    expect(component).toContain("PluginPathInstallCard");
-    expect(component).toContain("pickDirectory");
     expect(component).toContain("openPathInstall");
     expect(component).toContain("pathInstallOpen");
+    expect(component).toContain("pickDirectory");
+    expect(modals).toContain("PluginPathInstallCard");
+    expect(modals).toContain("openPathInstall");
   });
 
   it("reuses the shared card material and keeps its modifier layout-only", () => {


### PR DESCRIPTION
## Summary
Completes the modal-farm extraction started in #1164: the remaining **12 GlassModals + 2 OAuth wizards** (~1,000 lines of JSX) move out of `ExtensionsPanel` verbatim, split by domain to stay under the `files_ge_1000` budget:

- [`ExtensionsPanelPluginsModals.tsx`](src/components/ExtensionsPanelPluginsModals.tsx) (859 lines) — recommended install, path install + validate, install confirm, plugin details + row menu, sources management, uninstall confirm, validate result
- [`ExtensionsPanelMcpModals.tsx`](src/components/ExtensionsPanelMcpModals.tsx) (485 lines) — MCP server add form, remove confirm, doctor report, both OAuth wizards

`extensionsSurface.guard.test.ts` updated in the same PR (its intent unchanged): the tab-surface boundary assertion now ends at the plugins farm component, and the local-path-install assertions span panel + farm — `PluginPathInstallCard` moved with its modal, while the anchor, `pickDirectory` wiring, and `pathInstallOpen` state stay on the panel.

`ExtensionsPanel`: 3,980 → **3,058 lines**. Only the five tab surfaces now remain in the panel.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Refactor / chore

## Checklist
- [x] `pnpm typecheck` / `pnpm test` (646 files) / `lint` / gates (`files_ge_1000` back to 80) / self-test / `build:ui` — all green
- [x] No Rust change
- [x] No user-facing strings / no visual change (JSX moved verbatim)
- [x] No secrets included