### PR TITLE
feat(workspace): Doctor + modal show multi-root capability (#1194)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ See `docs/llm-wiki/release.md`.
 ## [Unreleased]
 
 ### Added
+- Doctor reports multi-root workspace capability and reason (#1194).
 - Independent mode can enable write on extra workspace folders (#1194).
 - Project menu can declare extra workspace folders for a chat (#1194).
 - Settings → Appearance can set a solid-color wallpaper with Morandi presets.
@@ -21,6 +22,7 @@ See `docs/llm-wiki/release.md`.
 - The composer branch chip can switch git branches in the current folder. Remote-only rows create a local tracking branch; a branch already checked out in another worktree opens that worktree instead.
 
 **中文 · 新增**
+- Doctor 会报告多根工作区的能力状态与原因（#1194）。
 - 独立模式下可为附加工作区文件夹开启写入（App 管理 sandbox profile）（#1194）。
 - 项目菜单可为会话声明附加工作区文件夹（#1194）。
 - 设置 → 外观可用莫兰迪纯色做背景，不必选图片。

--- a/src-tauri/src/command_registry.rs
+++ b/src-tauri/src/command_registry.rs
@@ -98,6 +98,7 @@ pub fn app_invoke_handler(
         commands::workspace_upsert,
         commands::workspace_delete,
         commands::workspace_validate_root,
+        commands::workspaces_diagnose,
         commands::session_set_workspace,
         // ── Session list/search & CLI session import ──
         commands::sessions_list,

--- a/src-tauri/src/commands/doctor_p1.rs
+++ b/src-tauri/src/commands/doctor_p1.rs
@@ -457,6 +457,94 @@ pub async fn doctor_report() -> Result<serde_json::Value, String> {
         }),
     ));
 
+    // 3b) Multi-root workspaces (#1194) — capability honesty for Doctor
+    let multi_root_ws = match crate::workspace_store::refresh_all_capabilities() {
+        Ok(list) => list,
+        Err(e) => {
+            checks.push(doctor_check(
+                "multi_root_workspace",
+                "warn",
+                "Multi-root workspace",
+                format!("Could not refresh workspace capabilities: {e}"),
+                serde_json::json!({ "error": e }),
+            ));
+            Vec::new()
+        }
+    };
+    if !multi_root_ws.is_empty() {
+        let write_active = multi_root_ws
+            .iter()
+            .filter(|w| {
+                matches!(
+                    w.capability,
+                    crate::workspace_store::WorkspaceCapability::ExtraWriteActive
+                )
+            })
+            .count();
+        let context_only = multi_root_ws
+            .iter()
+            .filter(|w| {
+                matches!(
+                    w.capability,
+                    crate::workspace_store::WorkspaceCapability::ContextOnly
+                )
+            })
+            .count();
+        let blocked = multi_root_ws
+            .iter()
+            .filter(|w| {
+                matches!(
+                    w.capability,
+                    crate::workspace_store::WorkspaceCapability::Blocked
+                )
+            })
+            .count();
+        let level = if blocked > 0 {
+            "fail"
+        } else if context_only > 0 && write_active == 0 {
+            "warn"
+        } else {
+            "ok"
+        };
+        let summaries: Vec<serde_json::Value> = multi_root_ws
+            .iter()
+            .map(|w| {
+                serde_json::json!({
+                    "id": w.id,
+                    "name": w.name,
+                    "capability": match w.capability {
+                        crate::workspace_store::WorkspaceCapability::None => "none",
+                        crate::workspace_store::WorkspaceCapability::ContextOnly => "context_only",
+                        crate::workspace_store::WorkspaceCapability::EnforcedRead => "enforced_read",
+                        crate::workspace_store::WorkspaceCapability::ExtraWriteActive => "extra_write_active",
+                        crate::workspace_store::WorkspaceCapability::Blocked => "blocked",
+                    },
+                    "profileRef": w.profile_ref,
+                    "reason": w.capability_reason,
+                    "rootCount": w.roots.len(),
+                    "extraWriteCount": w.roots.iter().filter(|r| {
+                        r.role == crate::workspace_store::WorkspaceRootRole::Extra
+                            && r.access == crate::workspace_store::WorkspaceRootAccess::Write
+                    }).count(),
+                })
+            })
+            .collect();
+        checks.push(doctor_check(
+            "multi_root_workspace",
+            level,
+            "Multi-root workspace",
+            format!(
+                "{} workspace(s) · {write_active} write-active · {context_only} context-only · {blocked} blocked · mode {}",
+                multi_root_ws.len(),
+                settings.session_data_mode
+            ),
+            serde_json::json!({
+                "workspaces": summaries,
+                "sessionDataMode": settings.session_data_mode,
+            }),
+        ));
+    }
+
     // 4) Backend
     let (backend_level, backend_detail) = if backend_default == "mock_acp" {
         (

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -46,6 +46,12 @@ pub fn workspace_validate_root(path: String) -> Result<WorkspaceRoot, String> {
     })
 }
 
+/// Refresh capability plans for all workspaces (Doctor / settings).
+#[tauri::command]
+pub fn workspaces_diagnose() -> Result<Vec<WorkspaceRecord>, String> {
+    workspace_store::refresh_all_capabilities()
+}
+
 /// Bind (or clear) a workspace on a session. Grants extra roots into Host
 /// path_scope for App file APIs; does not change CLI OS sandbox (MVP-0).
 #[tauri::command]

--- a/src-tauri/src/workspace_sandbox.rs
+++ b/src-tauri/src/workspace_sandbox.rs
@@ -334,6 +334,7 @@ mod tests {
             ],
             profile_ref: None,
             capability: WorkspaceCapability::ContextOnly,
+            capability_reason: None,
             updated_at: Utc::now(),
         }
     }

