### PR TITLE
fix(composer): stop treating @/goal prose as a file chip (#1197)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ See `docs/llm-wiki/release.md`.
 - 输入框上的分支 chip 可在当前目录切换 git 分支。仅远程存在的分支会建本地跟踪分支；已在其他 worktree 检出的则切到那个 worktree。
 
 ### Fixed
+- Typing `@/goal …` no longer becomes a missing-file chip; the line stays as text (#1197).
 - The account menu no longer repeats the quota card when only one official account is saved.
 - Saving project rules no longer kills another chat's background agent mid-turn.
 - Trusted-project chats no longer reuse a prewarm process that skipped folder trust.
@@ -49,6 +50,7 @@ See `docs/llm-wiki/release.md`.
 - Local video details now use the file's measured dimensions and duration.
 
 **中文 · 修复**
+- 输入 `@/goal …` 不再变成失效文件 chip，该行会保留为正文（#1197）。
 - 仅一个官方账号时，用户菜单不再重复显示额度卡片。
 - 保存项目规则时，不再打断同项目另一聊天后台进行中的 agent 回合。
 - 已信任项目不会复用未带文件夹信任的预热进程，AGENTS.md 可正确加载。

--- a/src-tauri/src/cli_sessions.rs
+++ b/src-tauri/src/cli_sessions.rs
@@ -1318,10 +1318,11 @@ pub fn parse_at_path_attachments(content: &str) -> (String, Vec<MessageAttachmen
     let mut seen = std::collections::HashSet::new();
     for line in content.lines() {
         let trimmed = line.trim();
-        // @/path or @C:\path — absolute only (same as FE).
+        // @/path or @C:\path — absolute only, and multi-segment for POSIX so
+        // `@/goal …` prose is not backfilled as a missing-file chip (#1197).
         let path = trimmed.strip_prefix('@').and_then(|rest| {
             let rest = rest.trim();
-            if rest.starts_with('/') || looks_like_windows_abs(rest) {
+            if is_sole_line_at_attachment_path(rest) {
                 Some(rest.to_string())
             } else {
                 None
@@ -1356,6 +1357,23 @@ pub fn parse_at_path_attachments(content: &str) -> (String, Vec<MessageAttachmen
 fn looks_like_windows_abs(path: &str) -> bool {
     let b = path.as_bytes();
     b.len() >= 3 && b[0].is_ascii_alphabetic() && b[1] == b':' && (b[2] == b'\\' || b[2] == b'/')
+}
+
+/// Mirrors FE `isSoleLineAtAttachmentPath`: POSIX needs ≥2 segments so
+/// `/goal` / `/goal 你再检查…` stay as text; Windows drive needs ≥1 segment.
+fn is_sole_line_at_attachment_path(path: &str) -> bool {
+    let p = path.trim();
+    if p.is_empty() {
+        return false;
+    }
+    if looks_like_windows_abs(p) {
+        let rest = p[2..].trim_start_matches(['/', '\\']).replace('\\', "/");
+        return rest.split('/').filter(|s| !s.is_empty()).count() >= 1;
+    }
+    if !p.starts_with('/') || p.starts_with("//") {
+        return false;
+    }
+    p.split('/').filter(|s| !s.is_empty()).count() >= 2
 }
 
 fn user_body_key(content: &str) -> String {
@@ -2203,6 +2221,15 @@ mod tests {
         assert_eq!(atts.len(), 1);
         assert_eq!(atts[0].path, "/Users/me/Downloads/Codex 安装教程文档.md");
         assert_eq!(atts[0].name, "Codex 安装教程文档.md");
+    }
+
+    #[test]
+    fn parse_at_path_attachments_keeps_at_goal_prose() {
+        let raw = "两句说明\n\n@/goal 你再检查优化一下吧\n\n@/tmp/notes.md";
+        let (text, atts) = parse_at_path_attachments(raw);
+        assert_eq!(text, "两句说明\n\n@/goal 你再检查优化一下吧");
+        assert_eq!(atts.len(), 1);
+        assert_eq!(atts[0].path, "/tmp/notes.md");
     }
 
     #[test]

--- a/src-tauri/src/session_manager/types.rs
+++ b/src-tauri/src/session_manager/types.rs
@@ -1751,6 +1751,27 @@ fn urlencoding_soft_decode(s: &str) -> String {
     String::from_utf8_lossy(&out).into_owned()
 }
 
+/// Same gate as FE `isSoleLineAtAttachmentPath` / cli_sessions helper.
+fn is_sole_line_at_attachment_path_ref(path: &str) -> bool {
+    let p = path.trim();
+    if p.is_empty() {
+        return false;
+    }
+    let b = p.as_bytes();
+    let windows_abs = b.len() >= 3
+        && b[0].is_ascii_alphabetic()
+        && b[1] == b':'
+        && (b[2] == b'\\' || b[2] == b'/');
+    if windows_abs {
+        let rest = p[2..].trim_start_matches(['/', '\\']).replace('\\', "/");
+        return rest.split('/').filter(|s| !s.is_empty()).count() >= 1;
+    }
+    if !p.starts_with('/') || p.starts_with("//") {
+        return false;
+    }
+    p.split('/').filter(|s| !s.is_empty()).count() >= 2
+}
+
 /// Append sole-line `@/abs/path` refs for journal dual-write (idempotent).
 ///
 /// Preserves **internal** blank lines in the user body. Only a trailing run of
@@ -1767,12 +1788,14 @@ pub(super) fn append_journal_attachment_refs(
     let mut lines: Vec<String> = content.lines().map(|l| l.to_string()).collect();
 
     // Peel existing trailing sole-line @path refs so we can re-merge idempotently.
+    // Only peel plausible multi-segment absolutes (same gate as FE / cli_sessions
+    // `is_sole_line_at_attachment_path`) so `@/goal …` prose stays in the body.
     let mut prior_refs: Vec<String> = Vec::new();
     while let Some(last) = lines.last() {
         let t = last.trim();
         if let Some(rest) = t.strip_prefix('@') {
             let path = rest.trim();
-            if !path.is_empty() {
+            if is_sole_line_at_attachment_path_ref(path) {
                 prior_refs.push(lines.pop().unwrap());
                 continue;
             }
@@ -1985,6 +2008,15 @@ mod journal_attach_tests {
         let once = append_journal_attachment_refs("hello\n\nworld".into(), &[att("/tmp/a.txt")]);
         let twice = append_journal_attachment_refs(once.clone(), &[att("/tmp/a.txt")]);
         assert_eq!(once, twice);
+    }
+
+    #[test]
+    fn append_does_not_peel_at_goal_prose() {
+        let out = append_journal_attachment_refs(
+            "body\n\n@/goal keep me".into(),
+            &[att("/tmp/shot.png")],
+        );
+        assert_eq!(out, "body\n\n@/goal keep me\n\n@/tmp/shot.png");
     }
 }
 

--- a/src/lib/attachments.test.ts
+++ b/src/lib/attachments.test.ts
@@ -14,6 +14,7 @@ import {
   isImagePath,
   isMediaPath,
   isPlausibleLocalMediaAbs,
+  isSoleLineAtAttachmentPath,
   isVideoPath,
   joinSessionMediaPath,
   mergeAttachments,
@@ -57,6 +58,31 @@ describe("attachments", () => {
     expect(attachments).toHaveLength(2);
     expect(attachments[0]!.path).toBe("/Users/me/pic.png");
     expect(attachments[0]!.name).toBe("pic.png");
+  });
+
+  it("does not treat @/goal prose as a missing-file chip (#1197)", () => {
+    expect(isSoleLineAtAttachmentPath("/goal")).toBe(false);
+    expect(isSoleLineAtAttachmentPath("/goal 你再检查优化一下吧")).toBe(false);
+    expect(isSoleLineAtAttachmentPath("/tmp/notes.md")).toBe(true);
+    expect(
+      isSoleLineAtAttachmentPath("/Users/me/Downloads/Codex 安装教程文档.md"),
+    ).toBe(true);
+
+    const raw =
+      "两句说明\n\n@/goal 你再检查优化一下吧\n\n@/tmp/notes.md";
+    const { text, attachments } = parseAttachmentsFromContent(raw);
+    expect(text).toBe("两句说明\n\n@/goal 你再检查优化一下吧");
+    expect(attachments.map((a) => a.path)).toEqual(["/tmp/notes.md"]);
+
+    // Appending a real ref must not peel the @/goal prose into the ref block.
+    const withRefs = appendAttachmentRefsToContent(
+      "body\n\n@/goal keep me",
+      [{ path: "/tmp/shot.png", name: "shot.png", isDir: false }],
+    );
+    expect(withRefs).toBe("body\n\n@/goal keep me\n\n@/tmp/shot.png");
+    const again = parseAttachmentsFromContent(withRefs);
+    expect(again.text).toBe("body\n\n@/goal keep me");
+    expect(again.attachments.map((a) => a.path)).toEqual(["/tmp/shot.png"]);
   });
 
   it("append+parse keeps internal blank lines in body", () => {

--- a/src/lib/attachments.ts
+++ b/src/lib/attachments.ts
@@ -56,6 +56,28 @@ export function pathBasename(path: string): string {
 }
 
 /**
+ * Whether a sole-line `@path` candidate is a dual-write attachment ref.
+ * Requires a real absolute shape with a directory segment so prose like
+ * `@/goal …` is not eaten as a missing-file chip (#1197).
+ */
+export function isSoleLineAtAttachmentPath(path: string): boolean {
+  const p = (path ?? "").trim();
+  if (!p) return false;
+  // Windows drive: need at least one path segment after `C:\` / `C:/`.
+  if (/^[A-Za-z]:[\\/]/.test(p)) {
+    const rest = p.slice(2).replace(/^[\\/]+/, "").replace(/\\/g, "/");
+    return rest.split("/").filter(Boolean).length >= 1;
+  }
+  if (!p.startsWith("/") || p.startsWith("//")) return false;
+  // POSIX: `/dir/file` (or deeper). Reject `/goal` and `/goal 你再检查…`
+  // (single segment even when it contains spaces).
+  return p.split("/").filter(Boolean).length >= 2;
+}
+
+/** Match sole-line `@/abs` or `@C:\…` dual-write refs. */
+const SOLE_AT_ABS_PATH_RE = /^@((?:\/|[A-Za-z]:[\\/]).+)$/;
+
+/**
  * Split stored/agent message into display text + attachment list.
  * Lines that are sole `@/abs/path` (or `@path`) become attachments.
  *
@@ -73,16 +95,18 @@ export function parseAttachmentsFromContent(content: string): {
   const textLines: string[] = [];
   for (const line of lines) {
     const trimmed = line.trim();
-    // @/path or @C:\path or @path
-    const m = trimmed.match(/^@((?:\/|[A-Za-z]:[\\/]).+)$/);
+    // @/path or @C:\path — only plausible multi-segment absolutes.
+    const m = trimmed.match(SOLE_AT_ABS_PATH_RE);
     if (m?.[1]) {
       const path = m[1].trim();
-      attachments.push({
-        path,
-        name: pathBasename(path),
-        isDir: false, // refined by pathsClassify when needed
-      });
-      continue;
+      if (isSoleLineAtAttachmentPath(path)) {
+        attachments.push({
+          path,
+          name: pathBasename(path),
+          isDir: false, // refined by pathsClassify when needed
+        });
+        continue;
+      }
     }
     // Legacy display markers from older builds
     const legacy = trimmed.match(/^\[(file|dir)\]\s+(.+)$/i);
@@ -118,8 +142,8 @@ export function appendAttachmentRefsToContent(
   const priorRefs: string[] = [];
   while (lines.length) {
     const t = lines[lines.length - 1]!.trim();
-    const m = t.match(/^@((?:\/|[A-Za-z]:[\\/]).+)$/);
-    if (m?.[1]) {
+    const m = t.match(SOLE_AT_ABS_PATH_RE);
+    if (m?.[1] && isSoleLineAtAttachmentPath(m[1].trim())) {
       priorRefs.unshift(lines.pop()!);
       continue;
     }

--- a/src/lib/mapStoredMessages.test.ts
+++ b/src/lib/mapStoredMessages.test.ts
@@ -39,6 +39,18 @@ describe("mapStoredMessages", () => {
     expect(msg.attachments?.map((a) => a.path)).toEqual(["/tmp/notes.md"]);
   });
 
+  it("keeps @/goal prose in the bubble instead of a missing-file chip (#1197)", () => {
+    const msg = mapStoredMessageToChat({
+      id: "u-goal",
+      role: "user",
+      content: "两句说明\n\n@/goal 你再检查优化一下吧",
+      createdAt: "2026-08-01T00:00:00.000Z",
+      attachments: null,
+    });
+    expect(msg.content).toBe("两句说明\n\n@/goal 你再检查优化一下吧");
+    expect(msg.attachments).toBeUndefined();
+  });
+
   it("maps a batch without dropping attachments", () => {
     const out = mapStoredMessagesToChat([
       {


### PR DESCRIPTION
## Summary
- Reject sole-line `@/` attachments that are only a single path segment (e.g. `@/goal …`), so slash `/goal` is not eaten as a fake file chip.
- Keep real absolute paths like `/tmp/notes.md` attachable.

Closes #1197

## Test plan
- [x] vitest attachments + mapStoredMessages
- [x] cargo tests for parse_at_path / peel
- [ ] Manual: type `@/goal 检查一下` and send — no missing chip; body preserved