### PR TITLE
chore(lint): enable react-hooks/rules-of-hooks and fix violations

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -103,7 +103,7 @@ export default tseslint.config(
     rules: {
       // Register hooks plugin so eslint-disable-next-line react-hooks/* is valid;
       // do not enforce exhaustive-deps yet (historical AppWorkbench surface).
-      "react-hooks/rules-of-hooks": "off",
+      "react-hooks/rules-of-hooks": "error",
       "react-hooks/exhaustive-deps": "off",
 
       // Project hard rule: never use native browser dialogs in Tauri UI.

--- a/src/components/Heatmap.tsx
+++ b/src/components/Heatmap.tsx
@@ -636,6 +636,18 @@ export function Heatmap({
     }
   })();
 
+  const selectRange = useCallback(
+    (range: HeatRange | null) => {
+      if (!onSelectRange) return;
+      if (range && heatRangesEqual(selectedRange, range)) {
+        onSelectRange(null);
+      } else {
+        onSelectRange(range);
+      }
+    },
+    [onSelectRange, selectedRange],
+  );
+
   // Full empty (loading / error / no samples) — no invented contribution grid.
   if (emptyState && emptyState.kind !== "range_empty") {
     return (
@@ -681,18 +693,6 @@ export function Heatmap({
   const monthTrail = 16;
   const labelCol = useDayGrid ? LABEL_COL : 0;
   const totalWidth = labelCol + graphWidth + monthTrail;
-
-  const selectRange = useCallback(
-    (range: HeatRange | null) => {
-      if (!onSelectRange) return;
-      if (range && heatRangesEqual(selectedRange, range)) {
-        onSelectRange(null);
-      } else {
-        onSelectRange(range);
-      }
-    },
-    [onSelectRange, selectedRange],
-  );
 
   return (
     <div ref={containerRef} className="gh-heatmap">

--- a/src/components/RemoteImChannelPanel.tsx
+++ b/src/components/RemoteImChannelPanel.tsx
@@ -502,6 +502,22 @@ export function RemoteImChannelPanel({
     };
   }, [scanPhase, scanDeviceCode, channelId, t]);
 
+  const health = useMemo(() => {
+    const filled = new Set(
+      Object.entries(secrets)
+        .filter(([, v]) => v.trim().length > 0)
+        .map(([k]) => k),
+    );
+    return classifyChannelHealth({
+      instance,
+      bridgeRunning,
+      bridgeLinked,
+      secretKeysFilled: filled,
+      // Live form options (e.g. WeCom connect_mode) for honest soft status
+      draftOptions: values,
+    });
+  }, [instance, bridgeRunning, bridgeLinked, secrets, values, channelId]);
+
   if (!schema) {
     return (
       <div className="rim-panel__empty">
@@ -690,22 +706,6 @@ export function RemoteImChannelPanel({
       setScanPhase("idle");
     }
   };
-
-  const health = useMemo(() => {
-    const filled = new Set(
-      Object.entries(secrets)
-        .filter(([, v]) => v.trim().length > 0)
-        .map(([k]) => k),
-    );
-    return classifyChannelHealth({
-      instance,
-      bridgeRunning,
-      bridgeLinked,
-      secretKeysFilled: filled,
-      // Live form options (e.g. WeCom connect_mode) for honest soft status
-      draftOptions: values,
-    });
-  }, [instance, bridgeRunning, bridgeLinked, secrets, values, channelId]);
 
   const statusTone = health.badgeTone;
   const statusLabel = t(health.statusKey);

--- a/src/lib/filePreviewSrc.ts
+++ b/src/lib/filePreviewSrc.ts
@@ -15,7 +15,7 @@ import {
 } from "@/lib/imageSrc";
 
 /** Prefer Range-capable media HTTP for streaming kinds (not HTML). */
-function useMediaHttp(kind: string): boolean {
+function shouldUseMediaHttp(kind: string): boolean {
   return (
     kind === "video" ||
     kind === "audio" ||
@@ -74,7 +74,7 @@ export async function pathToPreviewUrl(
 
   await ensureMediaEndpoint();
 
-  if (!kind || useMediaHttp(kind) || isOfficeKind(kind)) {
+  if (!kind || shouldUseMediaHttp(kind) || isOfficeKind(kind)) {
     const http = localPathToMediaHttpUrl(absolutePath);
     if (http) return http;
   }


### PR DESCRIPTION
## Summary
- Enables `react-hooks/rules-of-hooks` — previously off, so hook-order bugs went uncaught
- **Heatmap**: `useCallback` sat below empty-state early returns; hoisted above them so hook order is stable across prop changes
- **RemoteImChannelPanel**: `useMemo` for channel health sat below `!schema` early returns; hoisted (its deps are all defined earlier)
- **filePreviewSrc**: `useMediaHttp` was a pure predicate with a misleading `use` prefix; renamed to `shouldUseMediaHttp`

#### Test plan
- [x] `pnpm lint` clean
- [x] `pnpm typecheck` clean
- [x] `vitest` filePreviewSrc suite passes

Generated with [Devin](https://devin.ai)