--- a/src-tauri/src/workspace_store.rs
+++ b/src-tauri/src/workspace_store.rs
@@ -67,6 +67,9 @@ pub struct WorkspaceRecord {
     pub profile_ref: Option<String>,
     #[serde(default)]
     pub capability: WorkspaceCapability,
+    /// Human-readable reason for the current capability (Doctor / modal).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub capability_reason: Option<String>,
     pub updated_at: DateTime<Utc>,
 }
 
@@ -263,6 +266,7 @@ pub fn upsert_workspace(
                 roots: normalized,
                 profile_ref: None,
                 capability: WorkspaceCapability::ContextOnly,
+                capability_reason: None,
                 updated_at: now,
             };
             apply_capability_plan(&mut record)?;
@@ -276,6 +280,7 @@ pub fn upsert_workspace(
                 roots: normalized,
                 profile_ref: None,
                 capability: WorkspaceCapability::ContextOnly,
+                capability_reason: None,
                 updated_at: now,
             };
             apply_capability_plan(&mut record)?;
@@ -301,7 +306,18 @@ pub fn apply_capability_plan(record: &mut WorkspaceRecord) -> Result<(), String>
     }
     record.capability = plan.capability;
     record.profile_ref = plan.profile_ref;
+    record.capability_reason = Some(plan.reason);
     Ok(())
+}
+
+/// Recompute capability for every stored workspace (Doctor refresh).
+pub fn refresh_all_capabilities() -> Result<Vec<WorkspaceRecord>, String> {
+    let mut file = load_workspace_store();
+    for ws in &mut file.workspaces {
+        apply_capability_plan(ws)?;
+    }
+    save_workspace_store(&file)?;
+    Ok(file.workspaces)
 }
 
 /// Spawn sandbox override for a bound workspace, if any.

