### PR TITLE
fix(browser): open Google sign-in in the system browser (#1154)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ See `docs/llm-wiki/release.md`.
 - 输入框上的分支 chip 可在当前目录切换 git 分支。仅远程存在的分支会建本地跟踪分支；已在其他 worktree 检出的则切到那个 worktree。
 
 ### Fixed
+- Embedded browser opens Google sign-in in the system browser on Windows.
 - Slow trackpad scrolling up from the chat tail no longer snaps back or flashes.
 - Wallpaper frost stays stable while streaming on macOS.
 - The user menu lists every saved official account and remaining quota again.
@@ -31,6 +32,7 @@ See `docs/llm-wiki/release.md`.
 - Generated wallpaper stays visible when library indexing fails and can be saved again.
 
 **中文 · 修复**
+- 内嵌浏览器遇到 Google 登录时改为打开系统浏览器，避免 Windows 卡死。
 - 从聊天底部慢慢上滑时，不再被弹回底部或闪一下。
 - 流式输出时壁纸霜化层保持稳定，不再随 stream-perf 重建。
 - 用户菜单再次列出本机已保存的官方账号及各自剩余额度。

--- a/src-tauri/src/side_browser_host.rs
+++ b/src-tauri/src/side_browser_host.rs
@@ -449,9 +449,7 @@ pub fn create(
         .initialization_script(polyfill)
         // Google Sign-In inside WebView2 hard-freezes the Windows host (#1154).
         // Hand those navigations to the system browser and cancel in-webview load.
-        .on_navigation(move |url| {
-            !handoff_google_auth_externally(&nav_app, &nav_label, url)
-        })
+        .on_navigation(move |url| !handoff_google_auth_externally(&nav_app, &nav_label, url))
         .on_new_window(move |url, _features| {
             if handoff_google_auth_externally(&new_win_app, &new_win_label, &url) {
                 NewWindowResponse::Deny
@@ -895,13 +893,13 @@ mod tests {
     #[test]
     fn google_auth_hosts_open_externally() {
         let cases = [
-            ("https://accounts.google.com/o/oauth2/auth?client_id=1", true),
-            ("https://accounts.youtube.com/accounts/SetSID", true),
-            ("https://oauth2.googleapis.com/token", true),
             (
-                "https://www.google.com/o/oauth2/v2/auth?client_id=1",
+                "https://accounts.google.com/o/oauth2/auth?client_id=1",
                 true,
             ),
+            ("https://accounts.youtube.com/accounts/SetSID", true),
+            ("https://oauth2.googleapis.com/token", true),
+            ("https://www.google.com/o/oauth2/v2/auth?client_id=1", true),
             ("https://www.google.com/signin/identifier", true),
             ("https://www.google.com/search?q=hello", false),
             ("https://google.com/", false),

--- a/src-tauri/src/side_browser_host.rs
+++ b/src-tauri/src/side_browser_host.rs
@@ -23,6 +23,12 @@
 //! True Chromium-in-process (CEF) is **not** available in Tauri/Wry today.
 //! When CEF lands, it should register under the same label scheme and reuse
 //! these commands so automation clients stay compatible.
+//!
+//! ## Google Sign-In (#1154)
+//!
+//! WebView2 hard-freezes on Google account / OAuth documents. Top-level
+//! navigations and `window.open` to those hosts are cancelled and handed to
+//! the system browser via [`crate::commands::open_http_url`].
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -33,13 +39,14 @@ use std::time::Duration;
 
 use parking_lot::Mutex;
 use serde::Serialize;
-use tauri::webview::{DownloadEvent, PageLoadEvent, WebviewBuilder};
+use tauri::webview::{DownloadEvent, NewWindowResponse, PageLoadEvent, WebviewBuilder};
 use tauri::{AppHandle, Emitter, Manager, WebviewUrl};
 use tauri::{LogicalPosition, LogicalSize, Url};
 
 const LABEL_PREFIX: &str = "resource-browser";
 const DOWNLOAD_EVENT: &str = "side-browser://download";
 const PAGE_LOAD_EVENT: &str = "side-browser://page-load";
+const EXTERNAL_OPEN_EVENT: &str = "side-browser://external-open";
 
 /// url → staging path chosen in `Requested` (macOS finish omits path).
 static PENDING_DOWNLOADS: LazyLock<Mutex<HashMap<String, PendingDownload>>> =
@@ -80,6 +87,80 @@ pub struct SideBrowserPageLoadPayload {
     pub phase: String,
     pub label: String,
     pub url: String,
+}
+
+/// Payload for `side-browser://external-open` (status line after Google auth handoff).
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SideBrowserExternalOpenPayload {
+    pub label: String,
+    pub url: String,
+    /// `google_auth`
+    pub reason: String,
+}
+
+/// Google account / OAuth surfaces that hard-freeze WebView2 on Windows (#1154).
+///
+/// Intentionally narrow: plain `google.com` search / docs stay in-app.
+pub fn should_open_google_auth_externally(url: &Url) -> bool {
+    if url.scheme() != "https" && url.scheme() != "http" {
+        return false;
+    }
+    let Some(host) = url.host_str().map(str::to_ascii_lowercase) else {
+        return false;
+    };
+    if host == "accounts.google.com"
+        || host == "accounts.youtube.com"
+        || host == "accounts.googleusercontent.com"
+        || host.ends_with(".accounts.google.com")
+        || host == "oauth2.googleapis.com"
+    {
+        return true;
+    }
+    if host == "google.com" || host == "www.google.com" {
+        let path = url.path().to_ascii_lowercase();
+        return path.starts_with("/o/oauth2")
+            || path.starts_with("/signin")
+            || path.starts_with("/_/accountchooser")
+            || path.starts_with("/accountchooser");
+    }
+    false
+}
+
+fn emit_external_open(app: &AppHandle, label: &str, url: &str) {
+    if let Err(e) = app.emit(
+        EXTERNAL_OPEN_EVENT,
+        SideBrowserExternalOpenPayload {
+            label: label.into(),
+            url: url.into(),
+            reason: "google_auth".into(),
+        },
+    ) {
+        tracing::warn!(error = %e, "side-browser external-open emit failed");
+    }
+}
+
+fn handoff_google_auth_externally(app: &AppHandle, label: &str, url: &Url) -> bool {
+    if !should_open_google_auth_externally(url) {
+        return false;
+    }
+    let url_s = url.as_str();
+    tracing::info!(
+        target: "side_browser",
+        %label,
+        url = %url_s,
+        "Google auth URL → system browser (WebView2 freeze guard)"
+    );
+    if let Err(e) = crate::commands::open_http_url(url_s) {
+        tracing::warn!(
+            target: "side_browser",
+            error = %e,
+            url = %url_s,
+            "failed to open Google auth URL externally"
+        );
+    }
+    emit_external_open(app, label, url_s);
+    true
 }
 
 /// Emit download status for the EmbeddedBrowser status line (HTTP + blob paths).
@@ -286,7 +367,15 @@ pub fn create(
     height: f64,
 ) -> Result<(), String> {
     validate_side_label(&label)?;
-    let parsed = validate_url(&url)?;
+    let mut url = url;
+    let mut parsed = validate_url(&url)?;
+    // Address-bar / deep-link into Google auth: hand off before the child
+    // WebView2 ever loads the freeze-prone document.
+    if should_open_google_auth_externally(&parsed) {
+        handoff_google_auth_externally(app, &label, &parsed);
+        url = "about:blank".into();
+        parsed = validate_url(&url)?;
+    }
     let win_label = window_label.trim();
     if win_label.is_empty() {
         return Err("window_label empty".into());
@@ -323,6 +412,9 @@ pub fn create(
             .map(|current| current != parsed)
             .unwrap_or(true);
         if should_navigate {
+            if handoff_google_auth_externally(app, &label, &parsed) {
+                return Ok(());
+            }
             emit_page_load(app, "started", &label, &url);
             existing
                 .navigate(parsed)
@@ -343,6 +435,10 @@ pub fn create(
     let polyfill_reload = polyfill.clone();
     let title_label = label.clone();
     let page_load_label = label.clone();
+    let nav_label = label.clone();
+    let nav_app = app.clone();
+    let new_win_label = label.clone();
+    let new_win_app = app.clone();
     // Do not steal keyboard focus from the main chat/composer on create —
     // users click the page when they want to type there.
     // First document load starts immediately after create.
@@ -351,6 +447,18 @@ pub fn create(
         .accept_first_mouse(true)
         .focused(false)
         .initialization_script(polyfill)
+        // Google Sign-In inside WebView2 hard-freezes the Windows host (#1154).
+        // Hand those navigations to the system browser and cancel in-webview load.
+        .on_navigation(move |url| {
+            !handoff_google_auth_externally(&nav_app, &nav_label, url)
+        })
+        .on_new_window(move |url, _features| {
+            if handoff_google_auth_externally(&new_win_app, &new_win_label, &url) {
+                NewWindowResponse::Deny
+            } else {
+                NewWindowResponse::Allow
+            }
+        })
         // Drive UI loading bar + re-assert download polyfill after navigations.
         // Polyfill early-returns if already installed — cheap.
         .on_page_load(move |webview, payload| {
@@ -653,6 +761,9 @@ pub fn list(app: &AppHandle) -> Result<Vec<SideBrowserInfo>, String> {
 
 pub fn navigate(app: &AppHandle, label: String, url: String) -> Result<(), String> {
     let parsed = validate_url(&url)?;
+    if handoff_google_auth_externally(app, &label, &parsed) {
+        return Ok(());
+    }
     let wv = get_side_webview(app, &label)?;
     // Optimistic start so the UI can paint a progress bar before WK/WebView2
     // fires PageLoadEvent::Started (can lag on slow DNS / first byte).
@@ -779,5 +890,31 @@ mod tests {
             .file_name()
             .and_then(|n| n.to_str())
             .is_some_and(|n| n.ends_with("hello world.pdf")));
+    }
+
+    #[test]
+    fn google_auth_hosts_open_externally() {
+        let cases = [
+            ("https://accounts.google.com/o/oauth2/auth?client_id=1", true),
+            ("https://accounts.youtube.com/accounts/SetSID", true),
+            ("https://oauth2.googleapis.com/token", true),
+            (
+                "https://www.google.com/o/oauth2/v2/auth?client_id=1",
+                true,
+            ),
+            ("https://www.google.com/signin/identifier", true),
+            ("https://www.google.com/search?q=hello", false),
+            ("https://google.com/", false),
+            ("https://mail.google.com/", false),
+            ("https://example.com/accounts.google.com", false),
+        ];
+        for (raw, expect) in cases {
+            let url = Url::parse(raw).unwrap();
+            assert_eq!(
+                should_open_google_auth_externally(&url),
+                expect,
+                "url={raw}"
+            );
+        }
     }
 }

--- a/src/components/EmbeddedBrowser.tsx
+++ b/src/components/EmbeddedBrowser.tsx
@@ -36,6 +36,7 @@ import {
 } from "@/lib/api";
 import type {
   SideBrowserDownloadEvent,
+  SideBrowserExternalOpenEvent,
   SideBrowserPageLoadEvent,
 } from "@/lib/api";
 import { createT, type Locale } from "@/i18n";
@@ -126,6 +127,7 @@ function hostRectForWebview(hostEl: HTMLElement): HostRectPx | null {
 const WEBVIEW_LABEL_DEFAULT = "resource-browser";
 const DOWNLOAD_EVENT = "side-browser://download";
 const PAGE_LOAD_EVENT = "side-browser://page-load";
+const EXTERNAL_OPEN_EVENT = "side-browser://external-open";
 const CREATE_TIMEOUT_MS = 15_000;
 const CLOSE_GRACE_MS = 150;
 /** Drop loading UI if host never emits Finished (network hang / offline). */
@@ -590,6 +592,39 @@ export function EmbeddedBrowser({
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [webviewLabel]);
+
+  // Google Sign-In handoff (#1154): host cancels in-webview load and opens
+  // the system browser; surface a short status so the user knows why.
+  useEffect(() => {
+    if (!isTauri()) return;
+    let unlisten: (() => void) | undefined;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const { listen } = await import("@tauri-apps/api/event");
+        const off = await listen<SideBrowserExternalOpenEvent>(
+          EXTERNAL_OPEN_EVENT,
+          (ev) => {
+            const p = ev.payload;
+            if (!p || p.label !== webviewLabel) return;
+            if (p.reason === "google_auth") {
+              flashDownloadStatus(tr("resources.browserGoogleAuthExternal"));
+              markPageLoading(false);
+            }
+          },
+        );
+        if (cancelled) off();
+        else unlisten = off;
+      } catch {
+        /* ignore */
+      }
+    })();
+    return () => {
+      cancelled = true;
+      unlisten?.();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [webviewLabel, locale]);
 
   // Create once per label. URL changes navigate in-place (do not tear down WKWebView).
   useEffect(() => {

--- a/src/i18n/messages/de/workspace.ts
+++ b/src/i18n/messages/de/workspace.ts
@@ -255,6 +255,7 @@ export const deWorkspace = {
   "resources.browserDownloadSaved": "{name} gespeichert",
   "resources.browserDownloadFailed": "Download fehlgeschlagen",
   "resources.browserDownloadCancelled": "Download abgebrochen",
+  "resources.browserGoogleAuthExternal": "Google-Anmeldung im Systembrowser geöffnet.",
   "search.title": "Suchen",
   "search.placeholder": "Chats, Projekte, Aktionen oder Nachrichteninhalt suchen…",
   "search.projects": "Projekte",

--- a/src/i18n/messages/en/workspace.ts
+++ b/src/i18n/messages/en/workspace.ts
@@ -255,6 +255,7 @@ export const enWorkspace = {
   "resources.browserDownloadSaved": "Saved {name}",
   "resources.browserDownloadFailed": "Download failed",
   "resources.browserDownloadCancelled": "Download cancelled",
+  "resources.browserGoogleAuthExternal": "Google sign-in opened in your system browser.",
   "search.title": "Search",
   "search.placeholder": "Search chats, projects, actions, or message content…",
   "search.projects": "Projects",

--- a/src/i18n/messages/es/workspace.ts
+++ b/src/i18n/messages/es/workspace.ts
@@ -255,6 +255,7 @@ export const esWorkspace = {
   "resources.browserDownloadSaved": "Se guardó {name}",
   "resources.browserDownloadFailed": "Falló la descarga",
   "resources.browserDownloadCancelled": "Descarga cancelada",
+  "resources.browserGoogleAuthExternal": "Se abrió el inicio de sesión de Google en el navegador del sistema.",
   "search.title": "Buscar",
   "search.placeholder": "Buscar chats, proyectos, acciones o contenido de mensajes…",
   "search.projects": "Proyectos",

--- a/src/i18n/messages/fil/workspace.ts
+++ b/src/i18n/messages/fil/workspace.ts
@@ -255,6 +255,7 @@ export const filWorkspace = {
   "resources.browserDownloadSaved": "Na-save ang {name}",
   "resources.browserDownloadFailed": "Nabigo ang download",
   "resources.browserDownloadCancelled": "Nakansela ang download",
+  "resources.browserGoogleAuthExternal": "Binuksan ang Google sign-in sa system browser.",
   "search.title": "Maghanap",
   "search.placeholder": "Maghanap ng chat, proyekto, aksyon, o nilalaman ng mensahe…",
   "search.projects": "Mga proyekto",

--- a/src/i18n/messages/fr/workspace.ts
+++ b/src/i18n/messages/fr/workspace.ts
@@ -255,6 +255,7 @@ export const frWorkspace = {
   "resources.browserDownloadSaved": "{name} enregistré",
   "resources.browserDownloadFailed": "Échec du téléchargement",
   "resources.browserDownloadCancelled": "Téléchargement annulé",
+  "resources.browserGoogleAuthExternal": "Connexion Google ouverte dans le navigateur système.",
   "search.title": "Recherche",
   "search.placeholder": "Rechercher conversations, projets, actions ou contenu de messages…",
   "search.projects": "Projets",

--- a/src/i18n/messages/id/workspace.ts
+++ b/src/i18n/messages/id/workspace.ts
@@ -255,6 +255,7 @@ export const idWorkspace = {
   "resources.browserDownloadSaved": "{name} disimpan",
   "resources.browserDownloadFailed": "Unduhan gagal",
   "resources.browserDownloadCancelled": "Unduhan dibatalkan",
+  "resources.browserGoogleAuthExternal": "Login Google dibuka di browser sistem.",
   "search.title": "Cari",
   "search.placeholder": "Cari obrolan, proyek, tindakan, atau isi pesan…",
   "search.projects": "Proyek",

--- a/src/i18n/messages/it/workspace.ts
+++ b/src/i18n/messages/it/workspace.ts
@@ -255,6 +255,7 @@ export const itWorkspace = {
   "resources.browserDownloadSaved": "Salvato {name}",
   "resources.browserDownloadFailed": "Download non riuscito",
   "resources.browserDownloadCancelled": "Download annullato",
+  "resources.browserGoogleAuthExternal": "Accesso Google aperto nel browser di sistema.",
   "search.title": "Cerca",
   "search.placeholder": "Cerca chat, progetti, azioni o contenuto dei messaggi…",
   "search.projects": "Progetti",

--- a/src/i18n/messages/ja/workspace.ts
+++ b/src/i18n/messages/ja/workspace.ts
@@ -255,6 +255,7 @@ export const jaWorkspace = {
   "resources.browserDownloadSaved": "{name} を保存しました",
   "resources.browserDownloadFailed": "ダウンロードに失敗しました",
   "resources.browserDownloadCancelled": "ダウンロードをキャンセルしました",
+  "resources.browserGoogleAuthExternal": "Google ログインをシステムのブラウザで開きました。",
   "search.title": "検索",
   "search.placeholder": "チャット、プロジェクト、アクション、メッセージ本文を検索…",
   "search.projects": "プロジェクト",

--- a/src/i18n/messages/ko/workspace.ts
+++ b/src/i18n/messages/ko/workspace.ts
@@ -255,6 +255,7 @@ export const koWorkspace = {
   "resources.browserDownloadSaved": "{name}을(를) 저장했습니다",
   "resources.browserDownloadFailed": "다운로드 실패",
   "resources.browserDownloadCancelled": "다운로드 취소됨",
+  "resources.browserGoogleAuthExternal": "Google 로그인을 시스템 브라우저에서 열었습니다.",
   "search.title": "검색",
   "search.placeholder": "대화, 프로젝트, 동작 또는 메시지 내용 검색…",
   "search.projects": "프로젝트",

--- a/src/i18n/messages/pt-BR/workspace.ts
+++ b/src/i18n/messages/pt-BR/workspace.ts
@@ -255,6 +255,7 @@ export const ptBRWorkspace = {
   "resources.browserDownloadSaved": "{name} salvo",
   "resources.browserDownloadFailed": "O download falhou",
   "resources.browserDownloadCancelled": "Download cancelado",
+  "resources.browserGoogleAuthExternal": "Login do Google aberto no navegador do sistema.",
   "search.title": "Buscar",
   "search.placeholder": "Buscar chats, projetos, ações ou conteúdo de mensagens…",
   "search.projects": "Projetos",

--- a/src/i18n/messages/ru/workspace.ts
+++ b/src/i18n/messages/ru/workspace.ts
@@ -255,6 +255,7 @@ export const ruWorkspace = {
   "resources.browserDownloadSaved": "Сохранено: {name}",
   "resources.browserDownloadFailed": "Ошибка загрузки",
   "resources.browserDownloadCancelled": "Загрузка отменена",
+  "resources.browserGoogleAuthExternal": "Вход в Google открыт в системном браузере.",
   "search.title": "Поиск",
   "search.placeholder": "Поиск чатов, проектов, действий или содержимого сообщений…",
   "search.projects": "Проекты",

--- a/src/i18n/messages/ta/workspace.ts
+++ b/src/i18n/messages/ta/workspace.ts
@@ -255,6 +255,7 @@ export const taWorkspace = {
   "resources.browserDownloadSaved": "சேமிக்கப்பட்டது {name}",
   "resources.browserDownloadFailed": "பதிவிறக்கம் தோல்வியடைந்தது",
   "resources.browserDownloadCancelled": "பதிவிறக்கம் ரத்து செய்யப்பட்டது",
+  "resources.browserGoogleAuthExternal": "Google உள்நுழைவு கணினி உலாவியில் திறக்கப்பட்டது.",
   "search.title": "தேடு",
   "search.placeholder": "உரையாடல்கள், திட்டங்கள், செயல்கள் அல்லது செய்தி உள்ளடக்கத்தைத் தேடுங்கள்...",
   "search.projects": "திட்டங்கள்",

--- a/src/i18n/messages/uk/workspace.ts
+++ b/src/i18n/messages/uk/workspace.ts
@@ -255,6 +255,7 @@ export const ukWorkspace = {
   "resources.browserDownloadSaved": "Збережено {name}",
   "resources.browserDownloadFailed": "Завантаження не вдалося",
   "resources.browserDownloadCancelled": "Завантаження скасовано",
+  "resources.browserGoogleAuthExternal": "Вхід Google відкрито в системному браузері.",
   "search.title": "Пошук",
   "search.placeholder": "Шукати чати, проєкти, дії або вміст повідомлень…",
   "search.projects": "Проєкти",

--- a/src/i18n/messages/zh-TW/workspace.ts
+++ b/src/i18n/messages/zh-TW/workspace.ts
@@ -255,6 +255,7 @@ export const zhTWWorkspace = {
   "resources.browserDownloadSaved": "已儲存 {name}",
   "resources.browserDownloadFailed": "下載失敗",
   "resources.browserDownloadCancelled": "已取消下載",
+  "resources.browserGoogleAuthExternal": "已在系統瀏覽器中開啟 Google 登入。",
   "search.title": "搜尋",
   "search.placeholder": "搜尋對話、專案、操作或訊息內容…",
   "search.projects": "專案",

--- a/src/i18n/messages/zh/workspace.ts
+++ b/src/i18n/messages/zh/workspace.ts
@@ -255,6 +255,7 @@ export const zhWorkspace = {
   "resources.browserDownloadSaved": "已保存 {name}",
   "resources.browserDownloadFailed": "下载失败",
   "resources.browserDownloadCancelled": "已取消下载",
+  "resources.browserGoogleAuthExternal": "已在系统浏览器中打开 Google 登录。",
   "search.title": "搜索",
   "search.placeholder": "搜索会话、项目、操作或消息内容…",
   "search.projects": "项目",

--- a/src/lib/api/system.ts
+++ b/src/lib/api/system.ts
@@ -101,6 +101,13 @@ export type SideBrowserPageLoadEvent = {
   url: string;
 };
 
+/** Host event `side-browser://external-open` (Google auth handoff, #1154). */
+export type SideBrowserExternalOpenEvent = {
+  label: string;
+  url: string;
+  reason: "google_auth" | string;
+};
+
 export async function sideBrowserCreate(opts: {
   label: string;
   url: string;


### PR DESCRIPTION
## Summary
- Intercept Google **account / OAuth** hosts in the embedded side browser (`accounts.google.com`, `oauth2.googleapis.com`, `/o/oauth2`, `/signin`, …).
- Cancel the in-webview load / popup and open the URL with the system browser (`open_http_url`).
- Status line toast: “Google sign-in opened in your system browser.”
- Ordinary `google.com` search / browsing stays in-app.

Addresses the **Google login freeze** half of #1154.  
**Not in this PR:** MCP attaching to the embedded WebView2 via CDP (separate follow-up).

## Type of change
- [x] Bug fix

## Test plan
- [x] \`cargo test --lib side_browser_host::tests\`
- [x] \`pnpm typecheck\`
- [ ] Windows: open Resources browser → site with “Sign in with Google” → system browser opens, App does not freeze
- [ ] Windows: browse \`google.com\` search in embedded browser still works