### PR TITLE
fix(media): Windows PNG preview no longer claims corrupt (#1198)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ See `docs/llm-wiki/release.md`.
 
 ### Fixed
 - Typing `@/goal …` no longer becomes a missing-file chip; the line stays as text (#1197).
+- Windows PNG previews no longer claim a good file is corrupt (#1198).
 - The account menu no longer repeats the quota card when only one official account is saved.
 - Saving project rules no longer kills another chat's background agent mid-turn.
 - Trusted-project chats no longer reuse a prewarm process that skipped folder trust.
@@ -51,6 +52,7 @@ See `docs/llm-wiki/release.md`.
 
 **中文 · 修复**
 - 输入 `@/goal …` 不再变成失效文件 chip，该行会保留为正文（#1197）。
+- Windows 本地 PNG 预览不再误报「文件可能已损坏」（#1198）。
 - 仅一个官方账号时，用户菜单不再重复显示额度卡片。
 - 保存项目规则时，不再打断同项目另一聊天后台进行中的 agent 回合。
 - 已信任项目不会复用未带文件夹信任的预热进程，AGENTS.md 可正确加载。

--- a/src-tauri/src/media_protocol.rs
+++ b/src-tauri/src/media_protocol.rs
@@ -198,6 +198,21 @@ fn mime_from_path(path: &str) -> &'static str {
     }
 }
 
+/// Strip a spurious leading `/` before a Windows drive (`/C:/Users/…`).
+fn strip_leading_slash_before_windows_drive(path: &str) -> &str {
+    let b = path.as_bytes();
+    if b.len() >= 4
+        && b[0] == b'/'
+        && b[1].is_ascii_alphabetic()
+        && b[2] == b':'
+        && (b[3] == b'/' || b[3] == b'\\')
+    {
+        &path[1..]
+    } else {
+        path
+    }
+}
+
 /// Decode path from `media://localhost/<percent-encoded-path>` (or Windows variant).
 fn path_from_request(request: &Request<Vec<u8>>) -> Option<PathBuf> {
     let uri = request.uri();
@@ -212,7 +227,11 @@ fn path_from_request(request: &Request<Vec<u8>>) -> Option<PathBuf> {
     if decoded.is_empty() {
         return None;
     }
-    Some(PathBuf::from(decoded))
+    // WebView2 sometimes leaves a leading slash before a Windows drive
+    // (`/C:/Users/…`). Strip it so PathBuf opens the real file (#1198).
+    Some(PathBuf::from(strip_leading_slash_before_windows_drive(
+        &decoded,
+    )))
 }
 
 fn percent_decode(input: &str) -> String {
@@ -545,6 +564,23 @@ mod tests {
         assert_eq!(
             percent_decode("%2FUsers%2Fme%2Fvid.mp4"),
             "/Users/me/vid.mp4"
+        );
+    }
+
+    #[test]
+    fn strips_leading_slash_before_windows_drive() {
+        assert_eq!(
+            strip_leading_slash_before_windows_drive("/C:/Users/me/Pictures/a.png"),
+            "C:/Users/me/Pictures/a.png"
+        );
+        assert_eq!(
+            strip_leading_slash_before_windows_drive(r"/D:\shots\b.png"),
+            r"D:\shots\b.png"
+        );
+        // POSIX abs must keep the leading slash.
+        assert_eq!(
+            strip_leading_slash_before_windows_drive("/Users/me/a.png"),
+            "/Users/me/a.png"
         );
     }
 

--- a/src-tauri/src/session_manager/turn.rs
+++ b/src-tauri/src/session_manager/turn.rs
@@ -49,6 +49,7 @@ impl SessionManager {
         // those lines via parseAttachmentsFromContent for the bubble body).
         let journal_attachments = attachments.filter(|items| !items.is_empty());
         if let Some(ref atts) = journal_attachments {
+            grant_journal_attachment_paths(atts);
             journal_content = append_journal_attachment_refs(journal_content, atts);
         }
         // Note: image @path stripping + Host vision runs on the *final*
@@ -691,6 +692,7 @@ impl SessionManager {
             .unwrap_or_else(|| text.clone());
         let attachments = attachments.filter(|items| !items.is_empty());
         if let Some(ref atts) = attachments {
+            grant_journal_attachment_paths(atts);
             journal_content = append_journal_attachment_refs(journal_content, atts);
         }
         let target = session_id.as_deref();

--- a/src-tauri/src/session_manager/types.rs
+++ b/src-tauri/src/session_manager/types.rs
@@ -1772,6 +1772,25 @@ fn is_sole_line_at_attachment_path_ref(path: &str) -> bool {
     p.split('/').filter(|s| !s.is_empty()).count() >= 2
 }
 
+/// Grant path_scope for user-attached local files so chat thumbs / media HTTP
+/// can preview Desktop / Documents / Pictures paths without waiting on a later
+/// `paths_classify` race (Windows `@C:\…\shot.png` cards).
+pub(super) fn grant_journal_attachment_paths(atts: &[MessageAttachmentStored]) {
+    for att in atts {
+        let p = att.path.trim();
+        if p.is_empty() || p.starts_with("http://") || p.starts_with("https://") {
+            continue;
+        }
+        if att.is_dir {
+            continue;
+        }
+        let pb = std::path::Path::new(p);
+        if pb.is_file() {
+            crate::path_scope::grant_path(pb);
+        }
+    }
+}
+
 /// Append sole-line `@/abs/path` refs for journal dual-write (idempotent).
 ///
 /// Preserves **internal** blank lines in the user body. Only a trailing run of

--- a/src/lib/mediaLoadPro.test.ts
+++ b/src/lib/mediaLoadPro.test.ts
@@ -4,7 +4,9 @@ import {
   classifyMediaSrcFailure,
   deriveMediaLoadPhase,
   formatMediaLoadErrorMessage,
+  isLocalMediaDeliveryUrl,
   isSafeLocalMediaUrl,
+  mediaCustomProtocolPath,
   mediaLoadErrorLabelMap,
   mediaLoadErrorMessageKey,
   mediaLoadPhaseMessageKey,
@@ -117,14 +119,23 @@ describe("classifyMediaSrcFailure", () => {
     ).toBe("media_server_unavailable");
   });
 
-  it("broken blob after loadFailed with src", () => {
+  it("loadFailed with local delivery prefers retryable kinds over brokenBlob", () => {
+    // Real local path on a loopback URL → grant/allowlist race (retryable).
     expect(
       classifyMediaSrcFailure({
         pathOrUrl: "/Users/me/pic.png",
+        resolvedSrc: "http://127.0.0.1:9/v1/media?t=x&p=%2FUsers%2Fme%2Fpic.png",
+        loadFailed: true,
+      }),
+    ).toBe("untrusted");
+    // Garbage p= without a usable pathOrUrl → not "corrupt file".
+    expect(
+      classifyMediaSrcFailure({
+        pathOrUrl: "clip",
         resolvedSrc: "http://127.0.0.1:9/v1/media?t=x&p=y",
         loadFailed: true,
       }),
-    ).toBe("broken_blob");
+    ).toBe("media_server_unavailable");
     expect(
       classifyMediaSrcFailure({
         pathOrUrl: "clip",
@@ -290,7 +301,8 @@ describe("deriveMediaLoadPhase / phase keys", () => {
   });
 
   it("phase message keys", () => {
-    expect(mediaLoadPhaseMessageKey("broken")).toBe("media.err.brokenBlob");
+    // Coarse "broken" phase must not claim the file is corrupt (#1198).
+    expect(mediaLoadPhaseMessageKey("broken")).toBe("media.err.other");
     expect(mediaLoadPhaseMessageKey("missing")).toBe("media.err.missingPath");
     expect(mediaLoadPhaseMessageKey("pending")).toBe("media.loading");
     expect(mediaLoadPhaseMessageKey("ready")).toBeNull();
@@ -322,10 +334,19 @@ describe("classifyMediaSrcFailure — fused query keys & loopback URLs", () => {
     ).toBe("untrusted");
   });
 
-  it("loopback media URL without p= is media_server_unavailable", () => {
+  it("loopback media URL without p= still retries via pathOrUrl when absolute", () => {
+    // Missing p= is a malformed media URL, but a known local pathOrUrl must
+    // stay retryable (untrusted) so ImageUi can re-resolve after grant.
     expect(
       classifyMediaSrcFailure({
         pathOrUrl: "/Users/me/pic.png",
+        resolvedSrc: "http://127.0.0.1:52193/v1/media?t=tok",
+        loadFailed: true,
+      }),
+    ).toBe("untrusted");
+    expect(
+      classifyMediaSrcFailure({
+        pathOrUrl: "clip",
         resolvedSrc: "http://127.0.0.1:52193/v1/media?t=tok",
         loadFailed: true,
       }),
@@ -358,6 +379,48 @@ describe("classifyMediaSrcFailure — fused query keys & loopback URLs", () => {
       }),
     ).toBe("broken_blob");
   });
+
+  it("Windows media.localhost cold-start failure is retryable untrusted, not brokenBlob (#1198)", () => {
+    // WebView2 convertFileSrc yields http(s)://media.localhost/… before the
+    // loopback endpoint is ready. Mis-classifying that as broken_blob locked
+    // the card (no retry) even when the PNG on disk was fine.
+    expect(
+      classifyMediaSrcFailure({
+        pathOrUrl: "C:\\Users\\me\\Pictures\\oddsnap_1.png",
+        resolvedSrc:
+          "http://media.localhost/C%3A%2FUsers%2Fme%2FPictures%2Foddsnap_1.png",
+        loadFailed: true,
+      }),
+    ).toBe("untrusted");
+    expect(
+      classifyMediaSrcFailure({
+        pathOrUrl: "C:/Users/me/Pictures/oddsnap_1.png",
+        resolvedSrc:
+          "https://asset.localhost/C%3A%2FUsers%2Fme%2FPictures%2Foddsnap_1.png",
+        loadFailed: true,
+      }),
+    ).toBe("untrusted");
+    expect(
+      shouldRetryLocalMediaFailure(
+        classifyMediaSrcFailure({
+          pathOrUrl: "C:/Users/me/Pictures/a.png",
+          resolvedSrc: "http://media.localhost/C%3A%2FUsers%2Fme%2FPictures%2Fa.png",
+          loadFailed: true,
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("Windows loopback p= path is retryable untrusted on <img> onError", () => {
+    expect(
+      classifyMediaSrcFailure({
+        pathOrUrl: "C:/Users/me/Pictures/oddsnap_1.png",
+        resolvedSrc:
+          "http://127.0.0.1:52193/v1/media?t=tok&p=C%3A%2FUsers%2Fme%2FPictures%2Foddsnap_1.png",
+        loadFailed: true,
+      }),
+    ).toBe("untrusted");
+  });
 });
 
 describe("mediaUrlPathParam", () => {
@@ -379,11 +442,28 @@ describe("mediaUrlPathParam", () => {
     ).toBe(path);
   });
 
-  it("returns null for non-loopback or pathless URLs", () => {
+  it("returns null for remote or pathless URLs", () => {
     expect(mediaUrlPathParam("https://cdn.example/a.png")).toBe(null);
     expect(mediaUrlPathParam("http://127.0.0.1:9/v1/media?t=tok")).toBe(null);
     expect(mediaUrlPathParam("")).toBe(null);
     expect(mediaUrlPathParam(null)).toBe(null);
+  });
+
+  it("extracts Windows paths from media.localhost / asset.localhost (#1198)", () => {
+    expect(
+      mediaUrlPathParam(
+        "http://media.localhost/C%3A%2FUsers%2Fme%2FPictures%2Foddsnap_1.png",
+      ),
+    ).toBe("C:/Users/me/Pictures/oddsnap_1.png");
+    expect(
+      mediaCustomProtocolPath(
+        "https://asset.localhost/C%3A%2FUsers%2Fme%2Fa.png",
+      ),
+    ).toBe("C:/Users/me/a.png");
+    expect(isLocalMediaDeliveryUrl("http://media.localhost/C%3A%2Fx.png")).toBe(
+      true,
+    );
+    expect(isLocalMediaDeliveryUrl("blob:http://localhost/1")).toBe(false);
   });
 });
 

--- a/src/lib/mediaLoadPro.ts
+++ b/src/lib/mediaLoadPro.ts
@@ -296,27 +296,83 @@ export function classifyMediaLoadError(err: unknown): MediaLoadErrorKind {
   return "other";
 }
 
+/** True for token-gated loopback media HTTP (`/v1/media?p=`). */
+function isLoopbackMediaHttpUrl(src: string): boolean {
+  return /^https?:\/\/(127\.0\.0\.1|localhost|\[::1\]|::1)(:|\/)/i.test(src);
+}
+
 /**
- * Extract the `p=` path from a token-gated loopback media URL, or null when
- * the src is not a loopback media URL (or has no path).
- * Returns the *decoded* path exactly as the media server would resolve it.
+ * True for Host local-media delivery URLs: loopback HTTP, cold-start
+ * `media://` / `asset://`, and Windows WebView2 `*.localhost` custom schemes.
+ * Excludes `blob:` / `data:` (those are decoded pixels, not path delivery).
+ */
+export function isLocalMediaDeliveryUrl(src: string | null | undefined): boolean {
+  const raw = (src || "").trim();
+  if (!raw) return false;
+  if (raw.startsWith("blob:") || raw.startsWith("data:")) return false;
+  return isSafeLocalMediaUrl(raw);
+}
+
+/**
+ * Decode a filesystem path from cold-start `media://` / `asset://` /
+ * `http(s)://media.localhost/…` URLs (percent-encoded abs path in pathname).
+ * Windows drive paths arrive as `/C%3A%2F…` — strip the extra leading slash.
+ */
+export function mediaCustomProtocolPath(
+  src: string | null | undefined,
+): string | null {
+  const raw = (src || "").trim();
+  if (!raw) return null;
+  try {
+    const u = new URL(raw);
+    const host = u.hostname.toLowerCase();
+    const proto = u.protocol.toLowerCase();
+    const isCustomHost =
+      host === "media.localhost" || host === "asset.localhost";
+    const isCustomScheme =
+      (proto === "media:" || proto === "asset:") &&
+      (host === "localhost" || host === "" || isCustomHost);
+    if (!isCustomHost && !isCustomScheme) return null;
+    let path = u.pathname || "";
+    if (!path || path === "/") return null;
+    // Some runtimes leave %2F encoded in the pathname; decode fully.
+    try {
+      path = decodeURIComponent(path);
+    } catch {
+      /* keep raw pathname */
+    }
+    // URL pathname always has a leading `/`. Windows `C:/…` must not keep it.
+    if (/^\/[A-Za-z]:[\\/]/.test(path)) {
+      path = path.slice(1);
+    }
+    path = path.trim();
+    return path || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Extract the filesystem path from a local media delivery URL, or null.
+ * - Loopback HTTP: `p=` query param (decoded)
+ * - Cold-start media/asset: percent-decoded pathname
  */
 export function mediaUrlPathParam(
   src: string | null | undefined,
 ): string | null {
   const raw = (src || "").trim();
   if (!raw) return null;
-  if (!/^https?:\/\/(127\.0\.0\.1|localhost|\[::1\]|::1)(:|\/)/i.test(raw)) {
-    return null;
+  if (isLoopbackMediaHttpUrl(raw)) {
+    try {
+      const u = new URL(raw);
+      if (!u.pathname.includes("/v1/media")) return null;
+      const p = u.searchParams.get("p");
+      return p && p.trim() ? p.trim() : null;
+    } catch {
+      return null;
+    }
   }
-  try {
-    const u = new URL(raw);
-    if (!u.pathname.includes("/v1/media")) return null;
-    const p = u.searchParams.get("p");
-    return p && p.trim() ? p.trim() : null;
-  } catch {
-    return null;
-  }
+  return mediaCustomProtocolPath(raw);
 }
 
 /**
@@ -418,19 +474,27 @@ export function classifyMediaSrcFailure(input: {
       ) {
         return "broken_blob";
       }
-      // Loopback media URL: classify by what the server would have answered.
-      // A fused `t:/Users/…` p= param is a path_scope/parsing denial, and a
-      // missing p= means the URL was malformed — neither is a corrupt file.
-      if (/^https?:\/\/(127\.0\.0\.1|localhost|\[::1\]|::1)(:|\/)/i.test(input.resolvedSrc)) {
-        const mediaPath = mediaUrlPathParam(input.resolvedSrc);
+      // Local delivery (loopback HTTP + Windows WebView2 media.localhost /
+      // asset.localhost cold-start). A path_scope 403, grant race, or custom
+      // protocol miss is not a corrupt file — and must stay retryable so the
+      // card can upgrade to loopback HTTP after ensureMediaEndpoint + grant.
+      if (isLocalMediaDeliveryUrl(input.resolvedSrc)) {
+        const fromUrl = mediaUrlPathParam(input.resolvedSrc);
+        // Prefer p= / custom-protocol path; fall back to pathOrUrl so a
+        // Windows media.localhost miss still retries via the known abs path.
+        const mediaPath =
+          fromUrl || (isRealLocalAbsolutePath(path) ? path : null);
         if (mediaPath == null) return "media_server_unavailable";
         if (isFusedQueryKeyPath(mediaPath)) return "untrusted";
         // <img onError> has no HTTP status. A path_scope 403 (user-picked
-        // Desktop/Documents file after restart, before paths_classify grants)
-        // is indistinguishable from a corrupt decode. Known decode codes stay
-        // broken_blob; otherwise treat a real local p= as retryable untrusted.
+        // Desktop/Documents/Pictures file after restart, before paths_classify
+        // grants) is indistinguishable from a corrupt decode. Known decode
+        // codes stay broken_blob; otherwise treat a real local path as
+        // retryable untrusted (ImageUi retries → grant → loopback HTTP).
         if (input.mediaElementError === "decode") return "broken_blob";
         if (isRealLocalAbsolutePath(mediaPath)) return "untrusted";
+        // Garbage p= (not a real abs path) — not a corrupt file claim.
+        return "media_server_unavailable";
       }
       // Remote CDN / markdown images: honest decode failure, not allowlist.
       // (Untrusted is reserved for Host path_scope / media-server 403.)
@@ -559,13 +623,17 @@ export function deriveMediaLoadPhase(input: {
   return "pending";
 }
 
-/** i18n key for a load phase label (title / aria), or null when not needed. */
+/**
+ * i18n key for a load phase label (title / aria), or null when not needed.
+ * `broken` is a coarse phase (any loadFailed) — do **not** claim the file is
+ * corrupt here; prefer {@link mediaLoadErrorMessageKey} when a kind is known.
+ */
 export function mediaLoadPhaseMessageKey(
   phase: MediaLoadPhase,
 ): string | null {
   switch (phase) {
     case "broken":
-      return "media.err.brokenBlob";
+      return "media.err.other";
     case "missing":
       return "media.err.missingPath";
     case "pending":


### PR DESCRIPTION
## Summary
- Treat `media.localhost` / asset hosts as local delivery so cold-start preview failures are retryable, not `brokenBlob`.
- Grant user attachment paths on send; normalize Windows drive paths in media protocol.

Closes #1198

## Test plan
- [x] vitest mediaLoadPro (#1198 cases)
- [x] cargo strips_leading_slash_before_windows_drive
- [ ] Manual Win: attach PNG via `@C:\…\file.png` — thumbnail shows