### PR TITLE
fix(ui): drop duplicate quota card in single-account user menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ See `docs/llm-wiki/release.md`.
 - 输入框上的分支 chip 可在当前目录切换 git 分支。仅远程存在的分支会建本地跟踪分支；已在其他 worktree 检出的则切到那个 worktree。
 
 ### Fixed
+- The account menu no longer repeats the quota card when only one official account is saved.
 - Saving project rules no longer kills another chat's background agent mid-turn.
 - Trusted-project chats no longer reuse a prewarm process that skipped folder trust.
 - Switching git branches is blocked while an agent turn is still running in that folder.
@@ -46,6 +47,7 @@ See `docs/llm-wiki/release.md`.
 - Local video details now use the file's measured dimensions and duration.
 
 **中文 · 修复**
+- 仅一个官方账号时，用户菜单不再重复显示额度卡片。
 - 保存项目规则时，不再打断同项目另一聊天后台进行中的 agent 回合。
 - 已信任项目不会复用未带文件夹信任的预热进程，AGENTS.md 可正确加载。
 - 同文件夹仍有 agent 回合在跑时，禁止切换 git 分支。

--- a/src/components/UserMenu.test.tsx
+++ b/src/components/UserMenu.test.tsx
@@ -248,3 +248,56 @@ it("lists saved official accounts with remaining quota and switches on click", a
   fireEvent.click(screen.getByRole("menuitem", { name: "Alice, Active" }));
   expect(onAccountSettings).toHaveBeenCalled();
 });
+
+it("hides the single-account row when the top quota card is already shown", async () => {
+  const account = {
+    profile: {
+      signedIn: true,
+      name: "Alice",
+      email: "alice@x.ai",
+      userId: "u1",
+    },
+    channel: "official_oauth" as const,
+    billing: null,
+  };
+  render(
+    <UserMenu
+      open
+      onClose={() => undefined}
+      theme="dark"
+      themePreference="dark"
+      labels={{ ...labels, remaining: "remaining" }}
+      account={account as never}
+      activeProvider={null}
+      accountBusy={false}
+      officialQuota={{
+        plan: "Pro",
+        resetText: null,
+        remainLabel: "25%",
+        usedPercent: 75,
+        barFillClass: "",
+      }}
+      savedAccounts={[
+        {
+          id: "a1",
+          email: "alice@x.ai",
+          displayName: "Alice",
+          label: "Alice",
+          updatedAt: "",
+        },
+      ]}
+      activeAccountId="a1"
+      onTheme={() => undefined}
+      onLogin={() => undefined}
+      onLogout={() => undefined}
+    >
+      <button type="button">Account</button>
+    </UserMenu>,
+  );
+
+  await waitFor(() =>
+    expect(screen.getByTestId("user-menu-quota")).toBeTruthy(),
+  );
+  expect(screen.queryByTestId("user-menu-accounts")).toBeNull();
+  expect(screen.getByTestId("user-menu-quota").textContent).toContain("25%");
+});

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -281,7 +281,13 @@ export function UserMenu({
   const signedIn = !isCustomProvider && !!account?.profile?.signedIn;
   const profile = account?.profile ?? null;
   const livePercents = resolveQuotaPercents(account?.billing ?? null);
-  const showSavedOfficialAccounts = signedIn && savedAccounts.length > 0;
+  // Top officialQuota card already shows the active remain %. With a single
+  // saved account the account row is the same card again — hide it. Keep the
+  // list when there are 2+ accounts to switch, or when the top card is absent.
+  const showSavedOfficialAccounts =
+    signedIn &&
+    savedAccounts.length > 0 &&
+    (savedAccounts.length > 1 || !officialQuota);
   const remainingWord = labels.remaining ?? "remaining";
   const profileActiveLabel = labels.profileActive ?? "Active";
   const switchToLabel = labels.switchTo ?? "Switch to this account";


### PR DESCRIPTION
## Summary
- With one saved official account, the upward user menu already shows the top SuperGrok quota card (and the footer chip shows remain %). The middle account row repeated the same card — remove it.
- Keep the accounts list when there are 2+ saved accounts (or when the top quota card is absent).

## Test plan
- [x] `pnpm exec vitest run src/components/UserMenu.test.tsx src/app/WorkbenchSidebar.footer.test.tsx`
- [ ] Manual: one official account → open footer menu → only one quota card at top, no duplicate account row
- [ ] Manual: two+ accounts → list still appears for switching