### PR TITLE
docs(remote-bridge): mark package as deprecated reference-only

### DIFF
--- a/remote-bridge/README.md
+++ b/remote-bridge/README.md
@@ -1,10 +1,11 @@
 # remote-bridge (historical / reference)
 
-> **Deprecated for Grok App runtime.**  
+> **Deprecated for Grok App runtime — do not extend.**  
 > Remote IM connectors now run **in-process in Rust**: `src-tauri/src/remote_im/`.  
-> Host does **not** spawn this Node package.
+> Host does **not** spawn this Node package; it is not part of the pnpm
+> workspace, not type-checked in CI, and has no test coverage.
 
-This directory remains as a protocol reference (Feishu long-connection, engine ideas) migrated from agent-connect. Do not install `@ronglecat/agent-connect` for the App.
+This directory remains as a protocol reference (Feishu long-connection, engine ideas) migrated from agent-connect. Do not install `@ronglecat/agent-connect` for the App. Fixes to Remote IM behavior belong in `src-tauri/src/remote_im/`, not here.
 
 Active path:
 

--- a/remote-bridge/package.json
+++ b/remote-bridge/package.json
@@ -2,7 +2,7 @@
   "name": "@grok-app/remote-bridge",
   "version": "0.1.0",
   "private": true,
-  "description": "In-app Remote IM bridge for Grok App (Feishu/Lark × Grok Build ACP). Migrated from agent-connect.",
+  "description": "DEPRECATED reference-only package — Remote IM connectors run in-process in Rust (src-tauri/src/remote_im/). Not built, shipped, or covered by CI; kept as protocol reference.",
   "type": "module",
   "bin": {
     "grok-remote-bridge": "bin/grok-remote-bridge.js"


### PR DESCRIPTION
## Summary
- `remote-bridge/` is kept as a protocol reference, but its `package.json` still described a live in-app bridge
- Nothing told contributors the package is outside the pnpm workspace, outside CI, and has no test coverage
- Strengthens the README notice and package description so fixes land in `src-tauri/src/remote_im/`

#### Test plan
- [x] Docs/metadata only; no code paths touched
- [x] Confirmed nothing in `src-tauri/` or `scripts/` resolves this package at runtime

Generated with [Devin](https://devin.ai)