--- a/src/components/MultiRootWorkspaceModal.tsx
+++ b/src/components/MultiRootWorkspaceModal.tsx
@@ -99,6 +99,25 @@ export function MultiRootWorkspaceModal({
             ? tr("workspace.multiRoot.bannerIndependent")
             : tr("workspace.multiRoot.bannerContextOnly")}
       </p>
+      {draft ? (
+        <p className="muted" style={{ fontSize: 12, marginTop: 0 }}>
+          {tr("workspace.multiRoot.capabilityLabel")}:{" "}
+          <strong>
+            {draft.capability === "extraWriteActive"
+              ? tr("workspace.multiRoot.capWriteActive")
+              : draft.capability === "blocked"
+                ? tr("workspace.multiRoot.capBlocked")
+                : draft.capability === "enforcedRead"
+                  ? tr("workspace.multiRoot.capEnforcedRead")
+                  : tr("workspace.multiRoot.capContextOnly")}
+          </strong>
+          {draft.capabilityReason
+            ? ` — ${draft.capabilityReason}`
+            : draft.profileRef
+              ? ` — ${draft.profileRef}`
+              : ""}
+        </p>
+      ) : null}
       <label className="field">
         <span className="field-label">{tr("workspace.multiRoot.name")}</span>
         <input

--- a/src/components/settings/GeneralSection.tsx
+++ b/src/components/settings/GeneralSection.tsx
@@ -570,6 +570,9 @@ export function GeneralSection() {
                   <div className="settings-row__desc">
                     {t("settings.multiRootWorkspaceDesc")}
                   </div>
+                  <div className="settings-row__desc">
+                    {t("settings.multiRootWorkspaceDoctorHint")}
+                  </div>
                 </div>
               </div>
               {onSandboxProfile ? (

--- a/src/i18n/messages/de/settings.ts
+++ b/src/i18n/messages/de/settings.ts
@@ -554,5 +554,6 @@ export const deSettings = {
   "settings.ssh.watchError": "Überwachung konnte nicht geändert werden: {error}",
   "settings.ssh.remoteSessionsEmpty": "Noch keine Remote-Grok-Sitzungen gefunden.",
   "settings.multiRootWorkspace": "Multi-root workspace",
-  "settings.multiRootWorkspaceDesc": "Declare extra folders on a chat (read-only in this version). Cross-folder write needs a verified CLI sandbox profile later."
+  "settings.multiRootWorkspaceDesc": "Declare extra folders on a chat (read-only in this version). Cross-folder write needs a verified CLI sandbox profile later.",
+  "settings.multiRootWorkspaceDoctorHint": "Run Doctor to see each workspace capability and reason (write-active vs context-only)."
 };

--- a/src/i18n/messages/de/workspace.ts
+++ b/src/i18n/messages/de/workspace.ts
@@ -543,5 +543,10 @@ export const deWorkspace = {
   "workspace.multiRoot.manage": "Manage workspace roots",
   "workspace.multiRoot.bannerWriteActive": "Cross-folder write is active for this workspace via a verified sandbox profile. Changes apply on the next agent turn.",
   "workspace.multiRoot.bannerIndependent": "Independent mode can grant write on extra folders (App writes agent-home sandbox.toml). Shared mode stays read-only unless you maintain ~/.grok/sandbox.toml yourself.",
-  "workspace.multiRoot.enableWrite": "Allow write"
+  "workspace.multiRoot.enableWrite": "Allow write",
+  "workspace.multiRoot.capabilityLabel": "Capability",
+  "workspace.multiRoot.capContextOnly": "context_only",
+  "workspace.multiRoot.capEnforcedRead": "enforced_read",
+  "workspace.multiRoot.capWriteActive": "extra_write_active",
+  "workspace.multiRoot.capBlocked": "blocked"
 };

--- a/src/i18n/messages/en/settings.ts
+++ b/src/i18n/messages/en/settings.ts
@@ -555,5 +555,6 @@ export const enSettings = {
   "settings.ssh.watchError": "Could not change watch: {error}",
   "settings.ssh.remoteSessionsEmpty": "No remote Grok sessions found yet.",
   "settings.multiRootWorkspace": "Multi-root workspace",
-  "settings.multiRootWorkspaceDesc": "Declare extra folders on a chat (read-only in this version). Cross-folder write needs a verified CLI sandbox profile later."
+  "settings.multiRootWorkspaceDesc": "Declare extra folders on a chat (read-only in this version). Cross-folder write needs a verified CLI sandbox profile later.",
+  "settings.multiRootWorkspaceDoctorHint": "Run Doctor to see each workspace capability and reason (write-active vs context-only)."
 } as const;

--- a/src/i18n/messages/en/workspace.ts
+++ b/src/i18n/messages/en/workspace.ts
@@ -545,5 +545,10 @@ export const enWorkspace = {
   "workspace.multiRoot.manage": "Manage workspace roots",
   "workspace.multiRoot.bannerWriteActive": "Cross-folder write is active for this workspace via a verified sandbox profile. Changes apply on the next agent turn.",
   "workspace.multiRoot.bannerIndependent": "Independent mode can grant write on extra folders (App writes agent-home sandbox.toml). Shared mode stays read-only unless you maintain ~/.grok/sandbox.toml yourself.",
-  "workspace.multiRoot.enableWrite": "Allow write"
+  "workspace.multiRoot.enableWrite": "Allow write",
+  "workspace.multiRoot.capabilityLabel": "Capability",
+  "workspace.multiRoot.capContextOnly": "context_only",
+  "workspace.multiRoot.capEnforcedRead": "enforced_read",
+  "workspace.multiRoot.capWriteActive": "extra_write_active",
+  "workspace.multiRoot.capBlocked": "blocked"
 } as const;

--- a/src/i18n/messages/es/settings.ts
+++ b/src/i18n/messages/es/settings.ts
@@ -554,5 +554,6 @@ export const esSettings = {
   "settings.ssh.watchError": "No se pudo cambiar la supervisión: {error}",
   "settings.ssh.remoteSessionsEmpty": "Aún no se encontraron sesiones remotas de Grok.",
   "settings.multiRootWorkspace": "Multi-root workspace",
-  "settings.multiRootWorkspaceDesc": "Declare extra folders on a chat (read-only in this version). Cross-folder write needs a verified CLI sandbox profile later."
+  "settings.multiRootWorkspaceDesc": "Declare extra folders on a chat (read-only in this version). Cross-folder write needs a verified CLI sandbox profile later.",
+  "settings.multiRootWorkspaceDoctorHint": "Run Doctor to see each workspace capability and reason (write-active vs context-only)."
 };

--- a/src/i18n/messages/es/workspace.ts
+++ b/src/i18n/messages/es/workspace.ts
@@ -543,5 +543,10 @@ export const esWorkspace = {
   "workspace.multiRoot.manage": "Manage workspace roots",
   "workspace.multiRoot.bannerWriteActive": "Cross-folder write is active for this workspace via a verified sandbox profile. Changes apply on the next agent turn.",
   "workspace.multiRoot.bannerIndependent": "Independent mode can grant write on extra folders (App writes agent-home sandbox.toml). Shared mode stays read-only unless you maintain ~/.grok/sandbox.toml yourself.",
-  "workspace.multiRoot.enableWrite": "Allow write"
+  "workspace.multiRoot.enableWrite": "Allow write",
+  "workspace.multiRoot.capabilityLabel": "Capability",
+  "workspace.multiRoot.capContextOnly": "context_only",
+  "workspace.multiRoot.capEnforcedRead": "enforced_read",
+  "workspace.multiRoot.capWriteActive": "extra_write_active",
+  "workspace.multiRoot.capBlocked": "blocked"
 };

--- a/src/i18n/messages/fil/settings.ts
+++ b/src/i18n/messages/fil/settings.ts
@@ -554,5 +554,6 @@ export const filSettings = {
   "settings.ssh.watchError": "Hindi mabago ang pagbabantay: {error}",
   "settings.ssh.remoteSessionsEmpty": "Wala pang nakitang remote na session ng Grok.",
   "settings.multiRootWorkspace": "Multi-root workspace",
-  "settings.multiRootWorkspaceDesc": "Declare extra folders on a chat (read-only in this version). Cross-folder write needs a verified CLI sandbox profile later."
+  "settings.multiRootWorkspaceDesc": "Declare extra folders on a chat (read-only in this version). Cross-folder write needs a verified CLI sandbox profile later.",
+  "settings.multiRootWorkspaceDoctorHint": "Run Doctor to see each workspace capability and reason (write-active vs context-only)."
 };

--- a/src/i18n/messages/fil/workspace.ts
+++ b/src/i18n/messages/fil/workspace.ts
@@ -543,5 +543,10 @@ export const filWorkspace = {
   "workspace.multiRoot.manage": "Manage workspace roots",
   "workspace.multiRoot.bannerWriteActive": "Cross-folder write is active for this workspace via a verified sandbox profile. Changes apply on the next agent turn.",
   "workspace.multiRoot.bannerIndependent": "Independent mode can grant write on extra folders (App writes agent-home sandbox.toml). Shared mode stays read-only unless you maintain ~/.grok/sandbox.toml yourself.",
-  "workspace.multiRoot.enableWrite": "Allow write"
+  "workspace.multiRoot.enableWrite": "Allow write",
+  "workspace.multiRoot.capabilityLabel": "Capability",
+  "workspace.multiRoot.capContextOnly": "context_only",
+  "workspace.multiRoot.capEnforcedRead": "enforced_read",
+  "workspace.multiRoot.capWriteActive": "extra_write_active",
+  "workspace.multiRoot.capBlocked": "blocked"
 };

--- a/src/i18n/messages/fr/settings.ts
+++ b/src/i18n/messages/fr/settings.ts
@@ -554,5 +554,6 @@ export const frSettings = {
   "settings.ssh.watchError": "Impossible de modifier la surveillance : {error}",
   "settings.ssh.remoteSessionsEmpty": "Aucune session Grok distante trouvée pour l’instant.",
   "settings.multiRootWorkspace": "Multi-root workspace",
-  "settings.multiRootWorkspaceDesc": "Declare extra folders on a chat (read-only in this version). Cross-folder write needs a verified CLI sandbox profile later."
+  "settings.multiRootWorkspaceDesc": "Declare extra folders on a chat (read-only in this version). Cross-folder write needs a verified CLI sandbox profile later.",
+  "settings.multiRootWorkspaceDoctorHint": "Run Doctor to see each workspace capability and reason (write-active vs context-only)."
 };

--- a/src/i18n/messages/fr/workspace.ts
+++ b/src/i18n/messages/fr/workspace.ts
@@ -543,5 +543,10 @@ export const frWorkspace = {
   "workspace.multiRoot.manage": "Manage workspace roots",
   "workspace.multiRoot.bannerWriteActive": "Cross-folder write is active for this workspace via a verified sandbox profile. Changes apply on the next agent turn.",
   "workspace.multiRoot.bannerIndependent": "Independent mode can grant write on extra folders (App writes agent-home sandbox.toml). Shared mode stays read-only unless you maintain ~/.grok/sandbox.toml yourself.",
-  "workspace.multiRoot.enableWrite": "Allow write"
+  "workspace.multiRoot.enableWrite": "Allow write",
+  "workspace.multiRoot.capabilityLabel": "Capability",
+  "workspace.multiRoot.capContextOnly": "context_only",
+  "workspace.multiRoot.capEnforcedRead": "enforced_read",
+  "workspace.multiRoot.capWriteActive": "extra_write_active",
+  "workspace.multiRoot.capBlocked": "blocked"
 };

--- a/src/i18n/messages/id/settings.ts
+++ b/src/i18n/messages/id/settings.ts
@@ -554,5 +554,6 @@ export const idSettings = {
   "settings.ssh.watchError": "Tidak dapat mengubah pengawasan: {error}",
   "settings.ssh.remoteSessionsEmpty": "Belum ada sesi Grok jarak jauh yang ditemukan.",
   "settings.multiRootWorkspace": "Multi-root workspace",
-  "settings.multiRootWorkspaceDesc": "Declare extra folders on a chat (read-only in this version). Cross-folder write needs a verified CLI sandbox profile later."
+  "settings.multiRootWorkspaceDesc": "Declare extra folders on a chat (read-only in this version). Cross-folder write needs a verified CLI sandbox profile later.",
+  "settings.multiRootWorkspaceDoctorHint": "Run Doctor to see each workspace capability and reason (write-active vs context-only)."
 };

--- a/src/i18n/messages/id/workspace.ts
+++ b/src/i18n/messages/id/workspace.ts
@@ -543,5 +543,10 @@ export const idWorkspace = {
   "workspace.multiRoot.manage": "Manage workspace roots",
   "workspace.multiRoot.bannerWriteActive": "Cross-folder write is active for this workspace via a verified sandbox profile. Changes apply on the next agent turn.",
   "workspace.multiRoot.bannerIndependent": "Independent mode can grant write on extra folders (App writes agent-home sandbox.toml). Shared mode stays read-only unless you maintain ~/.grok/sandbox.toml yourself.",
-  "workspace.multiRoot.enableWrite": "Allow write"
+  "workspace.multiRoot.enableWrite": "Allow write",
+  "workspace.multiRoot.capabilityLabel": "Capability",
+  "workspace.multiRoot.capContextOnly": "context_only",
+  "workspace.multiRoot.capEnforcedRead": "enforced_read",
+  "workspace.multiRoot.capWriteActive": "extra_write_active",
+  "workspace.multiRoot.capBlocked": "blocked"
 };

--- a/src/i18n/messages/it/settings.ts
+++ b/src/i18n/messages/it/settings.ts
@@ -554,5 +554,6 @@ export const itSettings = {
   "settings.ssh.watchError": "Impossibile modificare il monitoraggio: {error}",
   "settings.ssh.remoteSessionsEmpty": "Nessuna sessione Grok remota trovata.",
   "settings.multiRootWorkspace": "Multi-root workspace",
-  "settings.multiRootWorkspaceDesc": "Declare extra folders on a chat (read-only in this version). Cross-folder write needs a verified CLI sandbox profile later."
+  "settings.multiRootWorkspaceDesc": "Declare extra folders on a chat (read-only in this version). Cross-folder write needs a verified CLI sandbox profile later.",
+  "settings.multiRootWorkspaceDoctorHint": "Run Doctor to see each workspace capability and reason (write-active vs context-only)."
 };

--- a/src/i18n/messages/it/workspace.ts
+++ b/src/i18n/messages/it/workspace.ts
@@ -543,5 +543,10 @@ export const itWorkspace = {
   "workspace.multiRoot.manage": "Manage workspace roots",
   "workspace.multiRoot.bannerWriteActive": "Cross-folder write is active for this workspace via a verified sandbox profile. Changes apply on the next agent turn.",
   "workspace.multiRoot.bannerIndependent": "Independent mode can grant write on extra folders (App writes agent-home sandbox.toml). Shared mode stays read-only unless you maintain ~/.grok/sandbox.toml yourself.",
-  "workspace.multiRoot.enableWrite": "Allow write"
+  "workspace.multiRoot.enableWrite": "Allow write",
+  "workspace.multiRoot.capabilityLabel": "Capability",
+  "workspace.multiRoot.capContextOnly": "context_only",
+  "workspace.multiRoot.capEnforcedRead": "enforced_read",
+  "workspace.multiRoot.capWriteActive": "extra_write_active",
+  "workspace.multiRoot.capBlocked": "blocked"
 };

--- a/src/i18n/messages/ja/settings.ts
+++ b/src/i18n/messages/ja/settings.ts
@@ -554,5 +554,6 @@ export const jaSettings = {
   "settings.ssh.watchError": "監視を変更できませんでした: {error}",
   "settings.ssh.remoteSessionsEmpty": "リモートの Grok セッションはまだ見つかりません。",
   "settings.multiRootWorkspace": "Multi-root workspace",
-  "settings.multiRootWorkspaceDesc": "Declare extra folders on a chat (read-only in this version). Cross-folder write needs a verified CLI sandbox profile later."
+  "settings.multiRootWorkspaceDesc": "Declare extra folders on a chat (read-only in this version). Cross-folder write needs a verified CLI sandbox profile later.",
+  "settings.multiRootWorkspaceDoctorHint": "Run Doctor to see each workspace capability and reason (write-active vs context-only)."
 };

--- a/src/i18n/messages/ja/workspace.ts
+++ b/src/i18n/messages/ja/workspace.ts
@@ -543,5 +543,10 @@ export const jaWorkspace = {
   "workspace.multiRoot.manage": "Manage workspace roots",
   "workspace.multiRoot.bannerWriteActive": "Cross-folder write is active for this workspace via a verified sandbox profile. Changes apply on the next agent turn.",
   "workspace.multiRoot.bannerIndependent": "Independent mode can grant write on extra folders (App writes agent-home sandbox.toml). Shared mode stays read-only unless you maintain ~/.grok/sandbox.toml yourself.",
-  "workspace.multiRoot.enableWrite": "Allow write"
+  "workspace.multiRoot.enableWrite": "Allow write",
+  "workspace.multiRoot.capabilityLabel": "Capability",
+  "workspace.multiRoot.capContextOnly": "context_only",
+  "workspace.multiRoot.capEnforcedRead": "enforced_read",
+  "workspace.multiRoot.capWriteActive": "extra_write_active",
+  "workspace.multiRoot.capBlocked": "blocked"
 };

--- a/src/i18n/messages/ko/settings.ts
+++ b/src/i18n/messages/ko/settings.ts
@@ -554,5 +554,6 @@ export const koSettings = {
   "settings.ssh.watchError": "감시 설정을 변경할 수 없습니다: {error}",
   "settings.ssh.remoteSessionsEmpty": "아직 원격 Grok 세션을 찾지 못했습니다.",
   "settings.multiRootWorkspace": "Multi-root workspace",
-  "settings.multiRootWorkspaceDesc": "Declare extra folders on a chat (read-only in this version). Cross-folder write needs a verified CLI sandbox profile later."
+  "settings.multiRootWorkspaceDesc": "Declare extra folders on a chat (read-only in this version). Cross-folder write needs a verified CLI sandbox profile later.",
+  "settings.multiRootWorkspaceDoctorHint": "Run Doctor to see each workspace capability and reason (write-active vs context-only)."
 };

--- a/src/i18n/messages/ko/workspace.ts
+++ b/src/i18n/messages/ko/workspace.ts
@@ -543,5 +543,10 @@ export const koWorkspace = {
   "workspace.multiRoot.manage": "Manage workspace roots",
   "workspace.multiRoot.bannerWriteActive": "Cross-folder write is active for this workspace via a verified sandbox profile. Changes apply on the next agent turn.",
   "workspace.multiRoot.bannerIndependent": "Independent mode can grant write on extra folders (App writes agent-home sandbox.toml). Shared mode stays read-only unless you maintain ~/.grok/sandbox.toml yourself.",
-  "workspace.multiRoot.enableWrite": "Allow write"
+  "workspace.multiRoot.enableWrite": "Allow write",
+  "workspace.multiRoot.capabilityLabel": "Capability",
+  "workspace.multiRoot.capContextOnly": "context_only",
+  "workspace.multiRoot.capEnforcedRead": "enforced_read",
+  "workspace.multiRoot.capWriteActive": "extra_write_active",
+  "workspace.multiRoot.capBlocked": "blocked"
 };

--- a/src/i18n/messages/pt-BR/settings.ts
+++ b/src/i18n/messages/pt-BR/settings.ts
@@ -554,5 +554,6 @@ export const ptBRSettings = {
   "settings.ssh.watchError": "Não foi possível alterar o monitoramento: {error}",
   "settings.ssh.remoteSessionsEmpty": "Nenhuma sessão remota do Grok encontrada ainda.",
   "settings.multiRootWorkspace": "Multi-root workspace",
-  "settings.multiRootWorkspaceDesc": "Declare extra folders on a chat (read-only in this version). Cross-folder write needs a verified CLI sandbox profile later."
+  "settings.multiRootWorkspaceDesc": "Declare extra folders on a chat (read-only in this version). Cross-folder write needs a verified CLI sandbox profile later.",
+  "settings.multiRootWorkspaceDoctorHint": "Run Doctor to see each workspace capability and reason (write-active vs context-only)."
 };

--- a/src/i18n/messages/pt-BR/workspace.ts
+++ b/src/i18n/messages/pt-BR/workspace.ts
@@ -543,5 +543,10 @@ export const ptBRWorkspace = {
   "workspace.multiRoot.manage": "Manage workspace roots",
   "workspace.multiRoot.bannerWriteActive": "Cross-folder write is active for this workspace via a verified sandbox profile. Changes apply on the next agent turn.",
   "workspace.multiRoot.bannerIndependent": "Independent mode can grant write on extra folders (App writes agent-home sandbox.toml). Shared mode stays read-only unless you maintain ~/.grok/sandbox.toml yourself.",
-  "workspace.multiRoot.enableWrite": "Allow write"
+  "workspace.multiRoot.enableWrite": "Allow write",
+  "workspace.multiRoot.capabilityLabel": "Capability",
+  "workspace.multiRoot.capContextOnly": "context_only",
+  "workspace.multiRoot.capEnforcedRead": "enforced_read",
+  "workspace.multiRoot.capWriteActive": "extra_write_active",
+  "workspace.multiRoot.capBlocked": "blocked"
 };

--- a/src/i18n/messages/ru/settings.ts
+++ b/src/i18n/messages/ru/settings.ts
@@ -554,5 +554,6 @@ export const ruSettings = {
   "settings.ssh.watchError": "Не удалось изменить наблюдение: {error}",
   "settings.ssh.remoteSessionsEmpty": "Удалённые сессии Grok пока не найдены.",
   "settings.multiRootWorkspace": "Multi-root workspace",
-  "settings.multiRootWorkspaceDesc": "Declare extra folders on a chat (read-only in this version). Cross-folder write needs a verified CLI sandbox profile later."
+  "settings.multiRootWorkspaceDesc": "Declare extra folders on a chat (read-only in this version). Cross-folder write needs a verified CLI sandbox profile later.",
+  "settings.multiRootWorkspaceDoctorHint": "Run Doctor to see each workspace capability and reason (write-active vs context-only)."
 };

--- a/src/i18n/messages/ru/workspace.ts
+++ b/src/i18n/messages/ru/workspace.ts
@@ -543,5 +543,10 @@ export const ruWorkspace = {
   "workspace.multiRoot.manage": "Manage workspace roots",
   "workspace.multiRoot.bannerWriteActive": "Cross-folder write is active for this workspace via a verified sandbox profile. Changes apply on the next agent turn.",
   "workspace.multiRoot.bannerIndependent": "Independent mode can grant write on extra folders (App writes agent-home sandbox.toml). Shared mode stays read-only unless you maintain ~/.grok/sandbox.toml yourself.",
-  "workspace.multiRoot.enableWrite": "Allow write"
+  "workspace.multiRoot.enableWrite": "Allow write",
+  "workspace.multiRoot.capabilityLabel": "Capability",
+  "workspace.multiRoot.capContextOnly": "context_only",
+  "workspace.multiRoot.capEnforcedRead": "enforced_read",
+  "workspace.multiRoot.capWriteActive": "extra_write_active",
+  "workspace.multiRoot.capBlocked": "blocked"
 };

--- a/src/i18n/messages/ta/settings.ts
+++ b/src/i18n/messages/ta/settings.ts
@@ -554,5 +554,6 @@ export const taSettings = {
   "settings.ssh.watchError": "கண்காணிப்பை மாற்ற முடியவில்லை: {error}",
   "settings.ssh.remoteSessionsEmpty": "தொலைநிலை Grok அமர்வுகள் இதுவரை கிடைக்கவில்லை.",
   "settings.multiRootWorkspace": "Multi-root workspace",
-  "settings.multiRootWorkspaceDesc": "Declare extra folders on a chat (read-only in this version). Cross-folder write needs a verified CLI sandbox profile later."
+  "settings.multiRootWorkspaceDesc": "Declare extra folders on a chat (read-only in this version). Cross-folder write needs a verified CLI sandbox profile later.",
+  "settings.multiRootWorkspaceDoctorHint": "Run Doctor to see each workspace capability and reason (write-active vs context-only)."
 };

--- a/src/i18n/messages/ta/workspace.ts
+++ b/src/i18n/messages/ta/workspace.ts
@@ -543,5 +543,10 @@ export const taWorkspace = {
   "workspace.multiRoot.manage": "Manage workspace roots",
   "workspace.multiRoot.bannerWriteActive": "Cross-folder write is active for this workspace via a verified sandbox profile. Changes apply on the next agent turn.",
   "workspace.multiRoot.bannerIndependent": "Independent mode can grant write on extra folders (App writes agent-home sandbox.toml). Shared mode stays read-only unless you maintain ~/.grok/sandbox.toml yourself.",
-  "workspace.multiRoot.enableWrite": "Allow write"
+  "workspace.multiRoot.enableWrite": "Allow write",
+  "workspace.multiRoot.capabilityLabel": "Capability",
+  "workspace.multiRoot.capContextOnly": "context_only",
+  "workspace.multiRoot.capEnforcedRead": "enforced_read",
+  "workspace.multiRoot.capWriteActive": "extra_write_active",
+  "workspace.multiRoot.capBlocked": "blocked"
 };

--- a/src/i18n/messages/uk/settings.ts
+++ b/src/i18n/messages/uk/settings.ts
@@ -554,5 +554,6 @@ export const ukSettings = {
   "settings.ssh.watchError": "Не вдалося змінити спостереження: {error}",
   "settings.ssh.remoteSessionsEmpty": "Віддалених сесій Grok ще не знайдено.",
   "settings.multiRootWorkspace": "Multi-root workspace",
-  "settings.multiRootWorkspaceDesc": "Declare extra folders on a chat (read-only in this version). Cross-folder write needs a verified CLI sandbox profile later."
+  "settings.multiRootWorkspaceDesc": "Declare extra folders on a chat (read-only in this version). Cross-folder write needs a verified CLI sandbox profile later.",
+  "settings.multiRootWorkspaceDoctorHint": "Run Doctor to see each workspace capability and reason (write-active vs context-only)."
 };

--- a/src/i18n/messages/uk/workspace.ts
+++ b/src/i18n/messages/uk/workspace.ts
@@ -543,5 +543,10 @@ export const ukWorkspace = {
   "workspace.multiRoot.manage": "Manage workspace roots",
   "workspace.multiRoot.bannerWriteActive": "Cross-folder write is active for this workspace via a verified sandbox profile. Changes apply on the next agent turn.",
   "workspace.multiRoot.bannerIndependent": "Independent mode can grant write on extra folders (App writes agent-home sandbox.toml). Shared mode stays read-only unless you maintain ~/.grok/sandbox.toml yourself.",
-  "workspace.multiRoot.enableWrite": "Allow write"
+  "workspace.multiRoot.enableWrite": "Allow write",
+  "workspace.multiRoot.capabilityLabel": "Capability",
+  "workspace.multiRoot.capContextOnly": "context_only",
+  "workspace.multiRoot.capEnforcedRead": "enforced_read",
+  "workspace.multiRoot.capWriteActive": "extra_write_active",
+  "workspace.multiRoot.capBlocked": "blocked"
 };

--- a/src/i18n/messages/zh-TW/settings.ts
+++ b/src/i18n/messages/zh-TW/settings.ts
@@ -555,5 +555,6 @@ export const zhTWSettings = {
   "settings.ssh.watchError": "無法切換監視：{error}",
   "settings.ssh.remoteSessionsEmpty": "還沒掃描到遠端 Grok session。",
   "settings.multiRootWorkspace": "多根工作區",
-  "settings.multiRootWorkspaceDesc": "在對話上宣告附加資料夾（本版本唯讀）。跨資料夾寫入需後續驗證 CLI sandbox profile。"
+  "settings.multiRootWorkspaceDesc": "在對話上宣告附加資料夾（本版本唯讀）。跨資料夾寫入需後續驗證 CLI sandbox profile。",
+  "settings.multiRootWorkspaceDoctorHint": "執行 Doctor 可查看每個工作區的能力狀態與原因（可寫 / 僅宣告）。"
 };

--- a/src/i18n/messages/zh-TW/workspace.ts
+++ b/src/i18n/messages/zh-TW/workspace.ts
@@ -545,5 +545,10 @@ export const zhTWWorkspace = {
   "workspace.multiRoot.manage": "管理工作區根目錄",
   "workspace.multiRoot.bannerWriteActive": "已透過已驗證的 sandbox profile 啟用跨目錄寫入。變更在下一輪 agent 生效。",
   "workspace.multiRoot.bannerIndependent": "獨立模式下可為附加資料夾開寫（App 寫入 agent-home sandbox.toml）。共享模式預設唯讀，除非你自行維護 ~/.grok/sandbox.toml。",
-  "workspace.multiRoot.enableWrite": "允許寫入"
+  "workspace.multiRoot.enableWrite": "允許寫入",
+  "workspace.multiRoot.capabilityLabel": "能力狀態",
+  "workspace.multiRoot.capContextOnly": "context_only（僅宣告）",
+  "workspace.multiRoot.capEnforcedRead": "enforced_read",
+  "workspace.multiRoot.capWriteActive": "extra_write_active（可寫）",
+  "workspace.multiRoot.capBlocked": "blocked"
 };

--- a/src/i18n/messages/zh/settings.ts
+++ b/src/i18n/messages/zh/settings.ts
@@ -555,5 +555,6 @@ export const zhSettings = {
   "settings.ssh.watchError": "无法切换监视：{error}",
   "settings.ssh.remoteSessionsEmpty": "还没有扫描到远程 Grok session。",
   "settings.multiRootWorkspace": "多根工作区",
-  "settings.multiRootWorkspaceDesc": "在会话上声明附加文件夹（本版本只读）。跨文件夹写入需后续验证 CLI sandbox profile。"
+  "settings.multiRootWorkspaceDesc": "在会话上声明附加文件夹（本版本只读）。跨文件夹写入需后续验证 CLI sandbox profile。",
+  "settings.multiRootWorkspaceDoctorHint": "运行 Doctor 可查看每个工作区的能力状态与原因（可写 / 仅声明）。"
 };

--- a/src/i18n/messages/zh/workspace.ts
+++ b/src/i18n/messages/zh/workspace.ts
@@ -545,5 +545,10 @@ export const zhWorkspace = {
   "workspace.multiRoot.manage": "管理工作区根目录",
   "workspace.multiRoot.bannerWriteActive": "已通过已验证的 sandbox profile 启用跨目录写入。更改在下一轮 agent 生效。",
   "workspace.multiRoot.bannerIndependent": "独立模式下可为附加文件夹开写（App 写入 agent-home sandbox.toml）。共享模式默认只读，除非你自行维护 ~/.grok/sandbox.toml。",
-  "workspace.multiRoot.enableWrite": "允许写入"
+  "workspace.multiRoot.enableWrite": "允许写入",
+  "workspace.multiRoot.capabilityLabel": "能力状态",
+  "workspace.multiRoot.capContextOnly": "context_only（仅声明）",
+  "workspace.multiRoot.capEnforcedRead": "enforced_read",
+  "workspace.multiRoot.capWriteActive": "extra_write_active（可写）",
+  "workspace.multiRoot.capBlocked": "blocked"
 };

--- a/src/lib/api/workspace.ts
+++ b/src/lib/api/workspace.ts
@@ -39,6 +39,11 @@ export async function workspaceValidateRoot(path: string) {
   return invoke<WorkspaceRoot>("workspace_validate_root", { path });
 }
 
+/** Refresh capability plans for all workspaces. */
+export async function workspacesDiagnose() {
+  return invoke<WorkspaceRecord[]>("workspaces_diagnose");
+}
+
 export async function sessionSetWorkspace(
   id: string,
   workspaceId: string | null,

--- a/src/lib/doctorFindings.ts
+++ b/src/lib/doctorFindings.ts
@@ -162,7 +162,13 @@ export function classifyDoctorFindingCategory(
     }
     if (head === "mic" || head === "audio") return "voice";
     if (head === "log" || head === "logging") return "logs";
-    if (head === "ws" || head === "project" || head === "cwd") {
+    if (
+      head === "ws" ||
+      head === "project" ||
+      head === "cwd" ||
+      head === "multi" ||
+      raw.startsWith("multi_root")
+    ) {
       return "workspace";
     }
     if (head === "agent" || head === "acp" || head === "runtime") {

--- a/src/lib/multiRootWorkspace.ts
+++ b/src/lib/multiRootWorkspace.ts
@@ -26,6 +26,8 @@ export type WorkspaceRecord = {
   roots: WorkspaceRoot[];
   profileRef?: string | null;
   capability: WorkspaceCapability;
+  /** Host reason for current capability (Doctor / modal). */
+  capabilityReason?: string | null;
   updatedAt: string;
 };
 

--- a/src/lib/settingsCatalog/entries/general.ts
+++ b/src/lib/settingsCatalog/entries/general.ts
@@ -235,6 +235,7 @@ export const GENERAL_ENTRIES: readonly SettingsEntry[] = [
     labelKey: "settings.multiRootWorkspace",
     descKeys: [
       "settings.multiRootWorkspaceDesc",
+      "settings.multiRootWorkspaceDoctorHint",
       "workspace.multiRoot.bannerContextOnly",
       "settings.section.permissions",
     ],


### PR DESCRIPTION
## Summary
Follow-up to #1202 for MVP-1 Doctor honesty:

- Persist `capabilityReason` on each workspace
- `doctor_report` refreshes all workspace plans and emits a **Multi-root workspace** check (write-active / context-only / blocked)
- New `workspaces_diagnose` IPC
- Modal shows capability label + reason; Settings permissions points at Doctor

## Test plan
- [x] cargo clippy / workspace_sandbox tests
- [x] i18n + whatsNew + typecheck
- [ ] Manual: Independent write-active workspace → Doctor shows ok/write-active
- [ ] Manual: Shared with no sandbox.toml → Doctor warn/context-only with reason