### PR TITLE
fix(chat): resume pin-follow after pinned wheel idle (#1172)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,15 @@ See `docs/llm-wiki/release.md`.
 ## [Unreleased]
 
 ### Added
+- Settings → Appearance can turn off chat virtual scrolling for native overflow.
 - The composer branch chip can switch git branches in the current folder. Remote-only rows create a local tracking branch; a branch already checked out in another worktree opens that worktree instead.
 
 **中文 · 新增**
+- 设置 → 外观可关闭聊天虚拟滚动，改回原生滚动（长对话滚动异常时可关）。
 - 输入框上的分支 chip 可在当前目录切换 git 分支。仅远程存在的分支会建本地跟踪分支；已在其他 worktree 检出的则切到那个 worktree。
 
 ### Fixed
+- Thinking and tool streams keep following the chat tail after a brief trackpad pause (#1172).
 - Tray Quit on Windows arms the exit failsafe before trying to show the window.
 - Embedded browser opens Google sign-in in a shared-cookie login window.
 - Slow trackpad scrolling up from the chat tail no longer snaps back or flashes.
@@ -33,6 +36,7 @@ See `docs/llm-wiki/release.md`.
 - Generated wallpaper stays visible when library indexing fails and can be saved again.
 
 **中文 · 修复**
+- 思考/工具流式增高时，触控板短暂停顿后内容区会继续贴底跟随，不再被输入框挡住（#1172）。
 - Windows 托盘退出会先启动退出保险，再尝试显示主窗口，卡住时也能退出。
 - 内嵌浏览器的 Google 登录改为共享 Cookie 的登录窗，完成后回到内嵌页。
 - 从聊天底部慢慢上滑时，不再被弹回底部或闪一下。

--- a/src/hooks/chatMessageVirtualizerShared.ts
+++ b/src/hooks/chatMessageVirtualizerShared.ts
@@ -1,0 +1,47 @@
+import type { RefObject } from "react";
+import type { ChatVirtualWindow } from "@/lib/chatVirtualList";
+
+export type UseChatMessageVirtualizerArgs = {
+  itemCount: number;
+  getKey: (index: number) => string;
+  /** Content-aware estimate before first measure (critical for tall answers). */
+  getEstimateHeight?: (index: number) => number;
+  viewportRef: RefObject<HTMLElement | null>;
+  /** Stick pin flag from useStickToBottom (ref, not reactive). */
+  isPinnedRef: RefObject<boolean>;
+  /** Reset height cache when conversation switches. */
+  conversationKey?: string | number | null;
+  /** Always-mounted indices (find match, streaming row, …). */
+  forceIndices?: readonly number[];
+  /** Below this count, render everything (no spacers). */
+  threshold?: number;
+  enabled?: boolean;
+};
+
+export type UseChatMessageVirtualizerResult = {
+  /** True when windowing is active. */
+  virtualized: boolean;
+  start: number;
+  end: number;
+  paddingTop: number;
+  paddingBottom: number;
+  richStart: number;
+  richEnd: number;
+  /** Measured height, else content estimate. */
+  rowHeight: (index: number) => number;
+  /** Attach to each row wrapper for measurement. */
+  measureRef: (index: number) => (el: HTMLElement | null) => void;
+  /** Recompute after scroll (also driven by native scroll listener). */
+  onViewportScroll: () => void;
+};
+
+/** Full (non-windowed) range covering every row. */
+export const fullChatVirtualWindow = (count: number): ChatVirtualWindow => ({
+  start: 0,
+  end: count,
+  paddingTop: 0,
+  paddingBottom: 0,
+  totalHeight: 0,
+  richStart: 0,
+  richEnd: count,
+});

--- a/src/hooks/useChatMessageVirtualizer.test.tsx
+++ b/src/hooks/useChatMessageVirtualizer.test.tsx
@@ -309,12 +309,20 @@ describe("useChatMessageVirtualizer touch freeze", () => {
     expect(viewport.dataset.scrolling).toBe("1");
   });
 
-  it("keeps scrolling UI after wheel + scroll while still pinned (#1159)", () => {
-    // Trackpad leave-bottom: wheel sets scrolling, then the native scroll
-    // event runs recomputeNow. That must NOT clear scrollingRef or pin-snap
-    // will yank the viewport back to the tail on sub-10px steps. Advance past
-    // the hover-restore debounce so a false clear would already have dropped
-    // data-scrolling.
+  it("does not clear scrolling mid-wheel while pinned (#1159)", () => {
+    // Trackpad leave-bottom: wheel sets scrolling, then scroll runs
+    // recomputeNow. Must not clear scrollingRef in the same turn or pin-snap
+    // yanks sub-10px escapes. Idle settle may clear later (#1172).
+    const { viewport } = mount({ pinned: true });
+    act(() => {
+      viewport.dispatchEvent(new Event("wheel"));
+      viewport.dispatchEvent(new Event("scroll"));
+      vi.advanceTimersByTime(16);
+    });
+    expect(viewport.dataset.scrolling).toBe("1");
+  });
+
+  it("clears scrolling after pinned wheel idle so thinking can pin-follow (#1172)", () => {
     const { viewport } = mount({ pinned: true });
     act(() => {
       viewport.dispatchEvent(new Event("wheel"));
@@ -323,9 +331,10 @@ describe("useChatMessageVirtualizer touch freeze", () => {
     });
     expect(viewport.dataset.scrolling).toBe("1");
     act(() => {
-      vi.advanceTimersByTime(250);
+      // pinnedScrollIdleTimer (160) + hover-restore debounce (220)
+      vi.advanceTimersByTime(400);
     });
-    expect(viewport.dataset.scrolling).toBe("1");
+    expect(viewport.dataset.scrolling).toBeUndefined();
   });
 
   it("clears contact on the last touchend, not pointercancel", () => {

--- a/src/hooks/useChatMessageVirtualizer.ts
+++ b/src/hooks/useChatMessageVirtualizer.ts
@@ -35,7 +35,6 @@ import {
   useLayoutEffect,
   useRef,
   useState,
-  type RefObject,
 } from "react";
 import {
   CHAT_DEFAULT_ROW_ESTIMATE_PX,
@@ -75,55 +74,20 @@ import {
   distanceFromBottom,
   markProgrammaticStickScroll,
   shouldForcePinnedSnapOnOpen,
-  STICK_ESCAPE_MIN_DELTA_PX,
   STICK_MIN_VIEWPORT_HEIGHT_PX,
   isStickViewportUnreliable,
 } from "@/lib/stickToBottom";
 import { createScrollVelocityTracker } from "@/lib/scrollVelocity";
+import {
+  fullChatVirtualWindow,
+  type UseChatMessageVirtualizerArgs,
+  type UseChatMessageVirtualizerResult,
+} from "@/hooks/chatMessageVirtualizerShared";
 
-export type UseChatMessageVirtualizerArgs = {
-  itemCount: number;
-  getKey: (index: number) => string;
-  /** Content-aware estimate before first measure (critical for tall answers). */
-  getEstimateHeight?: (index: number) => number;
-  viewportRef: RefObject<HTMLElement | null>;
-  /** Stick pin flag from useStickToBottom (ref, not reactive). */
-  isPinnedRef: RefObject<boolean>;
-  /** Reset height cache when conversation switches. */
-  conversationKey?: string | number | null;
-  /** Always-mounted indices (find match, streaming row, …). */
-  forceIndices?: readonly number[];
-  /** Below this count, render everything (no spacers). */
-  threshold?: number;
-  enabled?: boolean;
-};
-
-export type UseChatMessageVirtualizerResult = {
-  /** True when windowing is active. */
-  virtualized: boolean;
-  start: number;
-  end: number;
-  paddingTop: number;
-  paddingBottom: number;
-  richStart: number;
-  richEnd: number;
-  /** Measured height, else content estimate. */
-  rowHeight: (index: number) => number;
-  /** Attach to each row wrapper for measurement. */
-  measureRef: (index: number) => (el: HTMLElement | null) => void;
-  /** Recompute after scroll (also driven by native scroll listener). */
-  onViewportScroll: () => void;
-};
-
-const full = (count: number): ChatVirtualWindow => ({
-  start: 0,
-  end: count,
-  paddingTop: 0,
-  paddingBottom: 0,
-  totalHeight: 0,
-  richStart: 0,
-  richEnd: count,
-});
+export type {
+  UseChatMessageVirtualizerArgs,
+  UseChatMessageVirtualizerResult,
+} from "@/hooks/chatMessageVirtualizerShared";
 
 export function useChatMessageVirtualizer(
   args: UseChatMessageVirtualizerArgs,
@@ -197,7 +161,7 @@ export function useChatMessageVirtualizer(
     offsets: number[];
   } | null>(null);
 
-  const [win, setWin] = useState<ChatVirtualWindow>(() => full(itemCount));
+  const [win, setWin] = useState<ChatVirtualWindow>(() => fullChatVirtualWindow(itemCount));
   const winRef = useRef(win);
   winRef.current = win;
   /**
@@ -240,7 +204,7 @@ export function useChatMessageVirtualizer(
     observedIndicesRef.current.clear();
     const nextWin = virtualized
       ? chatOpenPinWindow(itemCount)
-      : full(itemCount);
+      : fullChatVirtualWindow(itemCount);
     winRef.current = nextWin;
     committedWinRef.current = nextWin;
     setWin(nextWin);
@@ -255,6 +219,10 @@ export function useChatMessageVirtualizer(
    * wheel ticks — without the debounce one gesture toggled hover 31 times.
    */
   const hoverRestoreTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
+  /** While pinned, release scrollingRef after trackpad idle so thinking growth can pin-follow (#1172). */
+  const pinnedScrollIdleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
   );
   const setScrollingUi = useCallback(
@@ -316,7 +284,7 @@ export function useChatMessageVirtualizer(
   const recomputeNow = useCallback((options?: { sampleVelocity?: boolean }) => {
     const count = itemCountRef.current;
     if (!virtualizedRef.current) {
-      const next = full(count);
+      const next = fullChatVirtualWindow(count);
       const prev = winRef.current;
       if (
         prev.start === next.start &&
@@ -332,7 +300,7 @@ export function useChatMessageVirtualizer(
     }
     const el = viewportRef.current;
     if (!el) {
-      const next = full(count);
+      const next = fullChatVirtualWindow(count);
       winRef.current = next;
       setWin(next);
       return;
@@ -368,7 +336,8 @@ export function useChatMessageVirtualizer(
     // paint one frame of visible jump. Forces the urgent lane.
     let scrollTopWasWritten = false;
 
-    // Velocity-driven motion tracking: only sample when requested by scroll/rAF loop
+    // Velocity-driven motion tracking: only sample when requested by scroll/rAF loop.
+    // Pinned idle release of scrollingRef is owned by pinnedScrollIdleTimer (#1172).
     if (options?.sampleVelocity && !pin) {
       const velState = velocityTrackerRef.current.sample(el.scrollTop, t0);
       if (velState.isMoving) {
@@ -600,7 +569,7 @@ export function useChatMessageVirtualizer(
   // observers still fire with a stale count (window fight = flash).
   useEffect(() => {
     if (!virtualized) {
-      setWin(full(itemCountRef.current));
+      setWin(fullChatVirtualWindow(itemCountRef.current));
       return;
     }
     const el = viewportRef.current;
@@ -639,6 +608,22 @@ export function useChatMessageVirtualizer(
       }
       scrollingRef.current = true;
       setScrollingUi(true);
+      // Pinned wheel/touchmove: keep scrolling during the gesture (#1159), but
+      // release after idle so streaming thinking/tool height can pin-follow (#1172).
+      if (pinnedScrollIdleTimerRef.current != null) {
+        clearTimeout(pinnedScrollIdleTimerRef.current);
+        pinnedScrollIdleTimerRef.current = null;
+      }
+      if (isPinnedRef.current) {
+        pinnedScrollIdleTimerRef.current = setTimeout(() => {
+          pinnedScrollIdleTimerRef.current = null;
+          if (fingerDownRef.current) return;
+          if (!isPinnedRef.current) return;
+          scrollingRef.current = false;
+          setScrollingUi(false);
+          scheduleOnFrame(scrollFrameRef.current, () => recomputeNow());
+        }, 160);
+      }
       if (isPinnedRef.current && fingerDownRef.current) return;
       scheduleOnFrame(scrollFrameRef.current, () =>
         recomputeNow({ sampleVelocity: true }),
@@ -730,6 +715,10 @@ export function useChatMessageVirtualizer(
         clearTimeout(hoverRestoreTimerRef.current);
         hoverRestoreTimerRef.current = null;
       }
+      if (pinnedScrollIdleTimerRef.current != null) {
+        clearTimeout(pinnedScrollIdleTimerRef.current);
+        pinnedScrollIdleTimerRef.current = null;
+      }
       delete el.dataset.scrolling;
       ro?.disconnect();
       cancelFrameSchedule(scrollFrameRef.current);
@@ -760,15 +749,15 @@ export function useChatMessageVirtualizer(
     const v = viewportRef.current;
     if (!v) return;
     if (v.clientHeight < STICK_MIN_VIEWPORT_HEIGHT_PX) return;
-    // User already left the bottom (trackpad ticks). Snapping here is the
-    // "wheel turns, screen does not move" freeze until a hard flick. Judged
-    // on the distance captured before the commit: post-commit numbers
-    // conflate user motion with scrollHeight drift from fresh row mounts.
+    // When stick still says pinned, always restore the bottom offset.
+    // Streaming thinking/tool growth can inflate pre-commit dist above the
+    // escape threshold without the user leaving the tail (#1172). True
+    // leave-bottom is owned by useStickToBottom flipping isPinnedRef.
+    // Mid-gesture yank is prevented by scrollingRef / fingerDown above and
+    // by not clearing scrollingRef during the wheel itself (#1159).
     let dist = pinnedPreCommitBottomDistRef.current;
     if (forceOpen) {
       dist = 0;
-    } else if (dist >= STICK_ESCAPE_MIN_DELTA_PX) {
-      return;
     }
     const top = Math.max(0, v.scrollHeight - v.clientHeight);
     const desired = Math.max(0, top - dist);


### PR DESCRIPTION
## Summary
- While stick-to-bottom is still pinned, streaming thinking/tool height growth can inflate pre-commit distance and look like a leave-bottom escape; pin-snap now always restores the bottom offset when stick still says pinned (#1172).
- Keep `scrollingRef` through mid-wheel/touchmove so trackpad leave-bottom is not yanked (#1159), then clear after 160ms idle so thinking can pin-follow again.
- Tests cover mid-gesture keep + idle clear.

## Test plan
- [x] `pnpm exec vitest run src/hooks/useChatMessageVirtualizer.test.tsx`
- [ ] Manual: pin to bottom, stream a long thinking/tool turn — content stays above the composer
- [ ] Manual: slow trackpad scroll up from bottom still leaves the tail without snap-back (#1159)

Closes #1172