### PR TITLE
chore(lint): forbid stray console.log in product code

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -140,6 +140,11 @@ export default tseslint.config(
           message: "Use in-app dialogs, never window.prompt.",
         },
       ],
+      // Keep stray console.log out of product code; warn/error/info/debug stay
+      // allowed. scrollPerfDebug.ts opts out per-file (its console report IS
+      // the feature).
+      "no-console": ["error", { allow: ["warn", "error", "info", "debug"] }],
+
       // Historical codebase is large; keep noise low in wave-a+.
       "no-unused-vars": "off",
       "no-undef": "off",

--- a/src/lib/scrollPerfDebug.ts
+++ b/src/lib/scrollPerfDebug.ts
@@ -1,3 +1,5 @@
+/* eslint-disable no-console -- dev-only scroll telemetry; the formatted
+ * console report is the feature, not a leftover debug print. */
 /**
  * Diagnostic telemetry logger for chat transcript scroll performance.
  * Accurately tracks two separate interaction phases:


### PR DESCRIPTION
## Summary
- Enables the no-console rule (allowing warn/error/info/debug) so accidental console.log cannot creep back in
- scrollPerfDebug.ts opts out at file level — its formatted console report is the feature, not a leftover
- Tree was already clean; this codifies the status quo

#### Test plan
- [x] pnpm lint clean

Generated with [Devin](https://devin.ai)
