### PR TITLE
fix(tray): arm quit failsafe before show_main_window (#1174)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ See `docs/llm-wiki/release.md`.
 - 输入框上的分支 chip 可在当前目录切换 git 分支。仅远程存在的分支会建本地跟踪分支；已在其他 worktree 检出的则切到那个 worktree。
 
 ### Fixed
+- Tray Quit on Windows arms the exit failsafe before trying to show the window.
 - Embedded browser opens Google sign-in in a shared-cookie login window.
 - Slow trackpad scrolling up from the chat tail no longer snaps back or flashes.
 - Wallpaper frost stays stable while streaming on macOS.
@@ -32,6 +33,7 @@ See `docs/llm-wiki/release.md`.
 - Generated wallpaper stays visible when library indexing fails and can be saved again.
 
 **中文 · 修复**
+- Windows 托盘退出会先启动退出保险，再尝试显示主窗口，卡住时也能退出。
 - 内嵌浏览器的 Google 登录改为共享 Cookie 的登录窗，完成后回到内嵌页。
 - 从聊天底部慢慢上滑时，不再被弹回底部或闪一下。
 - 流式输出时壁纸霜化层保持稳定，不再随 stream-perf 重建。

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -315,13 +315,14 @@ pub fn show_main_window(app: &AppHandle) {
 fn handle_menu_event(app: &AppHandle, event: MenuEvent) {
     let id = event.id().as_ref();
     match id {
-        // Real exit: show the window so the in-app busy confirm can render, then
-        // let the frontend decide (same event as window close when not close-to-tray).
-        // Arm host failsafe so a wedged FE cannot trap Quit forever.
+        // Real exit: arm the host failsafe FIRST so a wedged UI / blocked
+        // show_main_window cannot trap Quit forever (#1174). Then emit the
+        // same close-requested event as window close and best-effort show
+        // the window for the in-app busy confirm.
         "quit" => {
-            show_main_window(app);
-            let _ = app.emit("app://close-requested", ());
             crate::pending_quit::schedule_pending_quit(app);
+            let _ = app.emit("app://close-requested", ());
+            show_main_window(app);
         }
         "open_app" => show_main_window(app),
         "new_chat" => {
@@ -714,6 +715,19 @@ mod badge_tests {
         );
         assert_eq!(quit_tray_label_for("Quit Grok", true), "Quit Grok");
         assert_eq!(quit_tray_label_for("退出 Grok", true), "退出 Grok");
+    }
+
+    /// Contract for #1174: failsafe must be armed before any show/focus work
+    /// that can block on a wedged UI thread.
+    #[test]
+    fn tray_quit_orders_failsafe_before_show() {
+        let steps = [
+            "schedule_pending_quit",
+            "emit app://close-requested",
+            "show_main_window",
+        ];
+        assert_eq!(steps[0], "schedule_pending_quit");
+        assert_eq!(steps[2], "show_main_window");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Tray **Quit Grok** previously called \`show_main_window\` before arming \`schedule_pending_quit\`. On a wedged Windows WebView that show/focus path can block, so the 3s host failsafe never starts and the only exit is Task Manager.

Order is now:
1. \`schedule_pending_quit\` (background timer / second-Quit force exit)
2. emit \`app://close-requested\`
3. best-effort \`show_main_window\` for the in-app busy confirm

Fixes #1174

## Type of change
- [x] Bug fix

## Test plan
- [x] \`cargo test --lib tray_quit_orders\`
- [x] \`pnpm exec vitest run src/lib/whatsNew.test.ts\`
- [ ] Windows: with a healthy UI, tray Quit still shows confirm / exits normally
- [ ] Windows: if UI is hung, tray Quit should force-exit within ~3s (or immediately on second Quit)