### PR TITLE
chore(rust): narrow file-level #![allow(dead_code)] to item-level

### DIFF
--- a/src-tauri/src/account.rs
+++ b/src-tauri/src/account.rs
@@ -4,7 +4,6 @@
 //! Billing is best-effort HTTP (same field shape as CLI `/usage` / billing extension).
 //! Heatmap + call logs are derived from local CLI session signals (and optional app journal).
 
-#![allow(dead_code)] // residual-clippy: billing helpers not yet wired in UI path
 use std::collections::{BTreeMap, HashSet};
 use std::fs;
 use std::io::{BufRead, BufReader};
@@ -36,6 +35,7 @@ pub(crate) use build_oauth::{
 pub struct LoginProcState {
     cancel: tokio::sync::Notify,
     /// Guard: only one login may run at a time.
+    #[allow(dead_code)]
     busy: tokio::sync::Mutex<bool>,
     /// Live child stdin while `account_login` is in flight (for paste-back codes).
     stdin: tokio::sync::Mutex<Option<tokio::process::ChildStdin>>,
@@ -103,6 +103,7 @@ pub async fn account_login_submit_code(code: &str) -> Result<(), String> {
 }
 use crate::store;
 
+#[allow(dead_code)]
 const BILLING_CANDIDATES: &[&str] = &[
     // Confirmed live endpoint used by Grok Build CLI billing extension.
     "https://cli-chat-proxy.grok.com/v1/billing?format=credits",
@@ -686,6 +687,7 @@ fn save_billing_cache(b: &BillingSnapshot) {
 }
 
 /// Parse number or `{ "val": N }` money wrappers used by cli-chat-proxy billing.
+#[allow(dead_code)]
 fn json_number(v: Option<&Value>) -> Option<f64> {
     let v = v?;
     if let Some(n) = v.as_f64() {
@@ -709,6 +711,7 @@ fn json_number(v: Option<&Value>) -> Option<f64> {
     None
 }
 
+#[allow(dead_code)]
 fn parse_billing_json(v: &Value) -> BillingSnapshot {
     // Nested under data / credits / config (cli-chat-proxy uses `config`).
     let root = if v.get("creditUsagePercent").is_some() || v.get("monthlyLimit").is_some() {
@@ -1059,6 +1062,7 @@ async fn fetch_subscription_meta(token: &str) -> SubscriptionMeta {
     meta
 }
 
+#[allow(dead_code)]
 async fn fetch_billing_remote(token: &str) -> BillingSnapshot {
     let client = match crate::proxy::apply_to_reqwest(reqwest::Client::builder())
         .timeout(Duration::from_secs(10))
@@ -2011,6 +2015,7 @@ pub async fn open_subscribe() -> Result<(), String> {
 }
 
 /// Open a URL in the system browser (also used after device-code login).
+#[allow(dead_code)]
 pub fn open_browser_url(url: &str) -> Result<(), String> {
     open_url(url)
 }

--- a/src-tauri/src/acp_client.rs
+++ b/src-tauri/src/acp_client.rs
@@ -1,7 +1,6 @@
 //! Real ACP client: spawn `grok agent stdio`, JSON-RPC line framing.
 //! Default production transport. Mock only when GROK_APP_ACP=mock.
 
-#![allow(dead_code)] // residual-clippy: spawn-flag helpers and unused field reads kept for protocol parity
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::process::Stdio;
@@ -61,6 +60,7 @@ pub enum AcpEvent {
         rpc_id: u64,
         tool_call_id: Option<String>,
         questions: Vec<AskUserQuestionItem>,
+        #[allow(dead_code)]
         raw: Value,
     },
     PermissionRequest {
@@ -352,6 +352,7 @@ pub struct AcpClient {
     pending: ParkingMutex<HashMap<u64, Pending>>,
     event_tx: mpsc::UnboundedSender<(Option<String>, AcpEvent)>,
     agent_session_id: ParkingMutex<Option<String>>,
+    #[allow(dead_code)]
     cli_path: PathBuf,
     cwd: PathBuf,
     stopped: AtomicBool,
@@ -449,6 +450,7 @@ impl AcpClient {
             .unwrap_or(false)
     }
 
+    #[allow(dead_code)]
     pub async fn spawn(
         cli_path: PathBuf,
         cwd: PathBuf,
@@ -2548,6 +2550,7 @@ impl AcpClient {
     }
 
     /// Back-compat: always create a new session.
+    #[allow(dead_code)]
     pub async fn initialize_and_new_session(&self) -> Result<String, AgentError> {
         self.initialize_and_open_session(None, false)
             .await
@@ -2773,6 +2776,7 @@ impl AcpClient {
     /// - Older / reverse-RPC style: `_x.ai/interject`
     ///
     /// Interject into the most recently bound agent session.
+    #[allow(dead_code)]
     pub async fn interject(&self, text: &str) -> Result<(), String> {
         let sid = self
             .agent_session_id
@@ -2853,6 +2857,7 @@ impl AcpClient {
     }
 
     /// List rewind points (one per user prompt). Grok extension `x.ai/rewind/points`.
+    #[allow(dead_code)]
     pub async fn rewind_points(&self) -> Result<Value, String> {
         let sid = self
             .agent_session_id
@@ -2863,6 +2868,7 @@ impl AcpClient {
     }
 
     /// List rewind points on an explicit session (shared-process safe).
+    #[allow(dead_code)]
     pub async fn rewind_points_for(&self, session_id: &str) -> Result<Value, String> {
         self.request("x.ai/rewind/points", json!({ "sessionId": session_id }))
             .await
@@ -2875,6 +2881,7 @@ impl AcpClient {
     /// For "edit last user message", pass the **previous** user-turn index, or when
     /// editing the only user message use index `0` with a full clear via host journal.
     /// Truncate agent conversation on the most recently bound session.
+    #[allow(dead_code)]
     pub async fn rewind_execute(
         &self,
         target_prompt_index: u32,
@@ -3002,6 +3009,7 @@ impl AcpClient {
         self.write_line(&msg).await
     }
 
+    #[allow(dead_code)]
     pub fn agent_session_id(&self) -> Option<String> {
         self.agent_session_id.lock().clone()
     }
@@ -5098,6 +5106,7 @@ pub fn is_hard_transport_retry_reason(reason: &str) -> bool {
 /// - Bare `failed` / `error` only abort once we have used most of the budget —
 ///   some relays emit `failed` on a single stream blip while still retrying.
 /// - Otherwise abort when `attempt` reaches the host/agent cap.
+#[allow(dead_code)]
 pub fn should_abort_provider_retry(attempt: u32, max_retries: u32, status: &str) -> bool {
     should_abort_provider_retry_ex(attempt, max_retries, status, "")
 }

--- a/src-tauri/src/acp_client/spawn_flags.rs
+++ b/src-tauri/src/acp_client/spawn_flags.rs
@@ -10,6 +10,7 @@ use tokio::process::Command;
 /// `["--fork-session"]` when enabled; empty otherwise. The TUI requires this
 /// with `--resume`/`--continue`. Host `agent stdio` uses ACP `session/fork`
 /// instead of bare CLI flags (CLI errors without resume).
+#[allow(dead_code)]
 pub fn fork_session_spawn_flags(enabled: bool) -> Vec<&'static str> {
     if enabled {
         vec!["--fork-session"]
@@ -229,12 +230,14 @@ pub fn should_apply_sandbox(raw_cli_version: Option<&str>) -> bool {
 }
 
 /// Pure helper used by spawn + unit tests: args + env when sandbox is on.
+#[allow(dead_code)]
 pub fn sandbox_spawn_flags(profile: &str) -> Option<(Vec<String>, (String, String))> {
     let spec = SandboxSpawnSpec::from_setting(profile)?;
     Some((spec.cli_args().to_vec(), spec.env_pair()))
 }
 
 /// Soft-fail variant: omit when CLI is known older than {@link SANDBOX_MIN_CLI}.
+#[allow(dead_code)]
 pub fn sandbox_spawn_flags_soft(
     profile: &str,
     raw_cli_version: Option<&str>,
@@ -374,6 +377,7 @@ pub fn resolve_max_agent_turns(session: Option<u32>, global: Option<u32>) -> Opt
     normalize_max_agent_turns(session).or_else(|| normalize_max_agent_turns(global))
 }
 
+#[allow(dead_code)]
 pub fn max_turns_cli_args(raw: Option<u32>) -> Option<Vec<String>> {
     let spec = MaxTurnsSpawnSpec::from_setting(raw)?;
     Some(spec.cli_args().to_vec())
@@ -495,6 +499,7 @@ pub const HEADLESS_FORMAT_STREAMING_MESSAGES_JSON: &str = "streaming-messages-js
 pub const HEADLESS_FORMAT_STREAMING_JSON: &str = "streaming-json";
 
 /// True when format is `streaming-messages-json` (aliases normalized).
+#[allow(dead_code)]
 pub fn is_streaming_messages_json_format(format: &str) -> bool {
     let s = format.trim().to_ascii_lowercase().replace('_', "-");
     matches!(
@@ -505,6 +510,7 @@ pub fn is_streaming_messages_json_format(format: &str) -> bool {
 
 /// Top-level CLI flags for `--include-partial-messages`.
 /// Empty unless `enabled` **and** format is `streaming-messages-json`.
+#[allow(dead_code)]
 pub fn include_partial_messages_spawn_flags(
     enabled: bool,
     output_format: &str,
@@ -528,6 +534,7 @@ pub fn cli_supports_include_partial_messages(raw_version: &str) -> Option<bool> 
 /// - Known ≥ 0.2.117 + enabled + streaming-messages-json → flag
 /// - Known older / unknown → omit (avoid clap crash)
 /// - Disabled or wrong format → empty always
+#[allow(dead_code)]
 pub fn include_partial_messages_spawn_flags_soft(
     enabled: bool,
     output_format: &str,
@@ -703,11 +710,13 @@ impl AgentSpawnSpec {
     }
 }
 
+#[allow(dead_code)]
 pub fn preferred_agent_spawn_flags(raw: &str) -> Option<Vec<String>> {
     crate::agents_catalog::agent_spawn_cli_args(raw)
 }
 
 /// Pure: agent-option `["--agent-profile", path]` when Settings path is set.
+#[allow(dead_code)]
 pub fn agent_profile_spawn_flags(raw: &str) -> Option<Vec<String>> {
     crate::agents_catalog::agent_profile_spawn_cli_args(raw)
 }

--- a/src-tauri/src/agent_auto_wake.rs
+++ b/src-tauri/src/agent_auto_wake.rs
@@ -11,7 +11,6 @@
 //!
 //! Soft-respawn after a settings flip so the next agent process reloads.
 
-#![allow(dead_code)] // residual-clippy: normalize_enabled
 use serde_json::{json, Value};
 
 use crate::agent_home_config::{
@@ -22,6 +21,7 @@ pub const CONFIG_KEY: &str = "auto_wake_enabled";
 pub const GROK_CONFIG_ENV: &str = "GROK_CONFIG";
 
 /// Normalize enable toggle (App default off / opt-in).
+#[allow(dead_code)]
 pub fn normalize_enabled(raw: bool) -> bool {
     raw
 }

--- a/src-tauri/src/agent_home_config.rs
+++ b/src-tauri/src/agent_home_config.rs
@@ -13,7 +13,6 @@
 //! - [`ensure_agent_home_config_sane`] dedupes broken files only; valid configs are
 //!   never rewritten.
 
-#![allow(dead_code)] // residual-clippy: generic toml get/set helpers
 use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
@@ -169,6 +168,7 @@ pub fn set_top_level_bool(text: &str, key: &str, value: bool) -> String {
 }
 
 /// Upsert top-level `key = "value"` (quoted string).
+#[allow(dead_code)]
 pub fn set_top_level_string(text: &str, key: &str, value: &str) -> String {
     let escaped = value.replace('\\', "\\\\").replace('"', "\\\"");
     set_top_level_assignment(text, key, &format!("\"{escaped}\""))
@@ -304,6 +304,7 @@ fn value_for_key_in_scope<'a>(text: &'a str, table: Option<&str>, key: &str) -> 
 }
 
 /// Read top-level bool when present.
+#[allow(dead_code)]
 pub fn get_top_level_bool(text: &str, key: &str) -> Option<bool> {
     value_for_key_in_scope(text, None, key).and_then(parse_toml_bool)
 }
@@ -314,6 +315,7 @@ pub fn get_table_bool(text: &str, table: &str, key: &str) -> Option<bool> {
 }
 
 /// Read top-level string / scalar when present.
+#[allow(dead_code)]
 pub fn get_top_level_string(text: &str, key: &str) -> Option<String> {
     value_for_key_in_scope(text, None, key)
         .map(parse_toml_scalar)

--- a/src-tauri/src/agent_memory.rs
+++ b/src-tauri/src/agent_memory.rs
@@ -3,7 +3,6 @@
 //! CLI: `--experimental-memory` / `--no-memory`, `GROK_MEMORY`, `[memory] enabled`,
 //! `grok memory clear`.
 
-#![allow(dead_code)] // residual-clippy: search helpers
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -32,6 +31,7 @@ pub fn memory_spawn_env_value(enabled: bool) -> &'static str {
 }
 
 /// When off, always force-disable so config cannot leak memory on.
+#[allow(dead_code)]
 pub fn should_force_disable_memory(experimental_memory: bool) -> bool {
     !experimental_memory
 }
@@ -994,6 +994,7 @@ fn search_file_content(path: &Path, query_lower: &str, query_len: usize) -> Opti
 /// Always a keyword / file-body scan — never invents embeddings. When
 /// `embedding_configured` is true but no host hybrid CLI exists, `search_kind`
 /// is `hybrid_unavailable` (honest soft-fail).
+#[allow(dead_code)]
 pub fn search_workspace_memory(
     query: &str,
     cwd: Option<&Path>,

--- a/src-tauri/src/agent_subagent_wt_snap.rs
+++ b/src-tauri/src/agent_subagent_wt_snap.rs
@@ -8,7 +8,6 @@
 //! No dedicated CLI flag. Shared mode never rewrites `~/.grok/config.toml`.
 //! Soft-fail older CLIs: omit env when version is known &lt; 0.2.117.
 
-#![allow(dead_code)] // residual-clippy: normalize_enabled
 use crate::agent_home_config::{set_top_level_bool, update_config_toml_if_independent};
 
 /// First CLI that accepts the config / env surface.
@@ -18,6 +17,7 @@ pub const CONFIG_KEY: &str = "subagent_worktree_snapshot_enabled";
 pub const ENV_KEY: &str = "GROK_SUBAGENT_WORKTREE_SNAPSHOT";
 
 /// Normalize enable toggle (App default off).
+#[allow(dead_code)]
 pub fn normalize_enabled(raw: bool) -> bool {
     raw
 }

--- a/src-tauri/src/agent_subagents.rs
+++ b/src-tauri/src/agent_subagents.rs
@@ -3,7 +3,6 @@
 //! CLI: `--no-subagents`, `GROK_SUBAGENTS`, `[subagents] enabled`.
 //! Enabled by default; when App setting is off, force-disable at spawn.
 
-#![allow(dead_code)] // residual-clippy: force disable helper
 use crate::agent_home_config::{set_table_bool, update_config_toml_if_independent};
 
 /// Top-level CLI flags (before `agent`) for the subagents_enabled setting.
@@ -26,6 +25,7 @@ pub fn subagents_spawn_env_value(enabled: bool) -> Option<&'static str> {
 }
 
 /// When off, always force-disable so config cannot re-enable subagents.
+#[allow(dead_code)]
 pub fn should_force_disable_subagents(subagents_enabled: bool) -> bool {
     !subagents_enabled
 }

--- a/src-tauri/src/agent_two_pass_compaction.rs
+++ b/src-tauri/src/agent_two_pass_compaction.rs
@@ -8,7 +8,6 @@
 //! No dedicated CLI flag. Shared mode never rewrites `~/.grok/config.toml`.
 //! Soft-fail older CLIs: omit env when version is known &lt; 0.2.117.
 
-#![allow(dead_code)] // residual-clippy: normalize_enabled
 use crate::agent_home_config::{set_top_level_bool, update_config_toml_if_independent};
 
 /// First CLI that accepts the config / env surface.
@@ -18,6 +17,7 @@ pub const CONFIG_KEY: &str = "two_pass_compaction_enabled";
 pub const ENV_KEY: &str = "GROK_TWO_PASS_COMPACTION";
 
 /// Normalize enable toggle (App default off).
+#[allow(dead_code)]
 pub fn normalize_enabled(raw: bool) -> bool {
     raw
 }

--- a/src-tauri/src/agent_workflows.rs
+++ b/src-tauri/src/agent_workflows.rs
@@ -17,7 +17,6 @@
 //!
 //! No visual workflow editor. Shared mode never rewrites `~/.grok/config.toml`.
 
-#![allow(dead_code)] // residual-clippy: normalize_enabled
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
@@ -34,6 +33,7 @@ use crate::store;
 pub const CONFIG_KEY: &str = "workflows_enabled";
 
 /// Normalize enable toggle (App default off).
+#[allow(dead_code)]
 pub fn normalize_enabled(raw: bool) -> bool {
     raw
 }
@@ -553,12 +553,14 @@ fn prepare_log(stdout: &str, stderr: &str) -> (Option<String>, bool) {
     }
 }
 
+#[allow(dead_code)]
 enum ThreadWait<T> {
     Done(T),
     TimedOut,
     JoinErr,
 }
 
+#[allow(dead_code)]
 fn wait_thread<T: Send + 'static>(
     handle: std::thread::JoinHandle<T>,
     timeout: Duration,
@@ -589,6 +591,7 @@ pub const WORKFLOW_RUN_PROGRESS_EVENT: &str = "workflows://run-progress";
 ///
 /// When `app` is provided, emits line-level progress on
 /// [`WORKFLOW_RUN_PROGRESS_EVENT`] so Settings can show a live log.
+#[allow(dead_code)]
 pub fn run_workflow(
     name: &str,
     project_path: Option<&str>,

--- a/src-tauri/src/agents_catalog.rs
+++ b/src-tauri/src/agents_catalog.rs
@@ -9,7 +9,6 @@
 //! Scaffold: create a SKILL-like `{Name}.md` under the active agent home or
 //! project `.grok/agents` (path-scoped; no overwrite unless `force`).
 
-#![allow(dead_code)] // residual-clippy: spawn cli arg helpers
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -69,6 +68,7 @@ pub fn normalize_preferred_agent(raw: &str) -> Option<String> {
 }
 
 /// Pure: top-level CLI args `["--agent", name]` when set.
+#[allow(dead_code)]
 pub fn agent_spawn_cli_args(raw: &str) -> Option<Vec<String>> {
     let name = normalize_preferred_agent(raw)?;
     Some(vec!["--agent".into(), name])
@@ -90,6 +90,7 @@ pub fn normalize_agent_profile_path(raw: &str) -> Option<String> {
 
 /// Pure: agent-option CLI args `["--agent-profile", path]` when set.
 /// Placement: after `grok agent` and before `stdio` (not top-level).
+#[allow(dead_code)]
 pub fn agent_profile_spawn_cli_args(raw: &str) -> Option<Vec<String>> {
     let path = normalize_agent_profile_path(raw)?;
     Some(vec!["--agent-profile".into(), path])

--- a/src-tauri/src/audit_ledger.rs
+++ b/src-tauri/src/audit_ledger.rs
@@ -6,7 +6,6 @@
 //! retention (7 / 30 / 90 / unlimited) prunes on write, rotate, or explicit
 //! prune. Export can filter by event, session, and date range.
 
-#![allow(dead_code)] // residual-clippy: retention/export helpers
 use std::fs::{self, File, OpenOptions};
 use std::io::{BufRead, BufReader, Write};
 use std::path::PathBuf;
@@ -32,6 +31,7 @@ pub const RETENTION_UNLIMITED: u32 = 0;
 pub const RETENTION_7: u32 = 7;
 pub const RETENTION_30: u32 = 30;
 pub const RETENTION_90: u32 = 90;
+#[allow(dead_code)]
 pub const RETENTION_PRESETS: [u32; 4] =
     [RETENTION_7, RETENTION_30, RETENTION_90, RETENTION_UNLIMITED];
 
@@ -129,6 +129,7 @@ pub fn entry_ts_ms(entry: &AuditLedgerEntry) -> Option<i64> {
 
 /// Pure: keep entries within retention window. Unlimited (`0`) keeps all.
 /// Unparseable timestamps are kept (never drop opaque rows on time alone).
+#[allow(dead_code)]
 pub fn filter_by_retention(
     entries: Vec<AuditLedgerEntry>,
     retention_days: u32,
@@ -741,6 +742,7 @@ pub fn clear_ledger() -> Result<(), String> {
 }
 
 /// Export redacted JSONL text (file order = chronological). Soft-fail → empty string.
+#[allow(dead_code)]
 pub fn export_redacted_jsonl() -> String {
     export_redacted_jsonl_filtered(&AuditLedgerFilter::default())
 }

--- a/src-tauri/src/cli_sessions.rs
+++ b/src-tauri/src/cli_sessions.rs
@@ -5,7 +5,6 @@
 //!   - summary.json — title, timestamps, cwd
 //!   - chat_history.jsonl — line-delimited messages
 
-#![allow(dead_code)] // residual-clippy: pick_latest helper
 use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -90,6 +89,7 @@ struct SummaryFile {
 #[derive(Debug, Deserialize)]
 struct SummaryInfo {
     #[serde(default)]
+    #[allow(dead_code)]
     id: Option<String>,
     #[serde(default)]
     cwd: Option<String>,
@@ -240,6 +240,7 @@ fn ensure_untrusted_project_for_cwd(cwd: &str) {
 /// Pick the newest session among rows whose `cwd` matches `project_path` (pure).
 ///
 /// Compares `updated_at` lexicographically (RFC3339-friendly).
+#[allow(dead_code)]
 pub fn pick_latest_session_for_cwd<'a, T>(
     rows: &'a [T],
     project_path: &str,
@@ -1518,6 +1519,7 @@ fn load_tool_names_from_events(events_path: &std::path::Path) -> HashMap<String,
 struct ToolCallRecord {
     name: String,
     label: String,
+    #[allow(dead_code)]
     kind: String,
     input: Option<String>,
 }

--- a/src-tauri/src/extensions.rs
+++ b/src-tauri/src/extensions.rs
@@ -5,7 +5,6 @@
 //! `session/new` / `session/load`. Independent mode also mirrors `enabled`
 //! flags into agent-home `config.toml`.
 
-#![allow(dead_code)] // residual-clippy: enable-map merge helpers
 use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -126,6 +125,7 @@ pub fn enable_all(map: &mut HashMap<String, bool>, names: &[String]) {
 }
 
 /// Merge overlay flags into base (overlay wins). Pure helper for tests.
+#[allow(dead_code)]
 pub fn merge_enable_maps(
     base: &HashMap<String, bool>,
     overlay: &HashMap<String, bool>,
@@ -151,6 +151,7 @@ pub fn filter_enabled_mcp<'a>(
 }
 
 /// Filter skill names by App prefs (default-on).
+#[allow(dead_code)]
 pub fn filter_enabled_skill_names(names: &[String], prefs: &ExtensionsPrefs) -> Vec<String> {
     names
         .iter()
@@ -234,6 +235,7 @@ fn env_map_to_named_array(map: Option<&HashMap<String, String>>) -> Vec<Value> {
 ///
 /// Prefer [`build_acp_mcp_servers_with_opts`] on the connect path with
 /// [`McpInjectOptions::for_connect`] so OAuth network work cannot block ACP.
+#[allow(dead_code)]
 pub fn build_acp_mcp_servers(defs: &[McpServerDef], prefs: &ExtensionsPrefs) -> Value {
     build_acp_mcp_servers_with_opts(defs, prefs, McpInjectOptions::default())
 }

--- a/src-tauri/src/fs_browser.rs
+++ b/src-tauri/src/fs_browser.rs
@@ -1,7 +1,6 @@
 //! Project-scoped filesystem browser for the right-pane resource viewer.
 //! All paths are resolved under an explicit project root (no escape).
 
-#![allow(dead_code)] // Legacy Office text-extraction helpers remain available.
 use serde::Serialize;
 use std::fs;
 use std::io::Read;
@@ -239,6 +238,7 @@ fn mime_of(ext: &str, kind: &str) -> String {
 }
 
 /// Strip XML tags and decode a few common entities for OOXML / ODF preview text.
+#[allow(dead_code)]
 fn xml_to_plain(xml: &str) -> String {
     let mut out = String::with_capacity(xml.len() / 4);
     let mut in_tag = false;
@@ -303,6 +303,7 @@ fn xml_to_plain(xml: &str) -> String {
     cleaned.trim().to_string()
 }
 
+#[allow(dead_code)]
 fn decode_entity(s: &str) -> Option<(&'static str, usize)> {
     if s.starts_with("amp;") {
         Some(("&", 4))
@@ -321,6 +322,7 @@ fn decode_entity(s: &str) -> Option<(&'static str, usize)> {
     }
 }
 
+#[allow(dead_code)]
 fn read_zip_entry_text(path: &Path, entry_name: &str) -> Result<String, String> {
     let file = fs::File::open(path).map_err(|e| format!("open zip: {e}"))?;
     let mut archive = zip::ZipArchive::new(file).map_err(|e| format!("zip: {e}"))?;
@@ -334,6 +336,7 @@ fn read_zip_entry_text(path: &Path, entry_name: &str) -> Result<String, String> 
     Ok(buf)
 }
 
+#[allow(dead_code)]
 fn read_zip_entries_matching(
     path: &Path,
     prefix: &str,
@@ -364,6 +367,7 @@ fn read_zip_entries_matching(
 }
 
 /// Extract plain text from Office Open XML / ODF packages.
+#[allow(dead_code)]
 fn extract_office_text(path: &Path, kind: &str) -> Result<String, String> {
     match kind {
         "docx" => {

--- a/src-tauri/src/hooks.rs
+++ b/src-tauri/src/hooks.rs
@@ -3,7 +3,6 @@
 //! Management is list / reveal / open-folder only — no visual JSON editor.
 //! Hook file format lives in the Grok Build user guide (`10-hooks.md`).
 
-#![allow(dead_code)] // residual-clippy: join_hooks_path helper
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::UNIX_EPOCH;
@@ -73,6 +72,7 @@ pub fn hooks_docs_path() -> PathBuf {
 
 /// Join a hooks directory with a relative file name (pure; no FS access).
 /// Rejects empty names, absolute paths, and parent-directory traversal.
+#[allow(dead_code)]
 pub fn join_hooks_path(dir: &Path, name: &str) -> Option<PathBuf> {
     let n = name.trim();
     if n.is_empty() || n == "." || n == ".." {

--- a/src-tauri/src/journal_throttle.rs
+++ b/src-tauri/src/journal_throttle.rs
@@ -4,7 +4,6 @@
 //! token. Flush at most every [`DEFAULT_JOURNAL_FLUSH_MS`], on paragraph
 //! boundaries, or when forced (turn end / stop / disconnect).
 
-#![allow(dead_code)] // residual-clippy: accessor methods
 use std::time::{Duration, Instant};
 
 /// Spec default: ≥500ms between mid-stream journal flushes.
@@ -66,10 +65,12 @@ impl JournalWriteThrottle {
         Self::new(DEFAULT_JOURNAL_FLUSH_MS)
     }
 
+    #[allow(dead_code)]
     pub fn min_interval(&self) -> Duration {
         self.min_interval
     }
 
+    #[allow(dead_code)]
     pub fn last_flush(&self) -> Option<Instant> {
         self.last_flush
     }

--- a/src-tauri/src/leader.rs
+++ b/src-tauri/src/leader.rs
@@ -8,7 +8,6 @@
 //! The app may spawn a background leader and track its PID for stop; externally
 //! started leaders are still visible via socket probe + `leader list`.
 
-#![allow(dead_code)] // residual-clippy: mask_secret
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::Mutex;
@@ -128,6 +127,7 @@ pub fn path_age_secs(path: &Path, now: SystemTime) -> Option<u64> {
 }
 
 /// Mask secrets / tokens for UI display (never show full serve secret).
+#[allow(dead_code)]
 pub fn mask_secret(value: &str) -> String {
     let t = value.trim();
     if t.is_empty() {

--- a/src-tauri/src/logging.rs
+++ b/src-tauri/src/logging.rs
@@ -6,7 +6,6 @@
 //! Panic messages are written **synchronously** (in addition to the non-blocking
 //! file sink) so `abort()` after a Rust panic still leaves a diagnostic trail.
 
-#![allow(dead_code)] // residual-clippy: logs_dir helper
 use std::io::Write;
 use std::path::PathBuf;
 use std::sync::OnceLock;

--- a/src-tauri/src/media_server.rs
+++ b/src-tauri/src/media_server.rs
@@ -13,7 +13,6 @@
 //! GET http://127.0.0.1:{port}/v1/media?t={token}&p={urlencode(abs_path)}
 //! ```
 
-#![allow(dead_code)] // residual-clippy: url helper variants
 use std::io::{Read, Seek, SeekFrom};
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
@@ -191,6 +190,7 @@ pub async fn start() -> Result<MediaServerHandle, String> {
 }
 
 /// Build a viewable URL for an absolute path (used by tests / optional host helpers).
+#[allow(dead_code)]
 pub fn url_for_path(endpoint: &MediaServerEndpoint, abs_path: &str) -> String {
     format!(
         "{}/v1/media?t={}&p={}",
@@ -287,6 +287,7 @@ fn base64_url_encode(bytes: &[u8]) -> String {
 }
 
 /// Minimal encodeURIComponent-compatible encoder for query values.
+#[allow(dead_code)]
 fn urlencoding_encode(s: &str) -> String {
     let mut out = String::with_capacity(s.len() * 3);
     for b in s.as_bytes() {
@@ -304,6 +305,7 @@ fn urlencoding_encode(s: &str) -> String {
     out
 }
 
+#[allow(dead_code)]
 const HEX: &[u8; 16] = b"0123456789ABCDEF";
 
 async fn health() -> impl IntoResponse {

--- a/src-tauri/src/mirror/tunnel.rs
+++ b/src-tauri/src/mirror/tunnel.rs
@@ -5,7 +5,6 @@
 //! Stop tears down the process group and any managed container so no orphan
 //! tunnel keeps the mirror reachable (REQUIREMENT known pitfall).
 
-#![allow(dead_code)] // residual-clippy: public_url field/method
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -172,10 +171,12 @@ pub struct TunnelHandle {
     pgid: Option<i32>,
     adapter_name: &'static str,
     docker_cleanup: Option<DockerCleanup>,
+    #[allow(dead_code)]
     pub public_url: String,
 }
 
 impl TunnelHandle {
+    #[allow(dead_code)]
     pub fn public_url(&self) -> &str {
         &self.public_url
     }

--- a/src-tauri/src/models_aux.rs
+++ b/src-tauri/src/models_aux.rs
@@ -6,7 +6,6 @@
 //! **Safety:** only touches those four keys under `[models]`. Never mutates
 //! `[models].default`, never activates provider routes, never rewrites auth.json.
 
-#![allow(dead_code)] // residual-clippy: prompt-rewrite / spawn-env helpers retained for routing experiments
 use serde::{Deserialize, Serialize};
 
 use crate::agent_home_config::{
@@ -220,6 +219,7 @@ pub fn apply_all_slots(text: &str, model_id: &str) -> String {
 }
 
 /// Ensure `[model.<id>]` has `api_key` when non-empty (does not touch other fields).
+#[allow(dead_code)]
 pub fn ensure_model_api_key(text: &str, model_id: &str, api_key: &str) -> String {
     let id = model_id.trim();
     let key = api_key.trim();
@@ -798,6 +798,7 @@ fn strip_inline_image_at_refs(line: &str) -> (String, Vec<String>) {
 /// across custom relays; Host describes images instead).
 ///
 /// `vision_aux_ok` only changes the fallback note text (legacy param kept for tests).
+#[allow(dead_code)]
 pub fn rewrite_prompt_guard_text_only(
     prompt: &str,
     text_only_main: bool,
@@ -827,6 +828,7 @@ pub fn rewrite_prompt_guard_text_only(
 
 /// Live config: rewrite agent prompt when needed. Never touches journal UI text.
 /// Prefer [`prepare_agent_prompt_for_main`] which also Host-describes images.
+#[allow(dead_code)]
 pub fn maybe_rewrite_agent_prompt(prompt: &str) -> String {
     let text = read_config_text();
     let list = match list_custom_providers() {
@@ -842,6 +844,7 @@ pub fn maybe_rewrite_agent_prompt(prompt: &str) -> String {
 ///
 /// Keys match Grok Build: `GROK_WEB_SEARCH_MODEL`, `GROK_IMAGE_DESCRIPTION_MODEL`,
 /// `GROK_SESSION_SUMMARY_MODEL`, `GROK_PROMPT_SUGGESTIONS_MODEL`.
+#[allow(dead_code)]
 pub fn aux_model_spawn_env() -> Vec<(String, String)> {
     let text = read_config_text();
     let pairs = [
@@ -1200,10 +1203,12 @@ pub fn host_vision_will_run(prompt: &str) -> bool {
 pub struct HostVisionPrep {
     pub prompt: String,
     /// Whether we attempted host vision (images present on text-only main).
+    #[allow(dead_code)]
     pub ran: bool,
     /// True if at least one description succeeded (official or HTTP).
     pub ok: bool,
     /// Short status for logs / legacy chips.
+    #[allow(dead_code)]
     pub detail: String,
     /// Full description text for journal / expandable tool body (may be long).
     pub description: String,
@@ -1214,6 +1219,7 @@ pub struct HostVisionPrep {
 /// - Host describes images: **prefer official ACP**, else `grok -p`, else Amux HTTP
 ///
 /// Safe to call for every send; no-op when main is multimodal.
+#[allow(dead_code)]
 pub async fn prepare_agent_prompt_for_main(prompt: &str) -> String {
     prepare_agent_prompt_for_main_detailed(prompt, None)
         .await

--- a/src-tauri/src/official_aux.rs
+++ b/src-tauri/src/official_aux.rs
@@ -16,7 +16,6 @@
 //! Never writes official `auth.json` into the main agent-home while a custom
 //! relay is active (OIDC pollution).
 
-#![allow(dead_code)] // residual-clippy: x_search / aux helpers retained for tests and future host wiring
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
@@ -44,6 +43,7 @@ pub fn official_aux_config_toml() -> PathBuf {
 }
 
 /// Official catalog model used for side-channel jobs.
+#[allow(dead_code)]
 pub fn official_aux_model_id() -> &'static str {
     OFFICIAL_CATALOG_MODEL
 }
@@ -319,8 +319,10 @@ pub struct OfficialAcpProgress {
     /// Short non-technical detail for the chip (may be a stream tail).
     pub detail: String,
     /// Optional tool title override from agent tool_call.
+    #[allow(dead_code)]
     pub tool_title: Option<String>,
     /// Optional tool status from agent.
+    #[allow(dead_code)]
     pub tool_status: Option<String>,
 }
 
@@ -1108,6 +1110,7 @@ pub fn write_official_aux_mcp_script(home: &Path) -> Result<PathBuf, String> {
 ///
 /// Prefer [`write_official_aux_mcp_script`] for ACP inject. This lookup is a
 /// dev/fallback path (cargo tree / cwd).
+#[allow(dead_code)]
 pub fn mcp_script_path() -> Option<PathBuf> {
     let written = official_aux_home().join(OFFICIAL_AUX_MCP_SCRIPT_FILE);
     if written.is_file() {
@@ -1144,6 +1147,7 @@ pub fn mcp_script_path() -> Option<PathBuf> {
 }
 
 /// ACP mcpServers entry for official aux tools (stdio Node script).
+#[allow(dead_code)]
 pub fn mcp_server_acp_entry() -> Option<serde_json::Value> {
     mcp_server_acp_entry_reason().0
 }
@@ -1278,6 +1282,7 @@ pub fn native_media_block_read_image_reason() -> &'static str {
 }
 
 /// Shell script body: inspect PreToolUse stdin; deny native Imagine + image read_file.
+#[allow(dead_code)]
 pub fn native_media_block_hook_script_body() -> String {
     native_media_block_hook_script_body_with(true)
 }
@@ -1587,11 +1592,13 @@ pub fn merge_extra_rules(user: Option<&str>) -> Option<String> {
 /// `prior_context` (optional recent journal turns) resolves pronouns like
 /// 「它 / 这个」 so Host X does not search the literal sentence
 /// 「搜索它在 x 上的信息」 when the user meant the previous topic (e.g. DeepSeek).
+#[allow(dead_code)]
 pub fn detect_x_search_intent(prompt: &str) -> Option<XSearchIntent> {
     detect_x_search_intent_with_context(prompt, None)
 }
 
 /// Same as [`detect_x_search_intent`] with optional prior chat text for coref.
+#[allow(dead_code)]
 pub fn detect_x_search_intent_with_context(
     prompt: &str,
     prior_context: Option<&str>,
@@ -1685,6 +1692,7 @@ pub fn detect_x_search_intent_with_context(
 }
 
 /// Whether the query still looks like a pronoun / empty entity (needs coref).
+#[allow(dead_code)]
 fn query_needs_coref(q: &str) -> bool {
     let t = q.trim().to_ascii_lowercase();
     if t.is_empty() {
@@ -1717,6 +1725,7 @@ fn query_needs_coref(q: &str) -> bool {
 }
 
 /// Strip search/X filler words so we don't pass the whole sentence to x_keyword_search.
+#[allow(dead_code)]
 fn strip_x_search_filler(text: &str) -> String {
     let mut s = text.trim().to_string();
     // Order matters: longer phrases first.
@@ -1799,6 +1808,7 @@ fn strip_x_search_filler(text: &str) -> String {
 }
 
 /// Pull a plausible entity name from prior user/assistant text for coref.
+#[allow(dead_code)]
 pub fn extract_topic_entity_from_context(prior: &str) -> Option<String> {
     let prior = prior.trim();
     if prior.is_empty() {
@@ -1937,6 +1947,7 @@ pub fn extract_topic_entity_from_context(prior: &str) -> Option<String> {
 }
 
 /// Rewrite raw user text into a better x_keyword_search query.
+#[allow(dead_code)]
 pub fn rewrite_x_keyword_query(user_clean: &str, prior_context: Option<&str>) -> String {
     let mut q = strip_x_search_filler(user_clean);
     // Remove leftover standalone x/twitter tokens
@@ -2003,6 +2014,7 @@ pub fn rewrite_x_keyword_query(user_clean: &str, prior_context: Option<&str>) ->
 ///
 /// Skips the **latest user** message (already the current turn — may only say
 /// 「搜索它在 x 上」) so coref can resolve 「它」 from earlier turns.
+#[allow(dead_code)]
 pub fn prior_context_for_session(app_session_id: &str) -> String {
     let msgs = crate::store::load_messages(app_session_id);
     let end = if msgs.last().map(|m| m.role == "user").unwrap_or(false) {
@@ -2034,6 +2046,7 @@ pub fn prior_context_for_session(app_session_id: &str) -> String {
 }
 
 /// True when text has `@handle` (2–20 alnum/_) that is **not** a filesystem path.
+#[allow(dead_code)]
 fn text_has_x_handle_token(text: &str) -> bool {
     for token in text.split_whitespace() {
         let t = token.trim_matches(|c: char| {
@@ -2063,12 +2076,14 @@ fn text_has_x_handle_token(text: &str) -> bool {
 }
 
 #[derive(Debug, Clone)]
+#[allow(dead_code)]
 pub enum XSearchIntent {
     User { query: String },
     Keyword { query: String },
     Thread { id_or_url: String },
 }
 
+#[allow(dead_code)]
 fn extract_x_handle(text: &str) -> Option<String> {
     // @handle — never treat @/abs/path or @C:\path as a handle
     for token in text.split_whitespace() {
@@ -2138,6 +2153,7 @@ fn extract_x_handle(text: &str) -> Option<String> {
     None
 }
 
+#[allow(dead_code)]
 fn extract_x_status_ref(text: &str) -> Option<String> {
     for tok in text.split_whitespace() {
         if tok.contains("x.com/") && tok.contains("status") {
@@ -2156,6 +2172,7 @@ fn extract_x_status_ref(text: &str) -> Option<String> {
     None
 }
 
+#[allow(dead_code)]
 fn x_intent_prompt(intent: &XSearchIntent) -> (String, u32, Duration, String) {
     match intent {
         XSearchIntent::User { query } => {
@@ -2216,6 +2233,7 @@ Return the thread as markdown with status URLs. No file edits."#
     }
 }
 
+#[allow(dead_code)]
 fn finalize_x_block(intent: &XSearchIntent, text: String) -> (bool, String, String) {
     let text = crate::models_aux::neutralize_image_at_refs(&text);
     let label = match intent {
@@ -2229,6 +2247,7 @@ fn finalize_x_block(intent: &XSearchIntent, text: String) -> (bool, String, Stri
     (true, block, "ok".into())
 }
 
+#[allow(dead_code)]
 fn x_block_err(e: String) -> (bool, String, String) {
     tracing::warn!(target: "official_aux", "host x search failed: {e}");
     (
@@ -2246,6 +2265,7 @@ fn x_block_err(e: String) -> (bool, String, String) {
 }
 
 /// Host pre-run X search via official aux. Returns inject block + UI strings.
+#[allow(dead_code)]
 pub fn prepare_x_search_block(intent: &XSearchIntent) -> (bool, String, String) {
     if !should_inject_mcp_for_main() && !official_aux_available() {
         return (false, String::new(), "official aux unavailable".into());
@@ -2265,6 +2285,7 @@ pub fn prepare_x_search_block(intent: &XSearchIntent) -> (bool, String, String) 
 }
 
 /// Async X search with ACP stream progress for Chat chips.
+#[allow(dead_code)]
 pub async fn prepare_x_search_block_async(
     intent: &XSearchIntent,
     progress: Option<OfficialProgressCb>,

--- a/src-tauri/src/permission.rs
+++ b/src-tauri/src/permission.rs
@@ -1,6 +1,5 @@
 //! Permission scope_key rules (§17.3) + session allow cache.
 
-#![allow(dead_code)] // residual-clippy: request struct / cache clear
 use std::collections::HashSet;
 use std::path::{Component, Path, PathBuf};
 
@@ -81,6 +80,7 @@ pub fn is_edit_tool(tool_name: &str) -> bool {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[allow(dead_code)]
 pub struct PermissionRequest {
     pub request_id: u64,
     pub session_id: String,
@@ -708,6 +708,7 @@ pub fn fallback_always_allow_for_tool(tool_name: &str) -> &'static str {
 
 /// Resolve session / always-allow wire id (CLI uses `always-allow`, plus
 /// tool-scoped `allow-always-command` / `allow-always-mcp` / `allow-always-domain`).
+#[allow(dead_code)]
 pub fn resolve_always_allow_option_id(options: &serde_json::Value) -> String {
     resolve_always_allow_option_id_for_tool(options, "")
 }
@@ -763,6 +764,7 @@ fn pick_session_scoped_option_id(options: &serde_json::Value) -> Option<String> 
 
 /// True when `option_id` matches an entry in the ACP options list (exact or
 /// hyphen/underscore-normalized).
+#[allow(dead_code)]
 pub fn option_id_in_list(options: &serde_json::Value, option_id: &str) -> bool {
     let Some(arr) = options.as_array() else {
         return false;
@@ -817,6 +819,7 @@ pub fn wire_option_id_from_list(options: &serde_json::Value, option_id: &str) ->
 ///
 /// `tool_name` is used only when the options list is empty so session-allow
 /// can fall back to a tool-scoped wire id (#542).
+#[allow(dead_code)]
 pub fn coerce_wire_option_id(
     decision: &str,
     client_option_id: Option<&str>,
@@ -917,6 +920,7 @@ impl SessionAllowCache {
         self.keys.contains(key)
     }
 
+    #[allow(dead_code)]
     pub fn clear(&mut self) {
         self.keys.clear();
     }

--- a/src-tauri/src/permission_rules.rs
+++ b/src-tauri/src/permission_rules.rs
@@ -13,7 +13,6 @@
 //! `rules`) are left untouched. Writes target the active GROK_HOME for the
 //! current `session_data_mode` (agent-home or `~/.grok`).
 
-#![allow(dead_code)] // residual-clippy: rule mutate helpers
 use std::fs;
 use std::path::PathBuf;
 
@@ -79,6 +78,7 @@ pub fn normalize_rule(raw: &str) -> Option<String> {
 }
 
 /// Normalize an action name to `allow` | `deny` | `ask`.
+#[allow(dead_code)]
 pub fn normalize_action(raw: &str) -> Option<&'static str> {
     match raw.trim().to_ascii_lowercase().as_str() {
         "allow" => Some("allow"),
@@ -113,6 +113,7 @@ pub fn normalize_rules(rules: &PermissionRules) -> PermissionRules {
 }
 
 /// Pure helper: add a rule to one action bucket (deduped).
+#[allow(dead_code)]
 pub fn add_rule(
     rules: &PermissionRules,
     action: &str,
@@ -134,6 +135,7 @@ pub fn add_rule(
 }
 
 /// Pure helper: remove a rule from one action bucket (exact match after trim).
+#[allow(dead_code)]
 pub fn remove_rule(
     rules: &PermissionRules,
     action: &str,

--- a/src-tauri/src/process_limits.rs
+++ b/src-tauri/src/process_limits.rs
@@ -3,7 +3,6 @@
 //! Pure helpers are unit-tested; SessionManager applies them at runtime.
 //! Process budget snapshots expose live / background / parked occupancy for UI.
 
-#![allow(dead_code)] // residual-clippy: capacity helpers
 use serde::{Deserialize, Serialize};
 use std::time::{Duration, Instant};
 
@@ -72,6 +71,7 @@ pub fn can_spawn_process(active_processes: u32, max_concurrent: u32) -> bool {
 }
 
 /// How many processes must be recycled before a spawn is allowed.
+#[allow(dead_code)]
 pub fn processes_over_capacity(active_processes: u32, max_concurrent: u32) -> u32 {
     let max = normalize_max_concurrent(max_concurrent);
     active_processes.saturating_sub(max)
@@ -132,6 +132,7 @@ pub struct ProcessBudgetSnapshot {
 
 impl ProcessBudgetSnapshot {
     /// Soft-fail empty snapshot (settings defaults, zero occupancy).
+    #[allow(dead_code)]
     pub fn empty() -> Self {
         Self {
             live: 0,

--- a/src-tauri/src/process_util.rs
+++ b/src-tauri/src/process_util.rs
@@ -1,6 +1,5 @@
 //! Cross-platform process / path helpers (Windows GUI spawn, home dir, PATH).
 
-#![allow(dead_code)] // residual-clippy: tokio_command helper
 use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::path::{Path, PathBuf};
 use std::process::Command as StdCommand;
@@ -99,6 +98,7 @@ pub fn apply_no_window_tokio(cmd: &mut tokio::process::Command) {
 /// tool/shell grandchildren. Do **not** apply on SSH/WSL-wrapped spawns —
 /// those children are remote or live inside WSL and must not get local
 /// process-group / taskkill semantics blindly.
+#[allow(dead_code)]
 pub fn apply_process_group_no_window_std(cmd: &mut StdCommand) {
     #[cfg(windows)]
     {
@@ -128,6 +128,7 @@ pub fn apply_process_group_no_window_tokio(cmd: &mut tokio::process::Command) {
 /// `taskkill` wait uses `thread::sleep` — never call the sync helper on a Tokio
 /// worker. ACP stop / reconnect timeouts must be able to elapse while tree-kill
 /// runs on the blocking pool.
+#[allow(dead_code)]
 pub async fn kill_process_tree_async(pid: u32) -> bool {
     #[cfg(windows)]
     {
@@ -158,6 +159,7 @@ pub async fn kill_process_tree_async(pid: u32) -> bool {
 /// successfully. On non-Windows this is a no-op that returns `false`.
 ///
 /// Prefer [`kill_process_tree_async`] from async ACP / session-manager paths.
+#[allow(dead_code)]
 pub fn kill_process_tree(pid: u32) -> bool {
     #[cfg(windows)]
     {
@@ -303,6 +305,7 @@ pub fn command(program: impl AsRef<std::ffi::OsStr>) -> StdCommand {
 }
 
 /// Build a `tokio::process::Command` with Windows console hidden + HOME.
+#[allow(dead_code)]
 pub fn tokio_command(program: impl AsRef<std::ffi::OsStr>) -> tokio::process::Command {
     let mut cmd = tokio::process::Command::new(program);
     apply_no_window_tokio(&mut cmd);
@@ -760,6 +763,7 @@ pub fn path_for_editor(path: &Path) -> String {
 }
 
 /// Percent-encode a local path for a `file://` URI (Linux ShowItems).
+#[allow(dead_code)]
 fn file_uri_from_path(path: &str) -> String {
     // file:// + absolute path; encode non-unreserved octets.
     let mut out = String::from("file://");

--- a/src-tauri/src/remote_im/channels/feishu.rs
+++ b/src-tauri/src/remote_im/channels/feishu.rs
@@ -1,6 +1,5 @@
 //! Feishu / Lark long-connection (WS) + REST outbound — pure Rust.
 
-#![allow(dead_code)] // residual-clippy: download_message_resource
 use super::super::outbound::{http_client, opt_str, secret_or_opt};
 use super::super::pb_frame::{decode_frame, encode_frame, Frame, Header};
 use super::super::types::{ChannelInstance, IncomingMessage};
@@ -739,6 +738,7 @@ pub fn protocol_name() -> &'static str {
 }
 
 /// Download inbound image bytes (text-adjacent media path).
+#[allow(dead_code)]
 pub async fn download_message_resource(
     channel: &str,
     secrets: &HashMap<String, String>,

--- a/src-tauri/src/remote_im/config.rs
+++ b/src-tauri/src/remote_im/config.rs
@@ -1,6 +1,5 @@
 //! Persist Remote IM channel instances under ~/.grok-app/remote/.
 
-#![allow(dead_code)] // residual-clippy: bridge path helpers
 use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
@@ -176,16 +175,19 @@ pub fn set_instance_advisory(instance_id: &str, note: Option<String>) -> Result<
 }
 
 /// Legacy path kept for doctor/docs; Rust runtime does not require Node config.toml.
+#[allow(dead_code)]
 pub fn bridge_data_dir() -> PathBuf {
     let dir = app_data_root().join("remote").join("bridge-data");
     let _ = fs::create_dir_all(&dir);
     dir
 }
 
+#[allow(dead_code)]
 pub fn bridge_config_path() -> PathBuf {
     bridge_data_dir().join("config.toml")
 }
 
+#[allow(dead_code)]
 pub fn remote_log_path() -> PathBuf {
     remote_dir().join("logs").join("bridge.log")
 }

--- a/src-tauri/src/remote_im/control_plane.rs
+++ b/src-tauri/src/remote_im/control_plane.rs
@@ -1,7 +1,6 @@
 //! Pure control-plane transitions for Remote IM (/p /r / bind / resume).
 //! Network-free and unit-tested against production functions.
 
-#![allow(dead_code)] // residual-clippy: CLI arg builders for future grok turn variants
 use super::context::{ContextCompactSnapshot, ContextUsageSnapshot};
 use super::types::TrustedProject;
 use serde::{Deserialize, Serialize};
@@ -355,6 +354,7 @@ pub fn format_session_menu(sessions: &[AppSessionEntry], lang: &str) -> String {
 
 /// Whether this channel should use interactive cards for /p /r.
 /// Instance `presenter` / `enable_card` override the channel default.
+#[allow(dead_code)]
 pub fn channel_uses_cards(channel: &str) -> bool {
     channel_uses_cards_with_options(channel, None)
 }
@@ -864,6 +864,7 @@ pub fn build_dingtalk_session_card(sessions: &[AppSessionEntry], lang: &str) -> 
 
 /// CLI args for resume-capable grok turn (shipped helper used by grok_agent + tests).
 /// Default format is `streaming-json` (no partial stream events).
+#[allow(dead_code)]
 pub fn grok_turn_cli_args(
     prompt: &str,
     session_id: Option<&str>,
@@ -873,6 +874,7 @@ pub fn grok_turn_cli_args(
 }
 
 /// Headless `-p` argv builder with optional background-wait flags (CLI 0.2.117+).
+#[allow(dead_code)]
 pub fn grok_turn_cli_args_with_bg_wait(
     prompt: &str,
     session_id: Option<&str>,
@@ -891,6 +893,7 @@ pub fn grok_turn_cli_args_with_bg_wait(
 
 /// Headless `-p` argv with explicit output format + optional partial-stream flags
 /// (`--include-partial-messages` only when format is `streaming-messages-json`).
+#[allow(dead_code)]
 pub fn grok_turn_cli_args_with_stream(
     prompt: &str,
     session_id: Option<&str>,

--- a/src-tauri/src/remote_im/engine.rs
+++ b/src-tauri/src/remote_im/engine.rs
@@ -1,6 +1,5 @@
 //! Message engine: ACL, slash commands, Grok turns, project/session bind.
 
-#![allow(dead_code)] // residual-clippy: ephemeral engine API
 use super::app_sessions;
 use super::context::{
     estimate_visible_tokens, format_tokens, latest_compact_from_messages, ContextCompactSnapshot,
@@ -125,6 +124,7 @@ impl Engine {
     }
 
     /// Test helper: ephemeral store.
+    #[allow(dead_code)]
     pub fn new_ephemeral(outbound: OutboundRouter, allow_remote_yolo: bool) -> Self {
         Self {
             store: SessionStore::ephemeral(),
@@ -151,6 +151,7 @@ impl Engine {
         self.instances.lock().insert(inst.id.clone(), inst);
     }
 
+    #[allow(dead_code)]
     pub fn remove_instance(&self, id: &str) {
         self.instances.lock().remove(id);
     }

--- a/src-tauri/src/remote_im/outbound.rs
+++ b/src-tauri/src/remote_im/outbound.rs
@@ -1,6 +1,5 @@
 //! Unified outbound reply router for all channel types (Rust HTTP / WS clients).
 
-#![allow(dead_code)] // residual-clippy: test helpers and unused channel send paths
 use parking_lot::RwLock;
 use serde_json::json;
 use std::collections::HashMap;
@@ -44,6 +43,7 @@ impl OutboundRouter {
     }
 
     /// Test/helper: read back injected secrets for an instance.
+    #[allow(dead_code)]
     pub fn secrets_for_test(&self, instance_id: &str) -> Option<HashMap<String, String>> {
         self.creds
             .read()
@@ -51,10 +51,12 @@ impl OutboundRouter {
             .map(|c| c.secrets.clone())
     }
 
+    #[allow(dead_code)]
     pub fn unregister(&self, instance_id: &str) {
         self.creds.write().remove(instance_id);
     }
 
+    #[allow(dead_code)]
     pub fn clear(&self) {
         self.creds.write().clear();
     }
@@ -202,6 +204,7 @@ pub fn http_client() -> Result<reqwest::Client, String> {
         .map_err(|e| e.to_string())
 }
 
+#[allow(dead_code)]
 pub async fn json_post(url: &str, body: serde_json::Value) -> Result<serde_json::Value, String> {
     let c = http_client()?;
     let res = c
@@ -240,6 +243,7 @@ pub async fn json_get_bearer(url: &str, token: &str) -> Result<serde_json::Value
     serde_json::from_str(&text).map_err(|e| e.to_string())
 }
 
+#[allow(dead_code)]
 pub fn redact_preview(s: &str) -> String {
     if s.len() <= 8 {
         return "***".into();
@@ -329,6 +333,7 @@ pub fn require_mention(options: &serde_json::Value, acl: &serde_json::Value) -> 
 }
 
 /// Helper for telegram-style JSON APIs
+#[allow(dead_code)]
 pub fn empty_json() -> serde_json::Value {
     json!({})
 }

--- a/src-tauri/src/remote_im/runtime.rs
+++ b/src-tauri/src/remote_im/runtime.rs
@@ -1,6 +1,5 @@
 //! In-process multi-channel Remote IM runtime (Rust only).
 
-#![allow(dead_code)] // residual-clippy: runtime holder fields
 use super::channels;
 use super::config;
 use super::engine::Engine;
@@ -18,7 +17,9 @@ pub struct RuntimeHandle {
     connectors: Vec<JoinHandle<()>>,
     /// Kept alive so the pump channel never closes while connectors restart.
     _keepalive_tx: mpsc::Sender<IncomingMessage>,
+    #[allow(dead_code)]
     outbound: OutboundRouter,
+    #[allow(dead_code)]
     engine: Arc<Engine>,
 }
 

--- a/src-tauri/src/remote_im/session.rs
+++ b/src-tauri/src/remote_im/session.rs
@@ -1,6 +1,5 @@
 //! Per-scope IM session binding (project + agent session id), disk-persisted.
 
-#![allow(dead_code)] // residual-clippy: ephemeral/reset session API
 use super::control_plane::{binding_after_app_session_move, ScopeBinding};
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
@@ -56,6 +55,7 @@ impl SessionStore {
     }
 
     /// In-memory only (tests).
+    #[allow(dead_code)]
     pub fn ephemeral() -> Self {
         Self {
             inner: Arc::new(Mutex::new(HashMap::new())),
@@ -119,6 +119,7 @@ impl SessionStore {
         self.save_disk();
     }
 
+    #[allow(dead_code)]
     pub fn reset(&self, key: &str, work_dir: &str) -> ScopeBinding {
         let rec = ScopeBinding::fresh(work_dir);
         self.inner.lock().insert(key.to_string(), rec.clone());

--- a/src-tauri/src/remote_im/types.rs
+++ b/src-tauri/src/remote_im/types.rs
@@ -1,6 +1,5 @@
 //! Shared types for the in-process Remote IM runtime.
 
-#![allow(dead_code)] // residual-clippy: DTO fields for protocol completeness
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
@@ -9,7 +8,9 @@ use std::collections::HashMap;
 pub struct ChannelInstance {
     pub id: String,
     pub channel: String,
+    #[allow(dead_code)]
     pub name: String,
+    #[allow(dead_code)]
     pub enabled: bool,
     pub secrets: HashMap<String, String>,
     pub options: Value,
@@ -49,6 +50,7 @@ pub struct ConnectedChannel {
 }
 
 #[derive(Debug, Clone)]
+#[allow(dead_code)]
 pub struct SessionRecord {
     pub session_id: String,
     pub work_dir: String,
@@ -57,6 +59,7 @@ pub struct SessionRecord {
 }
 
 impl SessionRecord {
+    #[allow(dead_code)]
     pub fn new(work_dir: &str) -> Self {
         Self {
             session_id: uuid::Uuid::new_v4().to_string(),

--- a/src-tauri/src/remote_im/validate.rs
+++ b/src-tauri/src/remote_im/validate.rs
@@ -1,6 +1,5 @@
 //! Live credential validation per channel (no mock).
 
-#![allow(dead_code)] // residual-clippy: format validators
 use super::config;
 use super::TestConnectionDto;
 use std::collections::HashMap;

--- a/src-tauri/src/remote_im/weixin_reg.rs
+++ b/src-tauri/src/remote_im/weixin_reg.rs
@@ -1,6 +1,5 @@
 //! Weixin personal (ilink) QR login — mirrors cc-connect weixin setup.
 
-#![allow(dead_code)] // residual-clippy: scan/verify helpers for multi-channel reg
 use super::{ScanBeginDto, ScanPollDto};
 use serde::Deserialize;
 use serde_json::Value;
@@ -44,6 +43,7 @@ pub struct QrStatusResponse {
     #[serde(default, rename = "ilink_user_id")]
     pub ilink_user_id: String,
     #[serde(default, rename = "base_url")]
+    #[allow(dead_code)]
     pub base_url: String,
 }
 
@@ -145,10 +145,12 @@ async fn poll_status(
 }
 
 /// Channels that have a real Host scan implementation.
+#[allow(dead_code)]
 pub fn scan_supported_channels() -> &'static [&'static str] {
     &["feishu", "lark", "weixin"]
 }
 
+#[allow(dead_code)]
 pub fn channel_supports_scan(channel: &str) -> bool {
     scan_supported_channels().contains(&channel)
 }
@@ -325,6 +327,7 @@ pub async fn scan_poll(_device_code: &str) -> Result<ScanPollDto, String> {
 }
 
 /// Verify token with a short getUpdates call.
+#[allow(dead_code)]
 pub async fn verify_token(base_url: &str, token: &str, route_tag: &str) -> Result<(), String> {
     let client = http()?;
     let url = format!("{}/ilink/bot/getupdates", base_url.trim_end_matches('/'));

--- a/src-tauri/src/session_manager/control.rs
+++ b/src-tauri/src/session_manager/control.rs
@@ -1,6 +1,5 @@
 //! Policy, model, disconnect, recycle, permission resolution.
 
-#![allow(dead_code)] // residual-clippy: set_permission_policy / tracked counts
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
@@ -16,6 +15,7 @@ use crate::store::{self};
 use super::*;
 
 impl SessionManager {
+    #[allow(dead_code)]
     pub fn set_permission_policy(&self, policy: PermissionPolicy) {
         if let Some(s) = self.inner.lock().as_mut() {
             s.policy = policy;
@@ -260,6 +260,7 @@ impl SessionManager {
 
     /// Counts of tracked live shell / background / parked entries (alive or not).
     /// Used by diagnostics and unit tests — not the same as `active_process_count`.
+    #[allow(dead_code)]
     pub fn tracked_agent_map_counts(&self) -> (usize, usize, usize) {
         let live = self.inner.lock().is_some() as usize;
         let background = self.background.lock().len();

--- a/src-tauri/src/session_manager/process.rs
+++ b/src-tauri/src/session_manager/process.rs
@@ -1,6 +1,5 @@
 //! Process capacity, park/unpark, idle recycle, snapshots.
 
-#![allow(dead_code)] // residual-clippy: snapshot_from_parked
 use std::collections::{HashMap, HashSet};
 use std::time::{Duration, Instant};
 
@@ -1474,6 +1473,7 @@ impl SessionManager {
         }
     }
 
+    #[allow(dead_code)]
     pub(super) fn snapshot_from_parked(p: &ParkedAgent) -> SessionSnapshot {
         SessionSnapshot {
             session_id: Some(p.app_session_id.clone()),

--- a/src-tauri/src/skill_edit.rs
+++ b/src-tauri/src/skill_edit.rs
@@ -8,7 +8,6 @@
 //!
 //! Vendor/bundled/plugin trees are not allowlisted. Path traversal is rejected.
 
-#![allow(dead_code)] // residual-clippy: path_under_root helper
 use std::fs;
 use std::path::{Component, Path, PathBuf};
 use std::time::UNIX_EPOCH;
@@ -335,6 +334,7 @@ pub fn path_has_traversal(path: &Path) -> bool {
 }
 
 /// Component-wise: path is equal to root or a descendant.
+#[allow(dead_code)]
 pub fn path_under_root(path: &Path, root: &Path) -> bool {
     if path_has_traversal(path) || path_has_traversal(root) {
         return false;

--- a/src-tauri/src/store_lock.rs
+++ b/src-tauri/src/store_lock.rs
@@ -4,7 +4,6 @@
 //! We take an exclusive lock around read-modify-write of index files so the
 //! index is not half-written, and use temp+rename for atomic replace.
 
-#![allow(dead_code)] // residual-clippy: is_lock_busy helper
 use std::fs::{self, File, OpenOptions};
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, MutexGuard};
@@ -119,6 +118,7 @@ pub fn write_bytes_atomic(path: &Path, bytes: &[u8]) -> Result<(), String> {
 }
 
 /// True if error string is a lock contention failure.
+#[allow(dead_code)]
 pub fn is_lock_busy(err: &str) -> bool {
     err.contains("LOCK_BUSY")
 }

--- a/src-tauri/src/stream_emit.rs
+++ b/src-tauri/src/stream_emit.rs
@@ -4,16 +4,18 @@
 //! long answers. Buffer per turn and flush on a short timer, char budget,
 //! phase boundary, or terminal `done`.
 
-#![allow(dead_code)] // residual-clippy: normalize bounds helpers
 use std::time::{Duration, Instant};
 
 /// Default coalesce window (ms) before a non-forced flush.
 pub const DEFAULT_STREAM_EMIT_MS: u64 = 40;
 /// Flush once pending text reaches this many UTF-8 bytes (approx chars).
 pub const DEFAULT_STREAM_EMIT_MAX_CHARS: usize = 600;
+#[allow(dead_code)]
 pub const MIN_STREAM_EMIT_MS: u64 = 8;
+#[allow(dead_code)]
 pub const MAX_STREAM_EMIT_MS: u64 = 250;
 
+#[allow(dead_code)]
 pub fn normalize_stream_emit_ms(raw: u64) -> u64 {
     raw.clamp(MIN_STREAM_EMIT_MS, MAX_STREAM_EMIT_MS)
 }

--- a/src-tauri/src/stream_stall.rs
+++ b/src-tauri/src/stream_stall.rs
@@ -11,7 +11,6 @@
 //! Silent heal still applies when the agent RPC already completed and Host is
 //! merely stuck in Streaming with nothing left to wait on.
 
-#![allow(dead_code)] // residual-clippy: legacy stall emit helper
 use std::time::{Duration, Instant};
 
 /// Soft silence window default (settings `streamStallSeconds`).
@@ -77,6 +76,7 @@ pub fn effective_stall_seconds(
 
 /// Hard end silence: at least 10 minutes, or 3× soft window (whichever larger),
 /// capped at 30 minutes.
+#[allow(dead_code)]
 pub fn hard_stall_seconds(soft_seconds: u32) -> u32 {
     let soft = normalize_stream_stall_seconds(soft_seconds);
     let triple = soft.saturating_mul(3);
@@ -99,6 +99,7 @@ pub fn is_stream_stalled(last_progress: Instant, stall_seconds: u32, now: Instan
 }
 
 /// True when silence has reached the hard end window.
+#[allow(dead_code)]
 pub fn is_hard_stalled(last_progress: Instant, soft_seconds: u32, now: Instant) -> bool {
     let hard = hard_stall_seconds(soft_seconds);
     now >= last_progress + Duration::from_secs(u64::from(hard))
@@ -108,6 +109,7 @@ pub fn is_hard_stalled(last_progress: Instant, soft_seconds: u32, now: Instant) 
 ///
 /// Emits on first cross into stalled, then again every full stall window while
 /// silence continues — but only while `soft_emits_this_turn < MAX`.
+#[allow(dead_code)]
 pub fn should_emit_stall(
     last_progress: Instant,
     last_emit: Option<Instant>,
@@ -204,6 +206,7 @@ pub fn is_maybe_done_candidate(
 
 /// Deprecated name — use [`is_maybe_done_candidate`]. Kept for call-site greps.
 #[inline]
+#[allow(dead_code)]
 pub fn should_auto_end_maybe_done(
     saw_model_output: bool,
     open_tool_count: usize,

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -5,7 +5,6 @@
 //! (white glyph on transparency). Host picks by taskbar theme, not in-app theme.
 //! **App dock / .exe icons** → generated from `icons/icon (1).png` (do not mix).
 
-#![allow(dead_code)] // residual-clippy: busy_tooltip helper
 use std::sync::Mutex;
 
 use tauri::{
@@ -359,6 +358,7 @@ fn handle_menu_event(app: &AppHandle, event: MenuEvent) {
 
 /// Windows notification-area badge. Named by the *taskbar*, not the in-app theme.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(dead_code)]
 enum WinTrayBadge {
     /// Light taskbar → black tile, white glyph.
     LightTaskbar,
@@ -366,6 +366,7 @@ enum WinTrayBadge {
     DarkTaskbar,
 }
 
+#[allow(dead_code)]
 fn win_tray_badge(taskbar_light: bool) -> WinTrayBadge {
     if taskbar_light {
         WinTrayBadge::LightTaskbar
@@ -378,6 +379,7 @@ fn win_tray_badge(taskbar_light: bool) -> WinTrayBadge {
 ///
 /// Prefer `SystemUsesLightTheme` (taskbar / notification area). Fall back to
 /// `AppsUseLightTheme`. Missing both → dark taskbar (Win11 default).
+#[allow(dead_code)]
 fn taskbar_is_light_from_dwords(system: Option<u32>, apps: Option<u32>) -> bool {
     system.or(apps).is_some_and(|v| v != 0)
 }
@@ -528,6 +530,7 @@ pub fn tray_refresh(app: AppHandle) -> Result<(), String> {
 }
 
 /// Pure: dock badge count value. `0` → clear (`None`).
+#[allow(dead_code)]
 pub fn badge_count_value(count: u32) -> Option<i64> {
     if count == 0 {
         None
@@ -537,6 +540,7 @@ pub fn badge_count_value(count: u32) -> Option<i64> {
 }
 
 /// Pure: macOS dock badge label text. `0` → clear (`None`).
+#[allow(dead_code)]
 pub fn badge_label_value(count: u32) -> Option<String> {
     if count == 0 {
         None

--- a/src-tauri/src/voice_tools.rs
+++ b/src-tauri/src/voice_tools.rs
@@ -1,7 +1,6 @@
 //! Host tools exposed to the live voice model for agent delegation.
 //! Pure definitions + argument parsing (testable without network).
 
-#![allow(dead_code)] // residual-clippy: normalize_tool_status
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
@@ -303,6 +302,7 @@ pub fn recordable_delegated_session_id(session_id: Option<&str>) -> Option<Strin
 }
 
 /// Canonical tool-loop status tokens emitted on `voice://tool` (VOX-BUILD-FULL).
+#[allow(dead_code)]
 pub fn normalize_tool_status(raw: &str) -> &'static str {
     match raw.trim().to_lowercase().as_str() {
         "running" | "tool_running" | "in_progress" => "tool_running",

--- a/src-tauri/src/wallpaper_source.rs
+++ b/src-tauri/src/wallpaper_source.rs
@@ -1,7 +1,6 @@
 //! Wallpaper source: X search + Imagine generate via headless Grok CLI,
 //! plus allowlisted X / Imagine / Grok-album media download into the library.
 
-#![allow(dead_code)] // residual-clippy: kind_from_mime
 use std::fs;
 use std::io::{self, Read};
 use std::path::{Path, PathBuf};
@@ -34,6 +33,7 @@ const MAX_X_GALLERY_RESULTS: usize = 16;
 const MIN_X_GALLERY_RESULTS_BEFORE_SUPPLEMENT: usize = 6;
 pub(crate) const X_SEARCH_FIRST_ROUND_CALLS: u32 = 2;
 pub(crate) const X_SEARCH_SUPPLEMENT_CALLS: u32 = 1;
+#[allow(dead_code)]
 pub(crate) const X_SEARCH_TOTAL_CALLS: u32 = X_SEARCH_FIRST_ROUND_CALLS + X_SEARCH_SUPPLEMENT_CALLS;
 /// Headless X search budget.
 const X_SEARCH_TIMEOUT: Duration = Duration::from_secs(150);
@@ -551,6 +551,7 @@ fn mime_from_ext(ext: &str) -> &'static str {
     }
 }
 
+#[allow(dead_code)]
 fn ext_from_mime_or_url(mime: &str, url: &str) -> String {
     let m = mime.to_ascii_lowercase();
     if m.contains("jpeg") || m.contains("jpg") {
@@ -587,6 +588,7 @@ fn ext_from_mime_or_url(mime: &str, url: &str) -> String {
     "jpg".into()
 }
 
+#[allow(dead_code)]
 fn kind_from_mime(mime: &str) -> &'static str {
     if mime.starts_with("video/") {
         "video"
@@ -1065,6 +1067,7 @@ where
 enum WallpaperCliPipeRead {
     Data(usize),
     Pending,
+    #[allow(dead_code)]
     Eof,
 }
 
@@ -1643,6 +1646,7 @@ struct ImageProbe {
 
 #[derive(Debug, Clone)]
 pub(crate) struct ValidatedImagePrefix {
+    #[allow(dead_code)]
     pub(crate) mime: &'static str,
     pub(crate) dimensions: Option<(u32, u32)>,
 }
@@ -1899,6 +1903,7 @@ async fn inspect_image_url(client: &reqwest::Client, url: &str) -> Option<ImageP
 }
 
 /// Probe whether a remote URL is a reachable image (filters broken gallery thumbs).
+#[allow(dead_code)]
 pub async fn probe_image_reachable(client: &reqwest::Client, url: &str) -> bool {
     inspect_image_url(client, url).await.is_some()
 }
@@ -2146,6 +2151,7 @@ pub(crate) async fn filter_reachable_gallery_items_cancellable(
     merge_rank_x_gallery_items(out)
 }
 
+#[allow(dead_code)]
 pub async fn filter_reachable_gallery_items(
     items: Vec<WallpaperGalleryItem>,
 ) -> Vec<WallpaperGalleryItem> {
@@ -2276,6 +2282,7 @@ fn x_search_round(
 
 /// Sync first-round headless search only (no network probe). Prefer
 /// [`x_search_async`] for the complete quality and supplement pipeline.
+#[allow(dead_code)]
 pub fn x_search(query: &str, sort: Option<&str>) -> WallpaperSearchResult {
     x_search_round(query, sort, X_SEARCH_FIRST_ROUND_CALLS, false, &[], None)
 }
@@ -2359,6 +2366,7 @@ pub(crate) fn x_gallery_reference_ids(items: &[WallpaperGalleryItem]) -> Vec<Str
 }
 
 /// Headless X search + drop unreachable media URLs before returning to UI.
+#[allow(dead_code)]
 pub async fn x_search_async(query: &str, sort: Option<&str>) -> WallpaperSearchResult {
     x_search_cli_outcome(query, sort, None).await.result
 }


### PR DESCRIPTION
## Summary
- 45 files suppressed `dead_code` **file-wide** with `#![allow(dead_code)] // residual-clippy` comments — which also silently hid any *new* dead code those files accumulated afterward.
- This PR removes every file-level suppression and annotates the actual dead items instead: ~150 targeted `#[allow(dead_code)]` on the specific fns / struct fields / methods rustc flags (protocol-parity DTOs, helpers retained for tests, platform-gated paths). Two files needed no annotation — their suppression was fully stale.
- Net effect: every file is now lint-guarded again; only the flagged items are exempt. Attribute placement only — zero behavior change.
- Pre-existing item-level and `cfg_attr` allows (`not(test)`, `target_os`) were left untouched.

## Test plan
- [x] `cargo check` — zero dead_code warnings (was hidden by blanket allows)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy` — 0 warnings
- [x] `cargo test --lib` — 1866 tests pass

Generated with [Devin](https://devin.ai)
