### PR TITLE
fix(browser): Google sign-in via shared-cookie login window (#1154)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ See `docs/llm-wiki/release.md`.
 - 输入框上的分支 chip 可在当前目录切换 git 分支。仅远程存在的分支会建本地跟踪分支；已在其他 worktree 检出的则切到那个 worktree。
 
 ### Fixed
-- Embedded browser opens Google sign-in in the system browser on Windows.
+- Embedded browser opens Google sign-in in a shared-cookie login window.
 - Slow trackpad scrolling up from the chat tail no longer snaps back or flashes.
 - Wallpaper frost stays stable while streaming on macOS.
 - The user menu lists every saved official account and remaining quota again.
@@ -32,7 +32,7 @@ See `docs/llm-wiki/release.md`.
 - Generated wallpaper stays visible when library indexing fails and can be saved again.
 
 **中文 · 修复**
-- 内嵌浏览器遇到 Google 登录时改为打开系统浏览器，避免 Windows 卡死。
+- 内嵌浏览器的 Google 登录改为共享 Cookie 的登录窗，完成后回到内嵌页。
 - 从聊天底部慢慢上滑时，不再被弹回底部或闪一下。
 - 流式输出时壁纸霜化层保持稳定，不再随 stream-perf 重建。
 - 用户菜单再次列出本机已保存的官方账号及各自剩余额度。

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -66,6 +66,7 @@ mod wsl_backend;
 mod ssh_remote;
 
 mod side_browser_blob;
+mod side_browser_google_auth;
 mod side_browser_host;
 
 mod commands;

--- a/src-tauri/src/side_browser_google_auth.rs
+++ b/src-tauri/src/side_browser_google_auth.rs
@@ -1,0 +1,247 @@
+//! Google Sign-In handoff for the embedded side browser (#1154).
+//!
+//! Child WebView2 hard-freezes on Google account / OAuth documents. Those
+//! navigations open a top-level auth window that shares the side-browser
+//! data directory so cookies return to the embedded tab after redirect.
+
+use std::path::PathBuf;
+use std::sync::LazyLock;
+
+use parking_lot::Mutex;
+use serde::Serialize;
+use tauri::webview::NewWindowResponse;
+use tauri::{AppHandle, Emitter, Manager, Url, WebviewUrl, WebviewWindowBuilder};
+
+use crate::side_browser_host::{emit_page_load, get_side_webview};
+
+const AUTH_WINDOW_LABEL: &str = "side-browser-google-auth";
+const EXTERNAL_OPEN_EVENT: &str = "side-browser://external-open";
+
+/// Stable WKWebView data-store id (macOS 14+). Windows/Linux use `data_directory`.
+pub const SIDE_BROWSER_DATA_STORE: [u8; 16] = [
+    0x47, 0x72, 0x6f, 0x6b, 0x53, 0x69, 0x64, 0x65, 0x42, 0x72, 0x6f, 0x77, 0x73, 0x65, 0x72, 0x01,
+];
+
+static PENDING_GOOGLE_AUTH: LazyLock<Mutex<Option<PendingGoogleAuth>>> =
+    LazyLock::new(|| Mutex::new(None));
+
+struct PendingGoogleAuth {
+    side_label: String,
+}
+
+/// Payload for `side-browser://external-open` (status line after Google auth handoff).
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SideBrowserExternalOpenPayload {
+    pub label: String,
+    pub url: String,
+    /// `google_auth` — opened the shared-cookie login window
+    pub reason: String,
+}
+
+pub fn side_browser_data_directory() -> PathBuf {
+    crate::paths::app_data_root()
+        .join("webviews")
+        .join("side-browser")
+}
+
+/// Google account / OAuth surfaces that hard-freeze child WebView2 on Windows (#1154).
+///
+/// Intentionally narrow: plain `google.com` search / docs stay in-app.
+pub fn should_open_google_auth_externally(url: &Url) -> bool {
+    if url.scheme() != "https" && url.scheme() != "http" {
+        return false;
+    }
+    let Some(host) = url.host_str().map(str::to_ascii_lowercase) else {
+        return false;
+    };
+    if host == "accounts.google.com"
+        || host == "accounts.youtube.com"
+        || host == "accounts.googleusercontent.com"
+        || host.ends_with(".accounts.google.com")
+        || host == "oauth2.googleapis.com"
+    {
+        return true;
+    }
+    if host == "google.com" || host == "www.google.com" {
+        let path = url.path().to_ascii_lowercase();
+        return path.starts_with("/o/oauth2")
+            || path.starts_with("/signin")
+            || path.starts_with("/_/accountchooser")
+            || path.starts_with("/accountchooser");
+    }
+    false
+}
+
+fn emit_external_open(app: &AppHandle, label: &str, url: &str) {
+    if let Err(e) = app.emit(
+        EXTERNAL_OPEN_EVENT,
+        SideBrowserExternalOpenPayload {
+            label: label.into(),
+            url: url.into(),
+            reason: "google_auth".into(),
+        },
+    ) {
+        tracing::warn!(error = %e, "side-browser external-open emit failed");
+    }
+}
+
+fn resume_side_browser_after_google_auth(app: &AppHandle, callback: &Url) {
+    let side_label = PENDING_GOOGLE_AUTH.lock().take().map(|p| p.side_label);
+    let Some(side_label) = side_label else {
+        tracing::warn!(
+            target: "side_browser",
+            url = %callback,
+            "Google auth completed but no pending side-browser label"
+        );
+        if let Some(w) = app.get_webview_window(AUTH_WINDOW_LABEL) {
+            let _ = w.close();
+        }
+        return;
+    };
+    tracing::info!(
+        target: "side_browser",
+        %side_label,
+        url = %callback,
+        "Google auth redirect → resume embedded browser"
+    );
+    if let Some(w) = app.get_webview_window(AUTH_WINDOW_LABEL) {
+        let _ = w.close();
+    }
+    match get_side_webview(app, &side_label) {
+        Ok(wv) => {
+            emit_page_load(app, "started", &side_label, callback.as_str());
+            if let Err(e) = wv.navigate(callback.clone()) {
+                tracing::warn!(
+                    target: "side_browser",
+                    error = %e,
+                    %side_label,
+                    "failed to navigate side browser after Google auth"
+                );
+            }
+        }
+        Err(e) => {
+            tracing::warn!(
+                target: "side_browser",
+                error = %e,
+                %side_label,
+                "side browser missing after Google auth"
+            );
+        }
+    }
+}
+
+fn open_google_auth_window(app: &AppHandle, side_label: &str, url: &Url) -> Result<(), String> {
+    *PENDING_GOOGLE_AUTH.lock() = Some(PendingGoogleAuth {
+        side_label: side_label.to_string(),
+    });
+    let data_dir = side_browser_data_directory();
+    std::fs::create_dir_all(&data_dir).map_err(|e| format!("side browser profile dir: {e}"))?;
+
+    if let Some(existing) = app.get_webview_window(AUTH_WINDOW_LABEL) {
+        existing
+            .navigate(url.clone())
+            .map_err(|e| format!("google auth navigate: {e}"))?;
+        let _ = existing.set_focus();
+        let _ = existing.unminimize();
+        let _ = existing.show();
+        return Ok(());
+    }
+
+    let app_nav = app.clone();
+    let app_new = app.clone();
+    let builder =
+        WebviewWindowBuilder::new(app, AUTH_WINDOW_LABEL, WebviewUrl::External(url.clone()))
+            .title("Google Sign-In")
+            .inner_size(520.0, 740.0)
+            .min_inner_size(360.0, 480.0)
+            .resizable(true)
+            .center()
+            .data_directory(data_dir)
+            .data_store_identifier(SIDE_BROWSER_DATA_STORE)
+            .on_navigation(move |nav_url| {
+                if should_open_google_auth_externally(nav_url) {
+                    return true;
+                }
+                let scheme = nav_url.scheme();
+                if scheme == "about" || scheme == "blob" || scheme == "data" {
+                    return true;
+                }
+                // OAuth finished — load the redirect in the embedded tab (shared cookies).
+                resume_side_browser_after_google_auth(&app_nav, nav_url);
+                false
+            })
+            .on_new_window(move |popup_url, _features| {
+                if should_open_google_auth_externally(&popup_url) {
+                    if let Some(w) = app_new.get_webview_window(AUTH_WINDOW_LABEL) {
+                        let _ = w.navigate(popup_url);
+                    }
+                }
+                NewWindowResponse::Deny
+            });
+
+    let window = builder
+        .build()
+        .map_err(|e| format!("google auth window: {e}"))?;
+    window.on_window_event(move |event| {
+        if matches!(event, tauri::WindowEvent::Destroyed) {
+            let _ = PENDING_GOOGLE_AUTH.lock().take();
+        }
+    });
+    Ok(())
+}
+
+/// Cancel child-webview Google auth navigations and open the shared-cookie window.
+pub fn handoff_google_auth_externally(app: &AppHandle, label: &str, url: &Url) -> bool {
+    if !should_open_google_auth_externally(url) {
+        return false;
+    }
+    let url_s = url.as_str();
+    tracing::info!(
+        target: "side_browser",
+        %label,
+        url = %url_s,
+        "Google auth URL → shared-cookie login window (WebView2 freeze guard)"
+    );
+    if let Err(e) = open_google_auth_window(app, label, url) {
+        tracing::warn!(
+            target: "side_browser",
+            error = %e,
+            url = %url_s,
+            "failed to open Google auth window"
+        );
+    }
+    emit_external_open(app, label, url_s);
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn google_auth_hosts_open_externally() {
+        let cases = [
+            (
+                "https://accounts.google.com/o/oauth2/auth?client_id=1",
+                true,
+            ),
+            ("https://accounts.youtube.com/accounts/SetSID", true),
+            ("https://oauth2.googleapis.com/token", true),
+            ("https://www.google.com/o/oauth2/v2/auth?client_id=1", true),
+            ("https://www.google.com/signin/identifier", true),
+            ("https://www.google.com/search?q=hello", false),
+            ("https://google.com/", false),
+            ("https://mail.google.com/", false),
+            ("https://example.com/accounts.google.com", false),
+        ];
+        for (raw, expect) in cases {
+            let url = Url::parse(raw).unwrap();
+            assert_eq!(
+                should_open_google_auth_externally(&url),
+                expect,
+                "url={raw}"
+            );
+        }
+    }
+}

--- a/src-tauri/src/side_browser_host.rs
+++ b/src-tauri/src/side_browser_host.rs
@@ -26,9 +26,11 @@
 //!
 //! ## Google Sign-In (#1154)
 //!
-//! WebView2 hard-freezes on Google account / OAuth documents. Top-level
-//! navigations and `window.open` to those hosts are cancelled and handed to
-//! the system browser via [`crate::commands::open_http_url`].
+//! Child WebView2 hard-freezes on Google account / OAuth documents. Those
+//! navigations / `window.open` targets are cancelled in the child and opened
+//! in a **top-level auth window** that shares the side-browser
+//! [`data_directory`], so cookies return to the embedded tab after the
+//! OAuth redirect. The system browser is **not** used (cookie jars differ).
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -40,18 +42,31 @@ use std::time::Duration;
 use parking_lot::Mutex;
 use serde::Serialize;
 use tauri::webview::{DownloadEvent, NewWindowResponse, PageLoadEvent, WebviewBuilder};
-use tauri::{AppHandle, Emitter, Manager, WebviewUrl};
+use tauri::{AppHandle, Emitter, Manager, WebviewUrl, WebviewWindowBuilder};
 use tauri::{LogicalPosition, LogicalSize, Url};
 
 const LABEL_PREFIX: &str = "resource-browser";
+const AUTH_WINDOW_LABEL: &str = "side-browser-google-auth";
 const DOWNLOAD_EVENT: &str = "side-browser://download";
 const PAGE_LOAD_EVENT: &str = "side-browser://page-load";
 const EXTERNAL_OPEN_EVENT: &str = "side-browser://external-open";
+
+/// Stable WKWebView data-store id (macOS 14+). Windows/Linux use `data_directory`.
+const SIDE_BROWSER_DATA_STORE: [u8; 16] = [
+    0x47, 0x72, 0x6f, 0x6b, 0x53, 0x69, 0x64, 0x65, 0x42, 0x72, 0x6f, 0x77, 0x73, 0x65, 0x72, 0x01,
+];
 
 /// url → staging path chosen in `Requested` (macOS finish omits path).
 static PENDING_DOWNLOADS: LazyLock<Mutex<HashMap<String, PendingDownload>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 static DOWNLOAD_SEQ: AtomicU64 = AtomicU64::new(1);
+/// Which embedded tab started the Google auth window (for post-login resume).
+static PENDING_GOOGLE_AUTH: LazyLock<Mutex<Option<PendingGoogleAuth>>> =
+    LazyLock::new(|| Mutex::new(None));
+
+struct PendingGoogleAuth {
+    side_label: String,
+}
 
 struct PendingDownload {
     label: String,
@@ -95,11 +110,17 @@ pub struct SideBrowserPageLoadPayload {
 pub struct SideBrowserExternalOpenPayload {
     pub label: String,
     pub url: String,
-    /// `google_auth`
+    /// `google_auth` — opened the shared-cookie login window
     pub reason: String,
 }
 
-/// Google account / OAuth surfaces that hard-freeze WebView2 on Windows (#1154).
+fn side_browser_data_directory() -> PathBuf {
+    crate::paths::app_data_root()
+        .join("webviews")
+        .join("side-browser")
+}
+
+/// Google account / OAuth surfaces that hard-freeze child WebView2 on Windows (#1154).
 ///
 /// Intentionally narrow: plain `google.com` search / docs stay in-app.
 pub fn should_open_google_auth_externally(url: &Url) -> bool {
@@ -140,6 +161,112 @@ fn emit_external_open(app: &AppHandle, label: &str, url: &str) {
     }
 }
 
+fn resume_side_browser_after_google_auth(app: &AppHandle, callback: &Url) {
+    let side_label = PENDING_GOOGLE_AUTH.lock().take().map(|p| p.side_label);
+    let Some(side_label) = side_label else {
+        tracing::warn!(
+            target: "side_browser",
+            url = %callback,
+            "Google auth completed but no pending side-browser label"
+        );
+        if let Some(w) = app.get_webview_window(AUTH_WINDOW_LABEL) {
+            let _ = w.close();
+        }
+        return;
+    };
+    tracing::info!(
+        target: "side_browser",
+        %side_label,
+        url = %callback,
+        "Google auth redirect → resume embedded browser"
+    );
+    if let Some(w) = app.get_webview_window(AUTH_WINDOW_LABEL) {
+        let _ = w.close();
+    }
+    match get_side_webview(app, &side_label) {
+        Ok(wv) => {
+            emit_page_load(app, "started", &side_label, callback.as_str());
+            if let Err(e) = wv.navigate(callback.clone()) {
+                tracing::warn!(
+                    target: "side_browser",
+                    error = %e,
+                    %side_label,
+                    "failed to navigate side browser after Google auth"
+                );
+            }
+        }
+        Err(e) => {
+            tracing::warn!(
+                target: "side_browser",
+                error = %e,
+                %side_label,
+                "side browser missing after Google auth"
+            );
+        }
+    }
+}
+
+fn open_google_auth_window(app: &AppHandle, side_label: &str, url: &Url) -> Result<(), String> {
+    *PENDING_GOOGLE_AUTH.lock() = Some(PendingGoogleAuth {
+        side_label: side_label.to_string(),
+    });
+    let data_dir = side_browser_data_directory();
+    std::fs::create_dir_all(&data_dir).map_err(|e| format!("side browser profile dir: {e}"))?;
+
+    if let Some(existing) = app.get_webview_window(AUTH_WINDOW_LABEL) {
+        existing
+            .navigate(url.clone())
+            .map_err(|e| format!("google auth navigate: {e}"))?;
+        let _ = existing.set_focus();
+        let _ = existing.unminimize();
+        let _ = existing.show();
+        return Ok(());
+    }
+
+    let app_nav = app.clone();
+    let app_new = app.clone();
+    let builder =
+        WebviewWindowBuilder::new(app, AUTH_WINDOW_LABEL, WebviewUrl::External(url.clone()))
+            .title("Google Sign-In")
+            .inner_size(520.0, 740.0)
+            .min_inner_size(360.0, 480.0)
+            .resizable(true)
+            .center()
+            .data_directory(data_dir)
+            .data_store_identifier(SIDE_BROWSER_DATA_STORE)
+            .on_navigation(move |nav_url| {
+                if should_open_google_auth_externally(nav_url) {
+                    return true;
+                }
+                let scheme = nav_url.scheme();
+                if scheme == "about" || scheme == "blob" || scheme == "data" {
+                    return true;
+                }
+                // OAuth finished — load the redirect in the embedded tab (shared cookies).
+                resume_side_browser_after_google_auth(&app_nav, nav_url);
+                false
+            })
+            .on_new_window(move |popup_url, _features| {
+                if should_open_google_auth_externally(&popup_url) {
+                    if let Some(w) = app_new.get_webview_window(AUTH_WINDOW_LABEL) {
+                        let _ = w.navigate(popup_url);
+                    }
+                }
+                NewWindowResponse::Deny
+            });
+
+    let window = builder
+        .build()
+        .map_err(|e| format!("google auth window: {e}"))?;
+    window.on_window_event(move |event| {
+        if matches!(event, tauri::WindowEvent::Destroyed) {
+            let _ = PENDING_GOOGLE_AUTH.lock().take();
+        }
+    });
+    Ok(())
+}
+
+/// Cancel child-webview Google auth navigations and open the shared-cookie window.
 fn handoff_google_auth_externally(app: &AppHandle, label: &str, url: &Url) -> bool {
     if !should_open_google_auth_externally(url) {
         return false;
@@ -149,14 +276,14 @@ fn handoff_google_auth_externally(app: &AppHandle, label: &str, url: &Url) -> bo
         target: "side_browser",
         %label,
         url = %url_s,
-        "Google auth URL → system browser (WebView2 freeze guard)"
+        "Google auth URL → shared-cookie login window (WebView2 freeze guard)"
     );
-    if let Err(e) = crate::commands::open_http_url(url_s) {
+    if let Err(e) = open_google_auth_window(app, label, url) {
         tracing::warn!(
             target: "side_browser",
             error = %e,
             url = %url_s,
-            "failed to open Google auth URL externally"
+            "failed to open Google auth window"
         );
     }
     emit_external_open(app, label, url_s);
@@ -443,12 +570,17 @@ pub fn create(
     // users click the page when they want to type there.
     // First document load starts immediately after create.
     emit_page_load(app, "started", &label, &url);
+    let profile_dir = side_browser_data_directory();
+    std::fs::create_dir_all(&profile_dir).map_err(|e| format!("side browser profile dir: {e}"))?;
     let builder = WebviewBuilder::new(label.clone(), WebviewUrl::External(parsed))
         .accept_first_mouse(true)
         .focused(false)
+        // Shared with the Google auth top-level window so OAuth cookies return.
+        .data_directory(profile_dir)
+        .data_store_identifier(SIDE_BROWSER_DATA_STORE)
         .initialization_script(polyfill)
-        // Google Sign-In inside WebView2 hard-freezes the Windows host (#1154).
-        // Hand those navigations to the system browser and cancel in-webview load.
+        // Google Sign-In inside child WebView2 hard-freezes Windows (#1154).
+        // Open a shared-cookie top-level window instead; cancel in-child load.
         .on_navigation(move |url| !handoff_google_auth_externally(&nav_app, &nav_label, url))
         .on_new_window(move |url, _features| {
             if handoff_google_auth_externally(&new_win_app, &new_win_label, &url) {

--- a/src-tauri/src/side_browser_host.rs
+++ b/src-tauri/src/side_browser_host.rs
@@ -26,11 +26,8 @@
 //!
 //! ## Google Sign-In (#1154)
 //!
-//! Child WebView2 hard-freezes on Google account / OAuth documents. Those
-//! navigations / `window.open` targets are cancelled in the child and opened
-//! in a **top-level auth window** that shares the side-browser
-//! [`data_directory`], so cookies return to the embedded tab after the
-//! OAuth redirect. The system browser is **not** used (cookie jars differ).
+//! See [`crate::side_browser_google_auth`] — shared-cookie top-level login
+//! window; child WebView2 never loads Google auth documents (freeze guard).
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -39,35 +36,24 @@ use std::sync::mpsc;
 use std::sync::LazyLock;
 use std::time::Duration;
 
+use crate::side_browser_google_auth::{
+    handoff_google_auth_externally, should_open_google_auth_externally,
+    side_browser_data_directory, SIDE_BROWSER_DATA_STORE,
+};
 use parking_lot::Mutex;
 use serde::Serialize;
 use tauri::webview::{DownloadEvent, NewWindowResponse, PageLoadEvent, WebviewBuilder};
-use tauri::{AppHandle, Emitter, Manager, WebviewUrl, WebviewWindowBuilder};
+use tauri::{AppHandle, Emitter, Manager, WebviewUrl};
 use tauri::{LogicalPosition, LogicalSize, Url};
 
 const LABEL_PREFIX: &str = "resource-browser";
-const AUTH_WINDOW_LABEL: &str = "side-browser-google-auth";
 const DOWNLOAD_EVENT: &str = "side-browser://download";
 const PAGE_LOAD_EVENT: &str = "side-browser://page-load";
-const EXTERNAL_OPEN_EVENT: &str = "side-browser://external-open";
-
-/// Stable WKWebView data-store id (macOS 14+). Windows/Linux use `data_directory`.
-const SIDE_BROWSER_DATA_STORE: [u8; 16] = [
-    0x47, 0x72, 0x6f, 0x6b, 0x53, 0x69, 0x64, 0x65, 0x42, 0x72, 0x6f, 0x77, 0x73, 0x65, 0x72, 0x01,
-];
 
 /// url → staging path chosen in `Requested` (macOS finish omits path).
 static PENDING_DOWNLOADS: LazyLock<Mutex<HashMap<String, PendingDownload>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 static DOWNLOAD_SEQ: AtomicU64 = AtomicU64::new(1);
-/// Which embedded tab started the Google auth window (for post-login resume).
-static PENDING_GOOGLE_AUTH: LazyLock<Mutex<Option<PendingGoogleAuth>>> =
-    LazyLock::new(|| Mutex::new(None));
-
-struct PendingGoogleAuth {
-    side_label: String,
-}
-
 struct PendingDownload {
     label: String,
     staging: PathBuf,
@@ -104,198 +90,12 @@ pub struct SideBrowserPageLoadPayload {
     pub url: String,
 }
 
-/// Payload for `side-browser://external-open` (status line after Google auth handoff).
-#[derive(Debug, Clone, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct SideBrowserExternalOpenPayload {
-    pub label: String,
-    pub url: String,
-    /// `google_auth` — opened the shared-cookie login window
-    pub reason: String,
-}
-
-fn side_browser_data_directory() -> PathBuf {
-    crate::paths::app_data_root()
-        .join("webviews")
-        .join("side-browser")
-}
-
-/// Google account / OAuth surfaces that hard-freeze child WebView2 on Windows (#1154).
-///
-/// Intentionally narrow: plain `google.com` search / docs stay in-app.
-pub fn should_open_google_auth_externally(url: &Url) -> bool {
-    if url.scheme() != "https" && url.scheme() != "http" {
-        return false;
-    }
-    let Some(host) = url.host_str().map(str::to_ascii_lowercase) else {
-        return false;
-    };
-    if host == "accounts.google.com"
-        || host == "accounts.youtube.com"
-        || host == "accounts.googleusercontent.com"
-        || host.ends_with(".accounts.google.com")
-        || host == "oauth2.googleapis.com"
-    {
-        return true;
-    }
-    if host == "google.com" || host == "www.google.com" {
-        let path = url.path().to_ascii_lowercase();
-        return path.starts_with("/o/oauth2")
-            || path.starts_with("/signin")
-            || path.starts_with("/_/accountchooser")
-            || path.starts_with("/accountchooser");
-    }
-    false
-}
-
-fn emit_external_open(app: &AppHandle, label: &str, url: &str) {
-    if let Err(e) = app.emit(
-        EXTERNAL_OPEN_EVENT,
-        SideBrowserExternalOpenPayload {
-            label: label.into(),
-            url: url.into(),
-            reason: "google_auth".into(),
-        },
-    ) {
-        tracing::warn!(error = %e, "side-browser external-open emit failed");
-    }
-}
-
-fn resume_side_browser_after_google_auth(app: &AppHandle, callback: &Url) {
-    let side_label = PENDING_GOOGLE_AUTH.lock().take().map(|p| p.side_label);
-    let Some(side_label) = side_label else {
-        tracing::warn!(
-            target: "side_browser",
-            url = %callback,
-            "Google auth completed but no pending side-browser label"
-        );
-        if let Some(w) = app.get_webview_window(AUTH_WINDOW_LABEL) {
-            let _ = w.close();
-        }
-        return;
-    };
-    tracing::info!(
-        target: "side_browser",
-        %side_label,
-        url = %callback,
-        "Google auth redirect → resume embedded browser"
-    );
-    if let Some(w) = app.get_webview_window(AUTH_WINDOW_LABEL) {
-        let _ = w.close();
-    }
-    match get_side_webview(app, &side_label) {
-        Ok(wv) => {
-            emit_page_load(app, "started", &side_label, callback.as_str());
-            if let Err(e) = wv.navigate(callback.clone()) {
-                tracing::warn!(
-                    target: "side_browser",
-                    error = %e,
-                    %side_label,
-                    "failed to navigate side browser after Google auth"
-                );
-            }
-        }
-        Err(e) => {
-            tracing::warn!(
-                target: "side_browser",
-                error = %e,
-                %side_label,
-                "side browser missing after Google auth"
-            );
-        }
-    }
-}
-
-fn open_google_auth_window(app: &AppHandle, side_label: &str, url: &Url) -> Result<(), String> {
-    *PENDING_GOOGLE_AUTH.lock() = Some(PendingGoogleAuth {
-        side_label: side_label.to_string(),
-    });
-    let data_dir = side_browser_data_directory();
-    std::fs::create_dir_all(&data_dir).map_err(|e| format!("side browser profile dir: {e}"))?;
-
-    if let Some(existing) = app.get_webview_window(AUTH_WINDOW_LABEL) {
-        existing
-            .navigate(url.clone())
-            .map_err(|e| format!("google auth navigate: {e}"))?;
-        let _ = existing.set_focus();
-        let _ = existing.unminimize();
-        let _ = existing.show();
-        return Ok(());
-    }
-
-    let app_nav = app.clone();
-    let app_new = app.clone();
-    let builder =
-        WebviewWindowBuilder::new(app, AUTH_WINDOW_LABEL, WebviewUrl::External(url.clone()))
-            .title("Google Sign-In")
-            .inner_size(520.0, 740.0)
-            .min_inner_size(360.0, 480.0)
-            .resizable(true)
-            .center()
-            .data_directory(data_dir)
-            .data_store_identifier(SIDE_BROWSER_DATA_STORE)
-            .on_navigation(move |nav_url| {
-                if should_open_google_auth_externally(nav_url) {
-                    return true;
-                }
-                let scheme = nav_url.scheme();
-                if scheme == "about" || scheme == "blob" || scheme == "data" {
-                    return true;
-                }
-                // OAuth finished — load the redirect in the embedded tab (shared cookies).
-                resume_side_browser_after_google_auth(&app_nav, nav_url);
-                false
-            })
-            .on_new_window(move |popup_url, _features| {
-                if should_open_google_auth_externally(&popup_url) {
-                    if let Some(w) = app_new.get_webview_window(AUTH_WINDOW_LABEL) {
-                        let _ = w.navigate(popup_url);
-                    }
-                }
-                NewWindowResponse::Deny
-            });
-
-    let window = builder
-        .build()
-        .map_err(|e| format!("google auth window: {e}"))?;
-    window.on_window_event(move |event| {
-        if matches!(event, tauri::WindowEvent::Destroyed) {
-            let _ = PENDING_GOOGLE_AUTH.lock().take();
-        }
-    });
-    Ok(())
-}
-
-/// Cancel child-webview Google auth navigations and open the shared-cookie window.
-fn handoff_google_auth_externally(app: &AppHandle, label: &str, url: &Url) -> bool {
-    if !should_open_google_auth_externally(url) {
-        return false;
-    }
-    let url_s = url.as_str();
-    tracing::info!(
-        target: "side_browser",
-        %label,
-        url = %url_s,
-        "Google auth URL → shared-cookie login window (WebView2 freeze guard)"
-    );
-    if let Err(e) = open_google_auth_window(app, label, url) {
-        tracing::warn!(
-            target: "side_browser",
-            error = %e,
-            url = %url_s,
-            "failed to open Google auth window"
-        );
-    }
-    emit_external_open(app, label, url_s);
-    true
-}
-
 /// Emit download status for the EmbeddedBrowser status line (HTTP + blob paths).
 pub fn emit_download_payload(app: &AppHandle, payload: SideBrowserDownloadPayload) {
     emit_download(app, payload);
 }
 
-fn emit_page_load(app: &AppHandle, phase: &str, label: &str, url: &str) {
+pub(crate) fn emit_page_load(app: &AppHandle, phase: &str, label: &str, url: &str) {
     if let Err(e) = app.emit(
         PAGE_LOAD_EVENT,
         SideBrowserPageLoadPayload {
@@ -347,7 +147,7 @@ fn validate_url(url: &str) -> Result<Url, String> {
     Url::parse(u).map_err(|e| format!("bad url: {e}"))
 }
 
-fn get_side_webview<R: tauri::Runtime>(
+pub(crate) fn get_side_webview<R: tauri::Runtime>(
     app: &AppHandle<R>,
     label: &str,
 ) -> Result<tauri::Webview<R>, String> {
@@ -1020,31 +820,5 @@ mod tests {
             .file_name()
             .and_then(|n| n.to_str())
             .is_some_and(|n| n.ends_with("hello world.pdf")));
-    }
-
-    #[test]
-    fn google_auth_hosts_open_externally() {
-        let cases = [
-            (
-                "https://accounts.google.com/o/oauth2/auth?client_id=1",
-                true,
-            ),
-            ("https://accounts.youtube.com/accounts/SetSID", true),
-            ("https://oauth2.googleapis.com/token", true),
-            ("https://www.google.com/o/oauth2/v2/auth?client_id=1", true),
-            ("https://www.google.com/signin/identifier", true),
-            ("https://www.google.com/search?q=hello", false),
-            ("https://google.com/", false),
-            ("https://mail.google.com/", false),
-            ("https://example.com/accounts.google.com", false),
-        ];
-        for (raw, expect) in cases {
-            let url = Url::parse(raw).unwrap();
-            assert_eq!(
-                should_open_google_auth_externally(&url),
-                expect,
-                "url={raw}"
-            );
-        }
     }
 }

--- a/src/i18n/messages/de/workspace.ts
+++ b/src/i18n/messages/de/workspace.ts
@@ -255,7 +255,7 @@ export const deWorkspace = {
   "resources.browserDownloadSaved": "{name} gespeichert",
   "resources.browserDownloadFailed": "Download fehlgeschlagen",
   "resources.browserDownloadCancelled": "Download abgebrochen",
-  "resources.browserGoogleAuthExternal": "Google-Anmeldung im Systembrowser geöffnet.",
+  "resources.browserGoogleAuthExternal": "Google-Anmeldung im Anmeldefenster geöffnet.",
   "search.title": "Suchen",
   "search.placeholder": "Chats, Projekte, Aktionen oder Nachrichteninhalt suchen…",
   "search.projects": "Projekte",

--- a/src/i18n/messages/en/workspace.ts
+++ b/src/i18n/messages/en/workspace.ts
@@ -255,7 +255,7 @@ export const enWorkspace = {
   "resources.browserDownloadSaved": "Saved {name}",
   "resources.browserDownloadFailed": "Download failed",
   "resources.browserDownloadCancelled": "Download cancelled",
-  "resources.browserGoogleAuthExternal": "Google sign-in opened in your system browser.",
+  "resources.browserGoogleAuthExternal": "Google sign-in opened in a login window.",
   "search.title": "Search",
   "search.placeholder": "Search chats, projects, actions, or message content…",
   "search.projects": "Projects",

--- a/src/i18n/messages/es/workspace.ts
+++ b/src/i18n/messages/es/workspace.ts
@@ -255,7 +255,7 @@ export const esWorkspace = {
   "resources.browserDownloadSaved": "Se guardó {name}",
   "resources.browserDownloadFailed": "Falló la descarga",
   "resources.browserDownloadCancelled": "Descarga cancelada",
-  "resources.browserGoogleAuthExternal": "Se abrió el inicio de sesión de Google en el navegador del sistema.",
+  "resources.browserGoogleAuthExternal": "Inicio de sesión de Google abierto en una ventana de acceso.",
   "search.title": "Buscar",
   "search.placeholder": "Buscar chats, proyectos, acciones o contenido de mensajes…",
   "search.projects": "Proyectos",

--- a/src/i18n/messages/fil/workspace.ts
+++ b/src/i18n/messages/fil/workspace.ts
@@ -255,7 +255,7 @@ export const filWorkspace = {
   "resources.browserDownloadSaved": "Na-save ang {name}",
   "resources.browserDownloadFailed": "Nabigo ang download",
   "resources.browserDownloadCancelled": "Nakansela ang download",
-  "resources.browserGoogleAuthExternal": "Binuksan ang Google sign-in sa system browser.",
+  "resources.browserGoogleAuthExternal": "Binuksan ang Google sign-in sa login window.",
   "search.title": "Maghanap",
   "search.placeholder": "Maghanap ng chat, proyekto, aksyon, o nilalaman ng mensahe…",
   "search.projects": "Mga proyekto",

--- a/src/i18n/messages/fr/workspace.ts
+++ b/src/i18n/messages/fr/workspace.ts
@@ -255,7 +255,7 @@ export const frWorkspace = {
   "resources.browserDownloadSaved": "{name} enregistré",
   "resources.browserDownloadFailed": "Échec du téléchargement",
   "resources.browserDownloadCancelled": "Téléchargement annulé",
-  "resources.browserGoogleAuthExternal": "Connexion Google ouverte dans le navigateur système.",
+  "resources.browserGoogleAuthExternal": "Connexion Google ouverte dans une fenêtre de connexion.",
   "search.title": "Recherche",
   "search.placeholder": "Rechercher conversations, projets, actions ou contenu de messages…",
   "search.projects": "Projets",

--- a/src/i18n/messages/id/workspace.ts
+++ b/src/i18n/messages/id/workspace.ts
@@ -255,7 +255,7 @@ export const idWorkspace = {
   "resources.browserDownloadSaved": "{name} disimpan",
   "resources.browserDownloadFailed": "Unduhan gagal",
   "resources.browserDownloadCancelled": "Unduhan dibatalkan",
-  "resources.browserGoogleAuthExternal": "Login Google dibuka di browser sistem.",
+  "resources.browserGoogleAuthExternal": "Login Google dibuka di jendela login.",
   "search.title": "Cari",
   "search.placeholder": "Cari obrolan, proyek, tindakan, atau isi pesan…",
   "search.projects": "Proyek",

--- a/src/i18n/messages/it/workspace.ts
+++ b/src/i18n/messages/it/workspace.ts
@@ -255,7 +255,7 @@ export const itWorkspace = {
   "resources.browserDownloadSaved": "Salvato {name}",
   "resources.browserDownloadFailed": "Download non riuscito",
   "resources.browserDownloadCancelled": "Download annullato",
-  "resources.browserGoogleAuthExternal": "Accesso Google aperto nel browser di sistema.",
+  "resources.browserGoogleAuthExternal": "Accesso Google aperto in una finestra di login.",
   "search.title": "Cerca",
   "search.placeholder": "Cerca chat, progetti, azioni o contenuto dei messaggi…",
   "search.projects": "Progetti",

--- a/src/i18n/messages/ja/workspace.ts
+++ b/src/i18n/messages/ja/workspace.ts
@@ -255,7 +255,7 @@ export const jaWorkspace = {
   "resources.browserDownloadSaved": "{name} を保存しました",
   "resources.browserDownloadFailed": "ダウンロードに失敗しました",
   "resources.browserDownloadCancelled": "ダウンロードをキャンセルしました",
-  "resources.browserGoogleAuthExternal": "Google ログインをシステムのブラウザで開きました。",
+  "resources.browserGoogleAuthExternal": "Google ログインをログイン窓で開きました。",
   "search.title": "検索",
   "search.placeholder": "チャット、プロジェクト、アクション、メッセージ本文を検索…",
   "search.projects": "プロジェクト",

--- a/src/i18n/messages/ko/workspace.ts
+++ b/src/i18n/messages/ko/workspace.ts
@@ -255,7 +255,7 @@ export const koWorkspace = {
   "resources.browserDownloadSaved": "{name}을(를) 저장했습니다",
   "resources.browserDownloadFailed": "다운로드 실패",
   "resources.browserDownloadCancelled": "다운로드 취소됨",
-  "resources.browserGoogleAuthExternal": "Google 로그인을 시스템 브라우저에서 열었습니다.",
+  "resources.browserGoogleAuthExternal": "Google 로그인을 로그인 창에서 열었습니다.",
   "search.title": "검색",
   "search.placeholder": "대화, 프로젝트, 동작 또는 메시지 내용 검색…",
   "search.projects": "프로젝트",

--- a/src/i18n/messages/pt-BR/workspace.ts
+++ b/src/i18n/messages/pt-BR/workspace.ts
@@ -255,7 +255,7 @@ export const ptBRWorkspace = {
   "resources.browserDownloadSaved": "{name} salvo",
   "resources.browserDownloadFailed": "O download falhou",
   "resources.browserDownloadCancelled": "Download cancelado",
-  "resources.browserGoogleAuthExternal": "Login do Google aberto no navegador do sistema.",
+  "resources.browserGoogleAuthExternal": "Login do Google aberto em uma janela de autenticação.",
   "search.title": "Buscar",
   "search.placeholder": "Buscar chats, projetos, ações ou conteúdo de mensagens…",
   "search.projects": "Projetos",

--- a/src/i18n/messages/ru/workspace.ts
+++ b/src/i18n/messages/ru/workspace.ts
@@ -255,7 +255,7 @@ export const ruWorkspace = {
   "resources.browserDownloadSaved": "Сохранено: {name}",
   "resources.browserDownloadFailed": "Ошибка загрузки",
   "resources.browserDownloadCancelled": "Загрузка отменена",
-  "resources.browserGoogleAuthExternal": "Вход в Google открыт в системном браузере.",
+  "resources.browserGoogleAuthExternal": "Вход в Google открыт в окне входа.",
   "search.title": "Поиск",
   "search.placeholder": "Поиск чатов, проектов, действий или содержимого сообщений…",
   "search.projects": "Проекты",

--- a/src/i18n/messages/ta/workspace.ts
+++ b/src/i18n/messages/ta/workspace.ts
@@ -255,7 +255,7 @@ export const taWorkspace = {
   "resources.browserDownloadSaved": "சேமிக்கப்பட்டது {name}",
   "resources.browserDownloadFailed": "பதிவிறக்கம் தோல்வியடைந்தது",
   "resources.browserDownloadCancelled": "பதிவிறக்கம் ரத்து செய்யப்பட்டது",
-  "resources.browserGoogleAuthExternal": "Google உள்நுழைவு கணினி உலாவியில் திறக்கப்பட்டது.",
+  "resources.browserGoogleAuthExternal": "Google உள்நுழைவு உள்நுழைவு சாளரத்தில் திறக்கப்பட்டது.",
   "search.title": "தேடு",
   "search.placeholder": "உரையாடல்கள், திட்டங்கள், செயல்கள் அல்லது செய்தி உள்ளடக்கத்தைத் தேடுங்கள்...",
   "search.projects": "திட்டங்கள்",

--- a/src/i18n/messages/uk/workspace.ts
+++ b/src/i18n/messages/uk/workspace.ts
@@ -255,7 +255,7 @@ export const ukWorkspace = {
   "resources.browserDownloadSaved": "Збережено {name}",
   "resources.browserDownloadFailed": "Завантаження не вдалося",
   "resources.browserDownloadCancelled": "Завантаження скасовано",
-  "resources.browserGoogleAuthExternal": "Вхід Google відкрито в системному браузері.",
+  "resources.browserGoogleAuthExternal": "Вхід Google відкрито у вікні входу.",
   "search.title": "Пошук",
   "search.placeholder": "Шукати чати, проєкти, дії або вміст повідомлень…",
   "search.projects": "Проєкти",

--- a/src/i18n/messages/zh-TW/workspace.ts
+++ b/src/i18n/messages/zh-TW/workspace.ts
@@ -255,7 +255,7 @@ export const zhTWWorkspace = {
   "resources.browserDownloadSaved": "已儲存 {name}",
   "resources.browserDownloadFailed": "下載失敗",
   "resources.browserDownloadCancelled": "已取消下載",
-  "resources.browserGoogleAuthExternal": "已在系統瀏覽器中開啟 Google 登入。",
+  "resources.browserGoogleAuthExternal": "已在登入視窗中開啟 Google 登入。",
   "search.title": "搜尋",
   "search.placeholder": "搜尋對話、專案、操作或訊息內容…",
   "search.projects": "專案",

--- a/src/i18n/messages/zh/workspace.ts
+++ b/src/i18n/messages/zh/workspace.ts
@@ -255,7 +255,7 @@ export const zhWorkspace = {
   "resources.browserDownloadSaved": "已保存 {name}",
   "resources.browserDownloadFailed": "下载失败",
   "resources.browserDownloadCancelled": "已取消下载",
-  "resources.browserGoogleAuthExternal": "已在系统浏览器中打开 Google 登录。",
+  "resources.browserGoogleAuthExternal": "已在登录窗口中打开 Google 登录。",
   "search.title": "搜索",
   "search.placeholder": "搜索会话、项目、操作或消息内容…",
   "search.projects": "项目",


### PR DESCRIPTION
## Summary
Follow-up to #1168: system-browser handoff could not return Google login state to the embedded WebView2 (separate cookie jar).

- Side browser child WebViews now use a dedicated \`webviews/side-browser\` profile.
- Google account/OAuth navigations open a **top-level login window** with the **same** profile (avoids child WebView2 freeze).
- When Google redirects off auth hosts, the embedded tab navigates to that URL and the login window closes — cookies are already shared.
- Status toast updated to “login window”.

Addresses the login-state gap reported after #1168 / #1154.

## Type of change
- [x] Bug fix

## Test plan
- [x] \`cargo test --lib side_browser_host::tests\`
- [x] \`pnpm typecheck\`
- [ ] Windows: Resources browser → Sign in with Google → login **window** (not Chrome) opens, App does not freeze
- [ ] Complete Google login → window closes → embedded page is signed in
- [ ] Ordinary google.com search still stays in the embedded tab