### PR TITLE
fix(session): harden Codex release blockers (rules / trust / branch / Google auth)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ See `docs/llm-wiki/release.md`.
 - 输入框上的分支 chip 可在当前目录切换 git 分支。仅远程存在的分支会建本地跟踪分支；已在其他 worktree 检出的则切到那个 worktree。
 
 ### Fixed
+- Saving project rules no longer kills another chat's background agent mid-turn.
+- Trusted-project chats no longer reuse a prewarm process that skipped folder trust.
+- Switching git branches is blocked while an agent turn is still running in that folder.
+- Closing the Google sign-in window reloads the embedded browser so shared cookies apply.
 - Session rules and system prompt overrides apply on the next agent turn (#1171).
 - Trusted projects pass folder trust so AGENTS.md loads in App chats (#1171).
 - Windows IME candidate windows stay nearer the composer while composing (#1170).
@@ -37,8 +41,13 @@ See `docs/llm-wiki/release.md`.
 - Imagine portrait thumbnails stay contained when the wallpaper window narrows.
 - What's New now lists every entry; some were cut off before.
 - Generated wallpaper stays visible when library indexing fails and can be saved again.
+- Local video details now use the file's measured dimensions and duration.
 
 **中文 · 修复**
+- 保存项目规则时，不再打断同项目另一聊天后台进行中的 agent 回合。
+- 已信任项目不会复用未带文件夹信任的预热进程，AGENTS.md 可正确加载。
+- 同文件夹仍有 agent 回合在跑时，禁止切换 git 分支。
+- 关闭 Google 登录窗后会刷新内嵌页，共享 Cookie 才能生效。
 - 会话规则与系统提示覆盖会在下一轮 agent 生效，不再被旧会话 resume 吃掉（#1171）。
 - 已信任项目会传文件夹信任，App 内聊天能加载 AGENTS.md（#1171）。
 - Windows 组字时减少输入框高度抖动，候选栏更贴近输入区（#1170）。
@@ -54,6 +63,7 @@ See `docs/llm-wiki/release.md`.
 - 壁纸窗口缩小时，Imagine 纵向缩略图不再挤压错位。
 - 「新功能」弹窗不再漏掉部分条目。
 - 生成壁纸在图库索引失败时仍会显示，并可直接重试保存。
+- 本地视频详情现在显示文件实测的尺寸与时长。
 
 ### Changed
 - Ctrl+Tab fills the selected chat row. Busy chats show the same spinner as the sidebar (#1146).
@@ -68,12 +78,6 @@ See `docs/llm-wiki/release.md`.
 - 主题编辑器改为按需加载，不再拖累应用启动。
 - 打包内的 KaTeX 数学字体只保留 woff2 格式，安装包更小。
 - 设置的读写改走阻塞线程池，异步命令不再被设置文件锁卡住。
-
-### Improved
-- Local video details now use the file's measured dimensions and duration.
-
-**中文 · 改进**
-- 本地视频详情现在显示文件实测的尺寸与时长。
 
 ## [0.2.34] - 2026-09-09
 

--- a/docs/plans/2026-09-10-sidebar-toggle-ctrl-b.md
+++ b/docs/plans/2026-09-10-sidebar-toggle-ctrl-b.md
@@ -1,9 +1,9 @@
 # Ctrl+B 左侧栏展开/收起响应优化
 
-**日期**：2026-09-10  
-**基线**：`main` @ `2b43acbb`（`feat(session): show a recent-chat list while holding Ctrl+Tab (#1127)`）  
-**来源**：Ctrl+B 侧栏「响应慢」诊断（快捷键本身无 debounce；慢在 host 重渲染 + in-flow `width` 插值）  
-**执行位置**：worktree `D:/code/grok-app-sidebar-toggle-ctrl-b` · 分支 `perf/sidebar-toggle-ctrl-b`  
+**日期**：2026-09-10
+**基线**：`main` @ `2b43acbb`（`feat(session): show a recent-chat list while holding Ctrl+Tab (#1127)`）
+**来源**：Ctrl+B 侧栏「响应慢」诊断（快捷键本身无 debounce；慢在 host 重渲染 + in-flow `width` 插值）
+**执行位置**：worktree `D:/code/grok-app-sidebar-toggle-ctrl-b` · 分支 `perf/sidebar-toggle-ctrl-b`
 **状态**：WP-A/B/C 已实施、未开 PR、不 merge `main`（`zzzzz` 前禁止）
 
 `.husky/post-checkout` 不存在（无 symlink 步骤）。`android/capacitor.settings.gradle` 不存在，`skip-worktree` 跳过。

--- a/src-tauri/src/commands/git_p3.rs
+++ b/src-tauri/src/commands/git_p3.rs
@@ -385,6 +385,7 @@ fn git_branches_list_blocking(project: String) -> Result<GitBranchesResult, Stri
 /// `start_point` set → create a local tracking branch from that remote ref.
 #[tauri::command]
 pub async fn git_switch_branch(
+    mgr: State<'_, Arc<SessionManager>>,
     project_path: String,
     branch: String,
     start_point: Option<String>,
@@ -409,6 +410,25 @@ pub async fn git_switch_branch(
             None,
             None,
             Some("project not a directory".into()),
+        ));
+    }
+    // Refuse replacing the worktree while any live/background agent turn is
+    // still bound here — otherwise a background chat keeps writing against the
+    // branch the user just left.
+    let project_id = store::load_projects()
+        .into_iter()
+        .find(|p| normalize_fs_path(&p.path) == project)
+        .map(|p| p.id);
+    if let Some(sid) =
+        mgr.any_busy_turn_for_project(project_id.as_deref(), &project)
+    {
+        return Ok(switch_fail(
+            true,
+            "agent_busy",
+            None,
+            None,
+            None,
+            Some(format!("agent turn still running in session {sid}")),
         ));
     }
     let name = match sanitize_git_branch_name(&branch) {

--- a/src-tauri/src/session_manager/connect.rs
+++ b/src-tauri/src/session_manager/connect.rs
@@ -730,14 +730,26 @@ impl SessionManager {
         // Seatbelt/Landlock write root for the process lifetime. Prewarm
         // always starts in `workspaces/general` — never reuse it for a
         // project-bound session (open_session_at cannot widen the sandbox).
+        //
+        // Prewarm also omits folder `--trust`, per-session `--rules`,
+        // `--system-prompt-override`, and `--plugin-dir`. Reusing it for those
+        // connects would silently drop AGENTS.md / session rules.
         if !pending_fork && ssh_alias.is_none() {
+            let project_row_early = meta
+                .project_id
+                .as_deref()
+                .and_then(|pid| store::load_projects().into_iter().find(|p| p.id == pid));
+            let folder_trust_needed = project_row_early.as_ref().is_some_and(|p| p.trusted);
+            let session_spawn_flags_need_cold = Self::session_needs_cold_spawn_for_flags(
+                folder_trust_needed,
+                meta.extra_rules.as_deref(),
+                meta.system_prompt_override.as_deref(),
+                &meta.plugin_dirs,
+            );
             let eff_sandbox = {
-                let project_sandbox = meta.project_id.as_deref().and_then(|pid| {
-                    store::load_projects()
-                        .into_iter()
-                        .find(|p| p.id == pid)
-                        .and_then(|p| p.sandbox_profile)
-                });
+                let project_sandbox = project_row_early
+                    .as_ref()
+                    .and_then(|p| p.sandbox_profile.clone());
                 store::resolve_sandbox_profile(
                     &settings.sandbox_profile,
                     project_sandbox.as_deref(),
@@ -819,89 +831,100 @@ impl SessionManager {
                 // awaited briefly — its CLI has no accumulated actors, so the
                 // session/load that follows is fast instead of the CLI's 5s
                 // old-thread drain.
+                // Skip entirely when this connect needs process-level flags the
+                // ownerless prewarm never received (trust / rules / override /
+                // plugin dirs). Leave the Ready prewarm for a later unbound chat.
+                if session_spawn_flags_need_cold {
+                    rejected.push(
+                        "prewarm: session needs trust/rules/system-prompt/plugin-dirs (cold spawn)"
+                            .into(),
+                    );
+                }
                 let prewarm_wait_deadline =
                     std::time::Instant::now() + std::time::Duration::from_millis(2500);
-                loop {
-                    let taken = {
-                        let mut pw = self.prewarm.lock();
-                        match std::mem::replace(&mut *pw, PrewarmState::None) {
-                            PrewarmState::Ready(p) => {
-                                let process_cwd = p.acp.cwd().to_string_lossy();
-                                let target_cwd = cwd.to_string_lossy();
-                                if !Self::reuse_sandbox_cwd_ok(
-                                    p.sandbox_profile.as_deref(),
-                                    process_cwd.as_ref(),
-                                    target_cwd.as_ref(),
-                                ) {
-                                    // Keep the general-workspace prewarm for a
-                                    // later unbound chat; only cold-spawn this
-                                    // project session (#986).
-                                    rejected.push(format!(
-                                        "prewarm: sandbox cwd {process_cwd}≠{target_cwd}"
-                                    ));
-                                    *pw = PrewarmState::Ready(p);
+                if !session_spawn_flags_need_cold {
+                    loop {
+                        let taken = {
+                            let mut pw = self.prewarm.lock();
+                            match std::mem::replace(&mut *pw, PrewarmState::None) {
+                                PrewarmState::Ready(p) => {
+                                    let process_cwd = p.acp.cwd().to_string_lossy();
+                                    let target_cwd = cwd.to_string_lossy();
+                                    if !Self::reuse_sandbox_cwd_ok(
+                                        p.sandbox_profile.as_deref(),
+                                        process_cwd.as_ref(),
+                                        target_cwd.as_ref(),
+                                    ) {
+                                        // Keep the general-workspace prewarm for a
+                                        // later unbound chat; only cold-spawn this
+                                        // project session (#986).
+                                        rejected.push(format!(
+                                            "prewarm: sandbox cwd {process_cwd}≠{target_cwd}"
+                                        ));
+                                        *pw = PrewarmState::Ready(p);
+                                        None
+                                    } else if gate(
+                                        p.acp.is_alive(),
+                                        p.policy,
+                                        p.effort.as_deref(),
+                                        p.sandbox_profile.as_deref(),
+                                        p.acp.is_custom_route(),
+                                    ) {
+                                        Some((p.acp, p.process_id, p.created_at))
+                                    } else {
+                                        // `PrewarmState::Ready` is ownerless, so
+                                        // a gate mismatch cannot be handed back to
+                                        // another session. Drop and explicitly
+                                        // kill it after leaving the map lock; an
+                                        // Arc/Child drop alone does not terminate
+                                        // the CLI process.
+                                        stale_prewarm.push(p.acp.clone());
+                                        rejected.push(format!(
+                                            "prewarm: {}",
+                                            reject_reason(
+                                                p.acp.is_alive(),
+                                                p.policy,
+                                                p.effort.as_deref(),
+                                                p.sandbox_profile.as_deref(),
+                                                p.acp.is_custom_route(),
+                                            )
+                                        ));
+                                        None
+                                    }
+                                }
+                                PrewarmState::Spawning { since }
+                                    if since.elapsed() < std::time::Duration::from_millis(2500) =>
+                                {
+                                    *pw = PrewarmState::Spawning { since };
                                     None
-                                } else if gate(
-                                    p.acp.is_alive(),
-                                    p.policy,
-                                    p.effort.as_deref(),
-                                    p.sandbox_profile.as_deref(),
-                                    p.acp.is_custom_route(),
-                                ) {
-                                    Some((p.acp, p.process_id, p.created_at))
-                                } else {
-                                    // `PrewarmState::Ready` is ownerless, so
-                                    // a gate mismatch cannot be handed back to
-                                    // another session. Drop and explicitly
-                                    // kill it after leaving the map lock; an
-                                    // Arc/Child drop alone does not terminate
-                                    // the CLI process.
-                                    stale_prewarm.push(p.acp.clone());
-                                    rejected.push(format!(
-                                        "prewarm: {}",
-                                        reject_reason(
-                                            p.acp.is_alive(),
-                                            p.policy,
-                                            p.effort.as_deref(),
-                                            p.sandbox_profile.as_deref(),
-                                            p.acp.is_custom_route(),
-                                        )
-                                    ));
+                                }
+                                other => {
+                                    *pw = other;
                                     None
                                 }
                             }
-                            PrewarmState::Spawning { since }
-                                if since.elapsed() < std::time::Duration::from_millis(2500) =>
-                            {
-                                *pw = PrewarmState::Spawning { since };
-                                None
-                            }
-                            other => {
-                                *pw = other;
-                                None
-                            }
+                        };
+                        if let Some((acp, pid, at)) = taken {
+                            best = Some((acp, pid, at));
+                            break;
                         }
-                    };
-                    if let Some((acp, pid, at)) = taken {
-                        best = Some((acp, pid, at));
-                        break;
+                        let still_spawning =
+                            matches!(*self.prewarm.lock(), PrewarmState::Spawning { .. });
+                        if !still_spawning || std::time::Instant::now() >= prewarm_wait_deadline {
+                            break;
+                        }
+                        // Brief yield so the prewarm task can progress (it spawns
+                        // outside connect_lock, so this cannot deadlock).
+                        tokio::time::sleep(std::time::Duration::from_millis(120)).await;
                     }
-                    let still_spawning =
-                        matches!(*self.prewarm.lock(), PrewarmState::Spawning { .. });
-                    if !still_spawning || std::time::Instant::now() >= prewarm_wait_deadline {
-                        break;
-                    }
-                    // Brief yield so the prewarm task can progress (it spawns
-                    // outside connect_lock, so this cannot deadlock).
-                    tokio::time::sleep(std::time::Duration::from_millis(120)).await;
-                }
-                // A session-bound ACP process is never transferred to another
-                // App session. The old parked/background reuse path shared an
-                // `Arc<AcpClient>` while leaving the original owner registered;
-                // capacity and event routing could then kill or apply events to
-                // the wrong tenant. Only the ownerless prewarm process above is
-                // eligible for reuse. The target session is opened on a fresh
-                // process once its own parked entry is no longer focused.
+                } // if !session_spawn_flags_need_cold
+                  // A session-bound ACP process is never transferred to another
+                  // App session. The old parked/background reuse path shared an
+                  // `Arc<AcpClient>` while leaving the original owner registered;
+                  // capacity and event routing could then kill or apply events to
+                  // the wrong tenant. Only the ownerless prewarm process above is
+                  // eligible for reuse. The target session is opened on a fresh
+                  // process once its own parked entry is no longer focused.
                 if best.is_none() && !rejected.is_empty() {
                     tracing::warn!(
                         target: "session",
@@ -1878,6 +1901,21 @@ impl SessionManager {
             && p_custom_route == target_custom_route
     }
 
+    /// Ownerless prewarm never receives these process-level flags — force cold spawn.
+    pub(super) fn session_needs_cold_spawn_for_flags(
+        folder_trust: bool,
+        extra_rules: Option<&str>,
+        system_prompt_override: Option<&str>,
+        plugin_dirs: &[String],
+    ) -> bool {
+        folder_trust
+            || extra_rules.map(str::trim).is_some_and(|s| !s.is_empty())
+            || system_prompt_override
+                .map(str::trim)
+                .is_some_and(|s| !s.is_empty())
+            || !plugin_dirs.is_empty()
+    }
+
     /// Whether warm-reuse is safe for OS sandbox vs spawn cwd (#986).
     ///
     /// `off` does not lock filesystem roots to spawn cwd, so a different
@@ -2409,6 +2447,46 @@ mod reuse_gate_tests {
             Some("read-only"),
             general,
             project
+        ));
+    }
+
+    #[test]
+    fn session_needs_cold_spawn_when_trust_or_rules_present() {
+        assert!(!SessionManager::session_needs_cold_spawn_for_flags(
+            false,
+            None,
+            None,
+            &[]
+        ));
+        assert!(SessionManager::session_needs_cold_spawn_for_flags(
+            true,
+            None,
+            None,
+            &[]
+        ));
+        assert!(SessionManager::session_needs_cold_spawn_for_flags(
+            false,
+            Some(" always write tests "),
+            None,
+            &[]
+        ));
+        assert!(SessionManager::session_needs_cold_spawn_for_flags(
+            false,
+            None,
+            Some("you are terse"),
+            &[]
+        ));
+        assert!(SessionManager::session_needs_cold_spawn_for_flags(
+            false,
+            None,
+            None,
+            &[String::from("/tmp/plugin")]
+        ));
+        assert!(!SessionManager::session_needs_cold_spawn_for_flags(
+            false,
+            Some("   \n"),
+            Some(""),
+            &[]
         ));
     }
 

--- a/src-tauri/src/session_manager/control.rs
+++ b/src-tauri/src/session_manager/control.rs
@@ -62,7 +62,25 @@ impl SessionManager {
             bg.needs_history_bootstrap = true;
         }
         if self.is_live_session(session_id) {
+            // soft_respawn already defers when the live turn is busy.
             self.soft_respawn_with_reason(app, reason).await;
+            return;
+        }
+        // Background mid-turn: queue like effort/policy changes. Dropping now
+        // kills an in-flight answer and removes the map entry before
+        // ProcessExited can finish journal / cancel bookkeeping (#1177 follow-up).
+        let bg_busy = self
+            .with_session_mut(session_id, |s| Self::live_session_is_busy(s))
+            .unwrap_or(false);
+        if bg_busy {
+            self.pending_soft_respawn
+                .lock()
+                .insert(session_id.to_string(), reason.to_string());
+            tracing::info!(
+                session = %session_id,
+                reason = %reason,
+                "spawn-flag invalidate deferred: background session mid-turn"
+            );
             return;
         }
         self.drop_idle_agent_for_session(session_id, reason).await;

--- a/src-tauri/src/session_manager/process.rs
+++ b/src-tauri/src/session_manager/process.rs
@@ -265,6 +265,46 @@ impl SessionManager {
             .unwrap_or(false)
     }
 
+    /// True when any live or background mid-turn session is bound to `project_id`
+    /// or has a worktree path under `project_path` (git switch safety).
+    pub fn any_busy_turn_for_project(
+        &self,
+        project_id: Option<&str>,
+        project_path: &str,
+    ) -> Option<String> {
+        let norm = |s: &str| s.trim().trim_end_matches(['/', '\\']).replace('\\', "/");
+        let target = norm(project_path);
+        let matches = |s: &LiveSession| {
+            if !Self::live_session_is_busy(s) {
+                return false;
+            }
+            if let (Some(want), Some(have)) = (project_id, s.meta.project_id.as_deref()) {
+                if want == have {
+                    return true;
+                }
+            }
+            if let Some(wp) = s.meta.worktree_path.as_deref() {
+                let n = norm(wp);
+                if n == target || n.starts_with(&(target.clone() + "/")) {
+                    return true;
+                }
+            }
+            false
+        };
+        {
+            let guard = self.inner.lock();
+            if let Some(s) = guard.as_ref() {
+                if matches(s) {
+                    return Some(s.app_session_id.clone());
+                }
+            }
+        }
+        let bg = self.background.lock();
+        bg.values()
+            .find(|s| matches(s))
+            .map(|s| s.app_session_id.clone())
+    }
+
     pub(super) fn live_session_is_busy(s: &LiveSession) -> bool {
         // Authoritative: the prompt RPC has not resolved, so the agent is still
         // producing output for this chat no matter what the FSM says. Parking

--- a/src-tauri/src/side_browser_google_auth.rs
+++ b/src-tauri/src/side_browser_google_auth.rs
@@ -131,6 +131,41 @@ fn resume_side_browser_after_google_auth(app: &AppHandle, callback: &Url) {
     }
 }
 
+/// Auth window closed without a non-Google redirect (common for GIS popup /
+/// postMessage flows that never leave accounts.google.com). Shared cookies
+/// may already be written — reload the embedded tab so the site picks them up.
+fn reload_side_browser_after_google_auth_closed(app: &AppHandle, side_label: &str) {
+    tracing::info!(
+        target: "side_browser",
+        %side_label,
+        "Google auth window closed → reload embedded browser for shared cookies"
+    );
+    match get_side_webview(app, side_label) {
+        Ok(wv) => {
+            let url = wv.url().ok().map(|u| u.to_string()).unwrap_or_default();
+            if !url.is_empty() {
+                emit_page_load(app, "started", side_label, &url);
+            }
+            if let Err(e) = wv.reload() {
+                tracing::warn!(
+                    target: "side_browser",
+                    error = %e,
+                    %side_label,
+                    "failed to reload side browser after Google auth window closed"
+                );
+            }
+        }
+        Err(e) => {
+            tracing::warn!(
+                target: "side_browser",
+                error = %e,
+                %side_label,
+                "side browser missing after Google auth window closed"
+            );
+        }
+    }
+}
+
 fn open_google_auth_window(app: &AppHandle, side_label: &str, url: &Url) -> Result<(), String> {
     *PENDING_GOOGLE_AUTH.lock() = Some(PendingGoogleAuth {
         side_label: side_label.to_string(),
@@ -180,12 +215,16 @@ fn open_google_auth_window(app: &AppHandle, side_label: &str, url: &Url) -> Resu
                 NewWindowResponse::Deny
             });
 
+    let app_closed = app.clone();
     let window = builder
         .build()
         .map_err(|e| format!("google auth window: {e}"))?;
     window.on_window_event(move |event| {
         if matches!(event, tauri::WindowEvent::Destroyed) {
-            let _ = PENDING_GOOGLE_AUTH.lock().take();
+            let pending = PENDING_GOOGLE_AUTH.lock().take();
+            if let Some(p) = pending {
+                reload_side_browser_after_google_auth_closed(&app_closed, &p.side_label);
+            }
         }
     });
     Ok(())
@@ -210,6 +249,7 @@ pub fn handoff_google_auth_externally(app: &AppHandle, label: &str, url: &Url) -
             url = %url_s,
             "failed to open Google auth window"
         );
+        return false;
     }
     emit_external_open(app, label, url_s);
     true

--- a/src/hooks/useGitBranches.ts
+++ b/src/hooks/useGitBranches.ts
@@ -161,9 +161,14 @@ export function useGitBranches(opts: {
         return;
       }
 
+      // Capture ownership before the async switch so a mid-flight project /
+      // session change cannot bind the new branch onto the wrong chat.
+      const ownedSessionId =
+        h.viewingSessionIdRef.current || h.session.sessionId || null;
+      const ownedProjectPath = projectPath;
       setGitBranchesBusy(true);
       try {
-        const res = await api.gitSwitchBranch(projectPath, name, startPoint);
+        const res = await api.gitSwitchBranch(ownedProjectPath, name, startPoint);
         if (!res.ok) {
           const kind = gitSwitchKindFromHost(res.kind);
           h.showToast(
@@ -181,11 +186,9 @@ export function useGitBranches(opts: {
           return;
         }
         const next = (res.branch || name).trim();
-        applyStatusBranch(projectPath, { available: true, branch: next });
-        const liveId =
-          h.viewingSessionIdRef.current || h.session.sessionId || null;
-        if (liveId) {
-          await markSessionWorktree(liveId, projectPath, next);
+        applyStatusBranch(ownedProjectPath, { available: true, branch: next });
+        if (ownedSessionId) {
+          await markSessionWorktree(ownedSessionId, ownedProjectPath, next);
         }
         h.showToast(h.tr("composer.branchSwitched", { branch: next }), 2800);
         await Promise.all([

--- a/src/i18n/messages/de/composer.ts
+++ b/src/i18n/messages/de/composer.ts
@@ -181,6 +181,7 @@ export const deComposer = {
   "composer.branchSwitchFailed": "Wechsel zu {branch} fehlgeschlagen: {reason}",
   "composer.branchFail.dirty": "Uncommittete Änderungen würden überschrieben — zuerst committen oder stashen",
   "composer.branchFail.elsewhere": "Bereits ausgecheckt in {path}",
+  "composer.branchFail.agentBusy": "In diesem Ordner läuft noch ein Agent-Turn — warte oder stoppe ihn zuerst",
   "composer.branchFail.notFound": "Branch nicht gefunden",
   "composer.branchFail.invalid": "Ungültiger Branch-Name",
   "composer.branchFail.gitMissing": "git ist nicht verfügbar",

--- a/src/i18n/messages/en/composer.ts
+++ b/src/i18n/messages/en/composer.ts
@@ -183,6 +183,7 @@ export const enComposer = {
   "composer.branchSwitchFailed": "Could not switch to {branch}: {reason}",
   "composer.branchFail.dirty": "Uncommitted changes would be overwritten — commit or stash first",
   "composer.branchFail.elsewhere": "Already checked out in {path}",
+  "composer.branchFail.agentBusy": "An agent turn is still running in this folder — wait or stop it first",
   "composer.branchFail.notFound": "Branch not found",
   "composer.branchFail.invalid": "Invalid branch name",
   "composer.branchFail.gitMissing": "git is not available",

--- a/src/i18n/messages/es/composer.ts
+++ b/src/i18n/messages/es/composer.ts
@@ -181,6 +181,7 @@ export const esComposer = {
   "composer.branchSwitchFailed": "No se pudo cambiar a {branch}: {reason}",
   "composer.branchFail.dirty": "Los cambios sin confirmar se sobrescribirían — confirma o guarda en stash primero",
   "composer.branchFail.elsewhere": "Ya está en checkout en {path}",
+  "composer.branchFail.agentBusy": "Todavía hay un turno de agente en esta carpeta — espera o detenlo primero",
   "composer.branchFail.notFound": "Rama no encontrada",
   "composer.branchFail.invalid": "Nombre de rama no válido",
   "composer.branchFail.gitMissing": "git no está disponible",

--- a/src/i18n/messages/fil/composer.ts
+++ b/src/i18n/messages/fil/composer.ts
@@ -181,6 +181,7 @@ export const filComposer = {
   "composer.branchSwitchFailed": "Hindi makalipat sa {branch}: {reason}",
   "composer.branchFail.dirty": "Masusoverite ang mga hindi naka-commit na pagbabago — mag-commit o mag-stash muna",
   "composer.branchFail.elsewhere": "Naka-checkout na sa {path}",
+  "composer.branchFail.agentBusy": "May tumatakbong agent turn pa sa folder na ito — hintayin o ihinto muna",
   "composer.branchFail.notFound": "Hindi nahanap ang branch",
   "composer.branchFail.invalid": "Invalid na pangalan ng branch",
   "composer.branchFail.gitMissing": "Hindi available ang git",

--- a/src/i18n/messages/fr/composer.ts
+++ b/src/i18n/messages/fr/composer.ts
@@ -181,6 +181,7 @@ export const frComposer = {
   "composer.branchSwitchFailed": "Impossible de basculer sur {branch} : {reason}",
   "composer.branchFail.dirty": "Des modifications non commitées seraient écrasées — commitez ou stash d’abord",
   "composer.branchFail.elsewhere": "Déjà extraite dans {path}",
+  "composer.branchFail.agentBusy": "Un tour d’agent est encore en cours dans ce dossier — attendez ou arrêtez-le d’abord",
   "composer.branchFail.notFound": "Branche introuvable",
   "composer.branchFail.invalid": "Nom de branche invalide",
   "composer.branchFail.gitMissing": "git n’est pas disponible",

--- a/src/i18n/messages/id/composer.ts
+++ b/src/i18n/messages/id/composer.ts
@@ -181,6 +181,7 @@ export const idComposer = {
   "composer.branchSwitchFailed": "Tidak dapat beralih ke {branch}: {reason}",
   "composer.branchFail.dirty": "Perubahan yang belum di-commit akan ditimpa — commit atau stash dulu",
   "composer.branchFail.elsewhere": "Sudah di-checkout di {path}",
+  "composer.branchFail.agentBusy": "Masih ada giliran agen di folder ini — tunggu atau hentikan dulu",
   "composer.branchFail.notFound": "Cabang tidak ditemukan",
   "composer.branchFail.invalid": "Nama cabang tidak valid",
   "composer.branchFail.gitMissing": "git tidak tersedia",

--- a/src/i18n/messages/it/composer.ts
+++ b/src/i18n/messages/it/composer.ts
@@ -181,6 +181,7 @@ export const itComposer = {
   "composer.branchSwitchFailed": "Impossibile passare a {branch}: {reason}",
   "composer.branchFail.dirty": "Le modifiche non committate verrebbero sovrascritte — fai commit o stash prima",
   "composer.branchFail.elsewhere": "Già in checkout in {path}",
+  "composer.branchFail.agentBusy": "Un turno agent è ancora in corso in questa cartella — attendi o interrompilo prima",
   "composer.branchFail.notFound": "Ramo non trovato",
   "composer.branchFail.invalid": "Nome ramo non valido",
   "composer.branchFail.gitMissing": "git non disponibile",

--- a/src/i18n/messages/ja/composer.ts
+++ b/src/i18n/messages/ja/composer.ts
@@ -181,6 +181,7 @@ export const jaComposer = {
   "composer.branchSwitchFailed": "{branch} に切り替えられません：{reason}",
   "composer.branchFail.dirty": "未コミットの変更が上書きされます。先にコミットまたは stash してください",
   "composer.branchFail.elsewhere": "{path} ですでにチェックアウトされています",
+  "composer.branchFail.agentBusy": "このフォルダでエージェントのターンが実行中です — 完了または停止してから切り替えてください",
   "composer.branchFail.notFound": "ブランチが見つかりません",
   "composer.branchFail.invalid": "ブランチ名が無効です",
   "composer.branchFail.gitMissing": "git がありません",

--- a/src/i18n/messages/ko/composer.ts
+++ b/src/i18n/messages/ko/composer.ts
@@ -181,6 +181,7 @@ export const koComposer = {
   "composer.branchSwitchFailed": "{branch}(으)로 전환할 수 없습니다: {reason}",
   "composer.branchFail.dirty": "커밋하지 않은 변경이 덮어씌워집니다. 먼저 커밋하거나 stash 하세요",
   "composer.branchFail.elsewhere": "이미 {path}에서 체크아웃됨",
+  "composer.branchFail.agentBusy": "이 폴더에서 에이전트 턴이 진행 중입니다 — 기다리거나 먼저 중지하십시오",
   "composer.branchFail.notFound": "브랜치를 찾을 수 없습니다",
   "composer.branchFail.invalid": "잘못된 브랜치 이름",
   "composer.branchFail.gitMissing": "git을 사용할 수 없습니다",

--- a/src/i18n/messages/pt-BR/composer.ts
+++ b/src/i18n/messages/pt-BR/composer.ts
@@ -181,6 +181,7 @@ export const ptBRComposer = {
   "composer.branchSwitchFailed": "Não foi possível mudar para {branch}: {reason}",
   "composer.branchFail.dirty": "Alterações não commitadas seriam sobrescritas — faça commit ou stash primeiro",
   "composer.branchFail.elsewhere": "Já está em checkout em {path}",
+  "composer.branchFail.agentBusy": "Ainda há um turno do agente nesta pasta — aguarde ou interrompa primeiro",
   "composer.branchFail.notFound": "Branch não encontrada",
   "composer.branchFail.invalid": "Nome de branch inválido",
   "composer.branchFail.gitMissing": "git não está disponível",

--- a/src/i18n/messages/ru/composer.ts
+++ b/src/i18n/messages/ru/composer.ts
@@ -181,6 +181,7 @@ export const ruComposer = {
   "composer.branchSwitchFailed": "Не удалось переключиться на {branch}: {reason}",
   "composer.branchFail.dirty": "Несохранённые изменения будут перезаписаны — сначала сделайте commit или stash",
   "composer.branchFail.elsewhere": "Уже извлечена в {path}",
+  "composer.branchFail.agentBusy": "В этой папке ещё идёт ход агента — сначала дождитесь или остановите",
   "composer.branchFail.notFound": "Ветка не найдена",
   "composer.branchFail.invalid": "Недопустимое имя ветки",
   "composer.branchFail.gitMissing": "git недоступен",

--- a/src/i18n/messages/ta/composer.ts
+++ b/src/i18n/messages/ta/composer.ts
@@ -181,6 +181,7 @@ export const taComposer = {
   "composer.branchSwitchFailed": "{branch}க்கு மாற்ற முடியவில்லை: {reason}",
   "composer.branchFail.dirty": "கமிட் செய்யாத மாற்றங்கள் மேலெழுதப்படும் — முதலில் கமிட் அல்லது stash செய்யவும்",
   "composer.branchFail.elsewhere": "ஏற்கனவே {path} இல் செக்அவுட் செய்யப்பட்டுள்ளது",
+  "composer.branchFail.agentBusy": "இந்த கோப்புறையில் முகவர் turn இன்னும் இயங்குகிறது — முதலில் காத்திருங்கள் அல்லது நிறுத்துங்கள்",
   "composer.branchFail.notFound": "கிளை காணப்படவில்லை",
   "composer.branchFail.invalid": "தவறான கிளைப் பெயர்",
   "composer.branchFail.gitMissing": "git கிடைக்கவில்லை",

--- a/src/i18n/messages/uk/composer.ts
+++ b/src/i18n/messages/uk/composer.ts
@@ -181,6 +181,7 @@ export const ukComposer = {
   "composer.branchSwitchFailed": "Не вдалося перемкнути на {branch}: {reason}",
   "composer.branchFail.dirty": "Незакомічені зміни буде перезаписано — спочатку зробіть commit або stash",
   "composer.branchFail.elsewhere": "Уже витягнуто в {path}",
+  "composer.branchFail.agentBusy": "У цій теці ще триває хід агента — спочатку зачекайте або зупиніть",
   "composer.branchFail.notFound": "Гілку не знайдено",
   "composer.branchFail.invalid": "Неприпустима назва гілки",
   "composer.branchFail.gitMissing": "git недоступний",

--- a/src/i18n/messages/zh-TW/composer.ts
+++ b/src/i18n/messages/zh-TW/composer.ts
@@ -37,6 +37,7 @@ export const zhTWComposer = {
   "composer.branchSwitchFailed": "無法切換到 {branch}：{reason}",
   "composer.branchFail.dirty": "未提交的變更會被覆蓋 — 請先提交或暫存",
   "composer.branchFail.elsewhere": "已在 {path} 檢出",
+  "composer.branchFail.agentBusy": "此資料夾仍有進行中的 agent 回合 — 請先等待或停止",
   "composer.branchFail.notFound": "找不到該分支",
   "composer.branchFail.invalid": "分支名無效",
   "composer.branchFail.gitMissing": "找不到 git",

--- a/src/i18n/messages/zh/composer.ts
+++ b/src/i18n/messages/zh/composer.ts
@@ -183,6 +183,7 @@ export const zhComposer = {
   "composer.branchSwitchFailed": "无法切换到 {branch}：{reason}",
   "composer.branchFail.dirty": "未提交的更改会被覆盖 — 请先提交或暂存",
   "composer.branchFail.elsewhere": "已在 {path} 检出",
+  "composer.branchFail.agentBusy": "此文件夹仍有进行中的 agent 回合 — 请先等待或停止",
   "composer.branchFail.notFound": "找不到该分支",
   "composer.branchFail.invalid": "分支名无效",
   "composer.branchFail.gitMissing": "未找到 git",

--- a/src/lib/gitBranches.test.ts
+++ b/src/lib/gitBranches.test.ts
@@ -5,6 +5,7 @@ import {
   capGitBranchesForMenu,
   classifyGitSwitchError,
   gitSwitchFailMessage,
+  gitSwitchKindFromHost,
   filterGitBranches,
   GIT_BRANCH_MENU_CAP,
   isRemoteHeadRef,
@@ -190,7 +191,16 @@ describe("gitSwitchFailMessage", () => {
     expect(gitSwitchFailMessage(tr as never, "elsewhere", null, "/wt")).toBe(
       "composer.branchFail.elsewhere",
     );
+    expect(gitSwitchFailMessage(tr as never, "agent_busy")).toBe(
+      "composer.branchFail.agentBusy",
+    );
     expect(gitSwitchFailMessage(tr as never, "failed", "boom")).toBe("boom");
+  });
+});
+
+describe("gitSwitchKindFromHost", () => {
+  it("recognizes agent_busy", () => {
+    expect(gitSwitchKindFromHost("agent_busy")).toBe("agent_busy");
   });
 });
 

--- a/src/lib/gitBranches.ts
+++ b/src/lib/gitBranches.ts
@@ -31,6 +31,7 @@ export type GitSwitchKind =
   | "ok"
   | "dirty"
   | "elsewhere"
+  | "agent_busy"
   | "not_found"
   | "invalid"
   | "git_not_available"
@@ -314,6 +315,7 @@ export function gitSwitchFailMessage(
     key:
       | "composer.branchFail.dirty"
       | "composer.branchFail.elsewhere"
+      | "composer.branchFail.agentBusy"
       | "composer.branchFail.notFound"
       | "composer.branchFail.invalid"
       | "composer.branchFail.gitMissing"
@@ -331,6 +333,8 @@ export function gitSwitchFailMessage(
       return tr("composer.branchFail.elsewhere", {
         path: (path || "").trim() || "—",
       });
+    case "agent_busy":
+      return tr("composer.branchFail.agentBusy");
     case "not_found":
       return tr("composer.branchFail.notFound");
     case "invalid":
@@ -352,6 +356,7 @@ export function gitSwitchKindFromHost(
     case "ok":
     case "dirty":
     case "elsewhere":
+    case "agent_busy":
     case "not_found":
     case "invalid":
     case "git_not_available":

--- a/src/lib/providerForm.ts
+++ b/src/lib/providerForm.ts
@@ -207,4 +207,3 @@ export function ccSwitchStatusKey(status: string): MessageKey {
       return "prov.ccSwitch.status.invalid";
   }
 }
-


### PR DESCRIPTION
## Summary
Addresses Codex review of `v0.2.34..main` high-priority risks:

- **P1** Saving project rules no longer kills a sibling chat’s **background busy** ACP; queues `pending_soft_respawn` until the turn ends (same pattern as effort/policy).
- **Prewarm** Trusted projects / session `--rules` / system-prompt / plugin-dirs force cold spawn so ownerless prewarm cannot skip those flags.
- **Git switch** Host refuses `git switch` while any live/background turn is bound to that project/worktree (`agent_busy` + i18n).
- **Google auth** Closing the shared-cookie login window reloads the embedded tab; failed window open no longer emits a false success handoff.
- CHANGELOG: drop unsupported `### Improved`; document the fixes. Whitespace cleanup from `git diff --check`.

## Test plan
- [x] `cargo test --lib session_needs_cold_spawn`
- [x] `pnpm exec vitest run src/lib/gitBranches.test.ts src/lib/whatsNew.test.ts`
- [x] `pnpm typecheck` + FILES_OVER_1K gate
- [ ] Manual: chat A streaming in background → save AGENTS.md in chat B → A finishes, then next turn picks up rules
- [ ] Manual: trusted project with AGENTS.md after idle prewarm → new chat follows rules
- [ ] Manual: background agent in folder → branch chip switch shows agent_busy
- [ ] Manual: Google auth window close → embedded tab reloads with cookies